### PR TITLE
Add Docker environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,68 @@
+# build files
+artifacts/
+
+# intellij files
+.idea/
+*.iml
+*.ipr
+*.iws
+build-idea/
+out/
+
+# include shared intellij config
+!.idea/inspectionProfiles/Project_Default.xml
+!.idea/runConfigurations/Debug_OpenSearch.xml
+!.idea/vcs.xml
+
+# These files are generated in the main tree by annotation processors
+benchmarks/src/main/generated/*
+benchmarks/bin/*
+benchmarks/build-eclipse-default/*
+server/bin/*
+server/build-eclipse-default/*
+test/framework/build-eclipse-default/*
+
+# eclipse files
+.project
+.classpath
+.settings
+build-eclipse/
+
+# netbeans files
+nb-configuration.xml
+nbactions.xml
+
+# gradle stuff
+.gradle/
+build/
+
+# vscode stuff
+.vscode/
+
+# testing stuff
+**/.local*
+.vagrant/
+/logs/
+
+# osx stuff
+.DS_Store
+
+# default folders in which the create_bwc_index.py expects to find old es versions in
+/backwards
+/dev-tools/backwards
+
+# needed in case docs build is run...maybe we can configure doc build to generate files under build?
+html_docs
+
+# random old stuff that we should look at the necessity of...
+/tmp/
+eclipse-build
+
+# projects using testfixtures
+testfixtures_shared/
+
+# These are generated from .ci/jobs.t
+.ci/jobs/
+
+# build files generated
+doc-tools/missing-doclet/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,50 @@
+# =========
+# 1st approach
+# =========
+# I ran the script from my host machine .It failed due to Javadoc not being 
+# installed in my machine
+# =========
+# bash scripts/build.sh -v 2.11.0 -s false -p linux -a x64 -d rpm
+
+
+# =========
+# 2nd approach
+# =========
+# Use a Docker container. It worked and the rpm package was created
+# =========
+# docker run -ti --rm \
+#     -v .:/usr/share/opensearch \
+#     -w /usr/share/opensearch \
+#     eclipse-temurin:17 \
+#     bash scripts/build.sh -v 2.11.0 -s false -p linux -a x64 -d rpm
+
+
+# =========
+# 3rd approach
+# =========
+# Dockerfile
+# =========
+# docker build -t wazuh-indexer-builder:4.9.0 .
+# docker run wazuh-indexer-builder:4.9.0
+# docker run wazuh-indexer-builder:4.9.0 -v 2.11.0 -s false -p linux -a x64 -d rpm
+# docker run -v .:/usr/share/opensearch wazuh-indexer-builder:4.9.0 -v 2.11.0 -s false -p linux -a x64 -d rpm
+
+# mkdir wazuh-indexer-packages
+# cd wazuh-indexer-packages
+# docker run -v .:/usr/share/opensearch/artifacts wazuh-indexer-builder:4.9.0 
+
+
+FROM eclipse-temurin:17 AS builder
+
+# USER 1000:1000
+
+ENV JAVA_HOME=/opt/java/openjdk
+
+# Probably better to use a volume
+COPY . /usr/share/opensearch
+
+WORKDIR /usr/share/opensearch
+
+CMD ["-v", "2.11.0", "-s", "false", "-p", "linux", "-a", "x64", "-d", "tar"]
+
+ENTRYPOINT [ "bash", "scripts/build.sh" ]

--- a/scripts/docker.sh
+++ b/scripts/docker.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Attaches the project as a volume to a JDK 17 container
+# Requires Docker
+# Script usage: bash scripts/docker.sh
+
+set -e
+
+# Check the script is being run from the root of the project
+if [ ! -f "./scripts/docker.sh" ]; then
+    echo "Please run this script from the root of the project"
+    echo "Example: bash scripts/docker.sh"
+    exit 1
+fi
+
+# ====
+# Start the container
+# ====
+run_docker() {
+    docker run -ti --rm \
+    -v .:/usr/share/opensearch \
+    -w /usr/share/opensearch \
+    --name wi-dev \
+    eclipse-temurin:17 \
+    bash
+}
+
+run_docker


### PR DESCRIPTION
### Description
This PR adds a basic Docker environment to run wazuh-indexer and its tooling.

### Issues Resolved
#62 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [x] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] GitHub issue/PR created in [OpenSearch documentation repo](https://github.com/opensearch-project/documentation-website) for the required public documentation changes (#[Issue/PR number])

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
