### PR TITLE
Use short SHA as Git reference in packages naming

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,8 +26,11 @@ jobs:
   version:
     uses: ./.github/workflows/r_version.yml
 
+  commit_sha:
+    uses: ./.github/workflows/r_commit_sha.yml
+
   build:
-    needs: version
+    needs: [ version, commit_sha ]
     strategy:
       matrix:
         distribution: [tar, rpm, deb]
@@ -36,13 +39,13 @@ jobs:
     with:
       architecture: ${{ matrix.architecture }}
       distribution: ${{ matrix.distribution }}
-      name: wazuh-indexer-min_${{ needs.version.outputs.version }}-${{ inputs.revision }}-${{ matrix.architecture }}_${{ github.sha }}.${{ matrix.distribution }}
+      name: wazuh-indexer-min_${{ needs.version.outputs.version }}-${{ inputs.revision }}-${{ matrix.architecture }}_${{ needs.commit_sha.outputs.commit_sha }}.${{ matrix.distribution }}
       # wazuh-indexer-min_4.8.0-rc1_x64_ff98475f.deb
       # TODO arm64 != amd64 (deb), x64 != x86_64 (rpm)
       # TODO use short SHA https://stackoverflow.com/a/59819441/13918537
 
   assemble:
-    needs: [version, build]
+    needs: [version, commit_sha, build]
     strategy:
       matrix:
         distribution: [tar, rpm, deb]
@@ -56,5 +59,5 @@ jobs:
     with:
       architecture: ${{ matrix.architecture }}
       distribution: ${{ matrix.distribution }}
-      min: wazuh-indexer-min_${{ needs.version.outputs.version }}-${{ inputs.revision }}-${{ matrix.architecture }}_${{ github.sha }}.${{ matrix.distribution }}
-      name: wazuh-indexer_${{ needs.version.outputs.version }}-${{ inputs.revision }}-${{ matrix.architecture }}_${{ github.sha }}.${{ matrix.distribution }}
+      min: wazuh-indexer-min_${{ needs.version.outputs.version }}-${{ inputs.revision }}-${{ matrix.architecture }}_${{ needs.commit_sha.outputs.commit_sha }}.${{ matrix.distribution }}
+      name: wazuh-indexer_${{ needs.version.outputs.version }}-${{ inputs.revision }}-${{ matrix.architecture }}_${{ needs.commit_sha.outputs.commit_sha }}.${{ matrix.distribution }}

--- a/.github/workflows/r_commit_sha.yml
+++ b/.github/workflows/r_commit_sha.yml
@@ -1,4 +1,4 @@
-name: Get commit SHA (reusable)
+name: "Get commit's short SHA (reusable)"
 
 # This workflow runs when any of the following occur:
 # - Run from another workflow
@@ -6,7 +6,7 @@ on:
   workflow_call:
     outputs:
       commit_sha:
-        description: "Returns the SHA of the git commit"
+        description: "Returns the short SHA of the latest commit"
         value: ${{ jobs.r_commit_sha.outputs.commit_sha }}
 
 jobs:

--- a/.github/workflows/r_commit_sha.yml
+++ b/.github/workflows/r_commit_sha.yml
@@ -19,4 +19,4 @@ jobs:
       - name: Get git commit SHA
         id: get_commit_sha
         run: |
-          echo "git rev-parse --short HEAD" >> $GITHUB_OUTPUT
+          echo "commit_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT

--- a/.github/workflows/r_commit_sha.yml
+++ b/.github/workflows/r_commit_sha.yml
@@ -1,0 +1,22 @@
+name: Get commit SHA (reusable)
+
+# This workflow runs when any of the following occur:
+# - Run from another workflow
+on:
+  workflow_call:
+    outputs:
+      commit_sha:
+        description: "Returns the SHA of the git commit"
+        value: ${{ jobs.r_commit_sha.outputs.commit_sha }}
+
+jobs:
+  r_commit_sha:
+    runs-on: ubuntu-latest
+    outputs:
+      commit_sha: ${{ steps.get_commit_sha.outputs.commit_sha }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get git commit SHA
+        id: get_commit_sha
+        run: |
+          echo "git rev-parse --short HEAD" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### Description
Use short SHA form from current commit in package names.

### Issues Resolved
Resolves: #90 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] GitHub issue/PR created in [OpenSearch documentation repo](https://github.com/opensearch-project/documentation-website) for the required public documentation changes (#[Issue/PR number])

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
