### PR TITLE
Build scripts and GH workflows artifacts naming fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,4 +58,4 @@ jobs:
       architecture: ${{ matrix.architecture }}
       distribution: ${{ matrix.distribution }}
       min: wazuh-indexer-min_${{ needs.version.outputs.version }}-${{ inputs.revision }}-${{ matrix.architecture }}_${{ github.sha }}.${{ matrix.distribution }}
-      name: wazuh-indexer_${{ needs.version.outputs.version }}-${{ inputs.revision }}-${{ matrix.architecture }}_${{ github.sha }}.${{ matrix.distribution }}
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,3 +55,4 @@ jobs:
     with:
       architecture: ${{ matrix.architecture }}
       distribution: ${{ matrix.distribution }}
+      min: ${{ needs.build.outputs.artifact_name }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,6 @@ jobs:
     with:
       architecture: ${{ matrix.architecture }}
       distribution: ${{ matrix.distribution }}
-      name: wazuh-indexer-min_${{ needs.version.outputs.version }}-${{ inputs.revision }}-${{ matrix.architecture }}_${{ github.sha }}.${{ matrix.distribution }}
       # wazuh-indexer-min_4.8.0-rc1_x64_ff98475f.deb
       # TODO arm64 != amd64 (deb), x64 != x86_64 (rpm)
       # TODO use short SHA https://stackoverflow.com/a/59819441/13918537
@@ -56,5 +55,3 @@ jobs:
     with:
       architecture: ${{ matrix.architecture }}
       distribution: ${{ matrix.distribution }}
-      min: wazuh-indexer-min_${{ needs.version.outputs.version }}-${{ inputs.revision }}-${{ matrix.architecture }}_${{ github.sha }}.${{ matrix.distribution }}
-      name: wazuh-indexer_${{ needs.version.outputs.version }}-${{ inputs.revision }}-${{ matrix.architecture }}_${{ github.sha }}.${{ matrix.distribution }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,7 @@ jobs:
     with:
       architecture: ${{ matrix.architecture }}
       distribution: ${{ matrix.distribution }}
+      revision: ${{ inputs.revision }}
       # wazuh-indexer-min_4.8.0-rc1_x64_ff98475f.deb
       # TODO arm64 != amd64 (deb), x64 != x86_64 (rpm)
       # TODO use short SHA https://stackoverflow.com/a/59819441/13918537

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,7 @@ jobs:
       architecture: ${{ matrix.architecture }}
       distribution: ${{ matrix.distribution }}
       revision: ${{ inputs.revision }}
+      name: wazuh-indexer-min_${{ needs.version.outputs.version }}-${{ inputs.revision }}-${{ matrix.architecture }}_${{ github.sha }}.${{ matrix.distribution }}
       # wazuh-indexer-min_4.8.0-rc1_x64_ff98475f.deb
       # TODO arm64 != amd64 (deb), x64 != x86_64 (rpm)
       # TODO use short SHA https://stackoverflow.com/a/59819441/13918537
@@ -56,4 +57,5 @@ jobs:
     with:
       architecture: ${{ matrix.architecture }}
       distribution: ${{ matrix.distribution }}
-      min: ${{ needs.build.outputs.artifact_name }}
+      min: wazuh-indexer-min_${{ needs.version.outputs.version }}-${{ inputs.revision }}-${{ matrix.architecture }}_${{ github.sha }}.${{ matrix.distribution }}
+      name: wazuh-indexer_${{ needs.version.outputs.version }}-${{ inputs.revision }}-${{ matrix.architecture }}_${{ github.sha }}.${{ matrix.distribution }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,9 +38,6 @@ jobs:
       distribution: ${{ matrix.distribution }}
       revision: ${{ inputs.revision }}
       name: wazuh-indexer-min_${{ needs.version.outputs.version }}-${{ inputs.revision }}-${{ matrix.architecture }}_${{ github.sha }}.${{ matrix.distribution }}
-      # wazuh-indexer-min_4.8.0-rc1_x64_ff98475f.deb
-      # TODO arm64 != amd64 (deb), x64 != x86_64 (rpm)
-      # TODO use short SHA https://stackoverflow.com/a/59819441/13918537
 
   assemble:
     needs: [version, build]
@@ -58,4 +55,3 @@ jobs:
       architecture: ${{ matrix.architecture }}
       distribution: ${{ matrix.distribution }}
       min: wazuh-indexer-min_${{ needs.version.outputs.version }}-${{ inputs.revision }}-${{ matrix.architecture }}_${{ github.sha }}.${{ matrix.distribution }}
-

--- a/.github/workflows/r_assemble.yml
+++ b/.github/workflows/r_assemble.yml
@@ -19,10 +19,6 @@ on:
         description: The name of the package to download.
         required: true
         type: string
-      name:
-        description: The name of the package to upload.
-        required: true
-        type: string
 
 jobs:
   r_assemble:

--- a/.github/workflows/r_assemble.yml
+++ b/.github/workflows/r_assemble.yml
@@ -19,6 +19,10 @@ on:
         description: The name of the package to download.
         required: true
         type: string
+      name:
+        description: The name of the package to upload.
+        required: true
+        type: string
 
 jobs:
   r_assemble:
@@ -53,6 +57,6 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.get_name.outputs.name }}
+          name: ${{ inputs.name }}
           path: artifacts/dist/${{ steps.get_name.outputs.name }}
           if-no-files-found: error

--- a/.github/workflows/r_assemble.yml
+++ b/.github/workflows/r_assemble.yml
@@ -33,10 +33,17 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
+      # The -min package's name is stored in artifacts/artifact_min_name.txt.
+
+      - name: Set min package name
+        id: get_min_name
+        run: |
+          echo "name=$(cat artifacts/artifact_min_name.txt)" >> $GITHUB_OUTPUT
+
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
-          name: ${{ inputs.min }}
+          name: ${{ steps.get_min_name.outputs.name }}
           path: artifacts/dist
 
       - name: Provision
@@ -57,6 +64,6 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.name }}
+          name: ${{ steps.get_name.outputs.name }}
           path: artifacts/dist/${{ steps.get_name.outputs.name }}
           if-no-files-found: error

--- a/.github/workflows/r_assemble.yml
+++ b/.github/workflows/r_assemble.yml
@@ -33,17 +33,10 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
-      # The -min package's name is stored in artifacts/artifact_min_name.txt.
-
-      - name: Set min package name
-        id: get_min_name
-        run: |
-          echo "name=$(cat artifacts/artifact_min_name.txt)" >> $GITHUB_OUTPUT
-
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
-          name: ${{ steps.get_min_name.outputs.name }}
+          name: ${{ inputs.min }}
           path: artifacts/dist
 
       - name: Provision

--- a/.github/workflows/r_assemble.yml
+++ b/.github/workflows/r_assemble.yml
@@ -19,10 +19,6 @@ on:
         description: The name of the package to download.
         required: true
         type: string
-      name:
-        description: The name of the package to upload.
-        required: true
-        type: string
 
 jobs:
   r_assemble:
@@ -57,6 +53,6 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.name }}
+          name: ${{ steps.get_name.outputs.name }}
           path: artifacts/dist/${{ steps.get_name.outputs.name }}
           if-no-files-found: error

--- a/.github/workflows/r_build.yml
+++ b/.github/workflows/r_build.yml
@@ -15,7 +15,7 @@ on:
         default: "x64"
         required: false
         type: string
-      name:
+      revision:
         type: string
     outputs:
       artifact_name:
@@ -41,7 +41,7 @@ jobs:
 
       - name: Run `build.sh`
         run: |
-          bash scripts/build.sh -v ${{ vars.OPENSEARCH_VERSION }} -s false -p linux -a ${{ inputs.architecture }} -d ${{ inputs.distribution }}
+          bash scripts/build.sh -v ${{ vars.OPENSEARCH_VERSION }} -s false -p linux -a ${{ inputs.architecture }} -d ${{ inputs.distribution }} -r ${{ inputs.revision }}
 
       # The package's name is stored in artifacts/artifact_min_name.txt.
       - name: Set package name

--- a/.github/workflows/r_build.yml
+++ b/.github/workflows/r_build.yml
@@ -21,10 +21,6 @@ on:
         description: The name of the package to upload.
         required: true
         type: string
-    outputs:
-      artifact_name:
-        description: "Returns the build artifact's filename"
-        value: ${{ jobs.r_build.outputs.get_name.name }}
 
 jobs:
   r_build:

--- a/.github/workflows/r_build.yml
+++ b/.github/workflows/r_build.yml
@@ -17,6 +17,10 @@ on:
         type: string
       revision:
         type: string
+      name:
+        description: The name of the package to upload.
+        required: true
+        type: string
     outputs:
       artifact_name:
         description: "Returns the build artifact's filename"
@@ -52,6 +56,6 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.get_name.outputs.name }}
+          name: ${{ inputs.name }}
           path: artifacts/dist/${{ steps.get_name.outputs.name }}
           if-no-files-found: error

--- a/.github/workflows/r_build.yml
+++ b/.github/workflows/r_build.yml
@@ -39,15 +39,15 @@ jobs:
         run: |
           bash scripts/build.sh -v ${{ vars.OPENSEARCH_VERSION }} -s false -p linux -a ${{ inputs.architecture }} -d ${{ inputs.distribution }}
 
-      # The package's name is stored in artifacts/artifact_name.txt.
+      # The package's name is stored in artifacts/artifact_min_name.txt.
       - name: Set package name
         id: get_name
         run: |
-          echo "name=$(cat artifacts/artifact_name.txt)" >> $GITHUB_OUTPUT
+          echo "name=$(cat artifacts/artifact_min_name.txt)" >> $GITHUB_OUTPUT
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.name }}
+          name: ${{ steps.get_name.outputs.name }}
           path: artifacts/dist/${{ steps.get_name.outputs.name }}
           if-no-files-found: error

--- a/.github/workflows/r_build.yml
+++ b/.github/workflows/r_build.yml
@@ -17,6 +17,10 @@ on:
         type: string
       name:
         type: string
+    outputs:
+      artifact_name:
+        description: "Returns the build artifact's filename"
+        value: ${{ jobs.r_build.outputs.get_name }}
 
 jobs:
   r_build:

--- a/.github/workflows/r_build.yml
+++ b/.github/workflows/r_build.yml
@@ -20,7 +20,7 @@ on:
     outputs:
       artifact_name:
         description: "Returns the build artifact's filename"
-        value: ${{ jobs.r_build.outputs.get_name }}
+        value: ${{ jobs.r_build.outputs.get_name.name }}
 
 jobs:
   r_build:

--- a/docker/images/wi-dev.Dockerfile
+++ b/docker/images/wi-dev.Dockerfile
@@ -6,11 +6,13 @@ RUN gradle clean
 
 
 FROM eclipse-temurin:17-jdk-alpine
-RUN addgroup -g 1000 wazuh-indexer && \
+RUN apk add git && \
+    addgroup -g 1000 wazuh-indexer && \
     adduser -u 1000 -G wazuh-indexer -D -h /home/wazuh-indexer wazuh-indexer && \
     chmod 0775 /home/wazuh-indexer && \
     chown -R 1000:0 /home/wazuh-indexer
 USER wazuh-indexer
 COPY --from=builder --chown=1000:0 /home/wazuh-indexer/app /home/wazuh-indexer/app
 WORKDIR /home/wazuh-indexer/app
+RUN git config --global --add safe.directory /home/wazuh-indexer/app
 EXPOSE 9200 9300

--- a/scripts/assemble.sh
+++ b/scripts/assemble.sh
@@ -336,7 +336,7 @@ function main() {
 
     echo "Assembling wazuh-indexer for $PLATFORM-$DISTRIBUTION-$ARCHITECTURE"
 
-    ARTIFACT_BUILD_NAME=$(ls "${OUTPUT}/dist/" | grep "wazuh-indexer-min_.*\.$EXT")
+    ARTIFACT_BUILD_NAME=$(ls "${OUTPUT}/dist/" | grep "wazuh-indexer-min_.*$ARCHITECTURE.*\.$EXT")
 
 		ARTIFACT_PACKAGE_NAME=${ARTIFACT_BUILD_NAME/min_/}
 

--- a/scripts/assemble.sh
+++ b/scripts/assemble.sh
@@ -202,7 +202,7 @@ function clean() {
     rm -r "${OUTPUT}/tmp"
     echo "After execution, shell path is $(pwd)"
     # Store package's name to file. Used by GH Action.
-    echo "${package_name}" >"${OUTPUT}/artifact_name.txt"
+    echo "${ARTIFACT_PACKAGE_NAME}" >"${OUTPUT}/artifact_name.txt"
 }
 
 # ====
@@ -228,7 +228,7 @@ function assemble_tar() {
     cd ..
     tar -cvf "${archive_name}-${SUFFIX}.${EXT}" "${archive_name}"
     cd ../../..
-    cp "${TMP_DIR}/${archive_name}-${SUFFIX}.${EXT}" "${OUTPUT}/dist/"
+    cp "${TMP_DIR}/${archive_name}-${SUFFIX}.${EXT}" "${OUTPUT}/dist/$ARTIFACT_PACKAGE_NAME"
 
     clean
 }
@@ -272,8 +272,10 @@ function assemble_rpm() {
 
     # Move to the root folder, copy the package and clean.
     cd ../../..
+
     package_name="wazuh-indexer-${version}-1.${SUFFIX}.${EXT}"
-    cp "${TMP_DIR}/RPMS/${SUFFIX}/${package_name}" "${OUTPUT}/dist/"
+
+    cp "${TMP_DIR}/RPMS/${SUFFIX}/${package_name}" "${OUTPUT}/dist/$ARTIFACT_PACKAGE_NAME"
 
     clean
 }
@@ -319,9 +321,9 @@ function assemble_deb() {
 
     # Move to the root folder, copy the package and clean.
     cd ../../..
-    package_name="wazuh-indexer_${version}_${SUFFIX}.${EXT}"
+		package_name="wazuh-indexer_${version}_${SUFFIX}.${EXT}"
     # debmake creates the package one level above
-    cp "${TMP_DIR}/../${package_name}" "${OUTPUT}/dist/"
+    cp "${TMP_DIR}/../${package_name}" "${OUTPUT}/dist/$ARTIFACT_PACKAGE_NAME"
 
     clean
 }
@@ -333,8 +335,12 @@ function main() {
     parse_args "${@}"
 
     echo "Assembling wazuh-indexer for $PLATFORM-$DISTRIBUTION-$ARCHITECTURE"
-    # wazuh-indexer-min_4.9.0-1-x64_78fcc3db6a5b470294319e48b58c3d715bee39d1.rpm
-    ARTIFACT_BUILD_NAME=$(ls "${OUTPUT}/dist/" | grep "wazuh-indexer-min.*.$EXT")
+
+    ARTIFACT_BUILD_NAME=$(ls "${OUTPUT}/dist/" | grep "wazuh-indexer-min_.*\.$EXT")
+
+		ARTIFACT_PACKAGE_NAME=${ARTIFACT_BUILD_NAME/min_/}
+
+		
 
     # Create temporal directory and copy the min package there for extraction
     TMP_DIR="${OUTPUT}/tmp/${TARGET}"

--- a/scripts/assemble.sh
+++ b/scripts/assemble.sh
@@ -336,7 +336,7 @@ function main() {
 
     echo "Assembling wazuh-indexer for $PLATFORM-$DISTRIBUTION-$ARCHITECTURE"
 
-    ARTIFACT_BUILD_NAME=$(ls "${OUTPUT}/dist/" | grep "wazuh-indexer-min_.*$ARCHITECTURE.*\.$EXT")
+    ARTIFACT_BUILD_NAME=$(ls "${OUTPUT}/dist/" | grep "wazuh-indexer-min_.*$SUFFIX.*\.$EXT")
 
 		ARTIFACT_PACKAGE_NAME=${ARTIFACT_BUILD_NAME/min_/}
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -91,6 +91,7 @@ cp -r ./build/local-test-repo/org/opensearch "${OUTPUT}"/maven/org
 [ -z "$PLATFORM" ] && PLATFORM=$(uname -s | awk '{print tolower($0)}')
 [ -z "$ARCHITECTURE" ] && ARCHITECTURE=$(uname -m)
 [ -z "$DISTRIBUTION" ] && DISTRIBUTION="tar"
+[ -z "$QUALIFIER" ] && QUALIFIER="1"
 
 case $PLATFORM-$DISTRIBUTION-$ARCHITECTURE in
     linux-tar-x64|darwin-tar-x64)
@@ -169,6 +170,7 @@ ARTIFACT_BUILD_NAME=$(ls "distribution/$TYPE/$TARGET/build/distributions/" | gre
 GIT_COMMIT=$(git rev-parse --short HEAD)
 
 WI_VERSION=$(<VERSION)
+
 
 ARTIFACT_PACKAGE_NAME=wazuh-indexer-min_"$WI_VERSION"-"$QUALIFIER"_"$SUFFIX"_"$GIT_COMMIT"."$EXT"
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -19,11 +19,12 @@ function usage() {
     echo -e "-p PLATFORM\t[Optional] Platform, default is 'uname -s'."
     echo -e "-a ARCHITECTURE\t[Optional] Build architecture, default is 'uname -m'."
     echo -e "-d DISTRIBUTION\t[Optional] Distribution, default is 'tar'."
+    echo -e "-d REVISION\t[Optional] Package revision, default is '1'."
     echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."
     echo -e "-h help"
 }
 
-while getopts ":h:v:q:s:o:p:a:d:" arg; do
+while getopts ":h:v:q:s:o:p:a:d:r:" arg; do
     case $arg in
         h)
             usage
@@ -49,6 +50,9 @@ while getopts ":h:v:q:s:o:p:a:d:" arg; do
             ;;
         d)
             DISTRIBUTION=$OPTARG
+            ;;
+        r)
+            REVISION=$OPTARG
             ;;
         :)
             echo "Error: -${OPTARG} requires an argument"
@@ -91,7 +95,7 @@ cp -r ./build/local-test-repo/org/opensearch "${OUTPUT}"/maven/org
 [ -z "$PLATFORM" ] && PLATFORM=$(uname -s | awk '{print tolower($0)}')
 [ -z "$ARCHITECTURE" ] && ARCHITECTURE=$(uname -m)
 [ -z "$DISTRIBUTION" ] && DISTRIBUTION="tar"
-[ -z "$QUALIFIER" ] && QUALIFIER="1"
+[ -z "$REVISION" ] && REVISION="1"
 
 case $PLATFORM-$DISTRIBUTION-$ARCHITECTURE in
     linux-tar-x64|darwin-tar-x64)
@@ -172,7 +176,7 @@ GIT_COMMIT=$(git rev-parse --short HEAD)
 WI_VERSION=$(<VERSION)
 
 
-ARTIFACT_PACKAGE_NAME=wazuh-indexer-min_"$WI_VERSION"-"$QUALIFIER"_"$SUFFIX"_"$GIT_COMMIT"."$EXT"
+ARTIFACT_PACKAGE_NAME=wazuh-indexer-min_"$WI_VERSION"-"$REVISION"_"$SUFFIX"_"$GIT_COMMIT"."$EXT"
 
 # [WAZUH] Used by the GH workflow to upload the artifact
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -162,8 +162,19 @@ echo "Building OpenSearch for $PLATFORM-$DISTRIBUTION-$ARCHITECTURE"
 # Copy artifact to dist folder in bundle build output
 echo "Copying artifact to ${OUTPUT}/dist"
 # [[ "$SNAPSHOT" == "true" ]] && IDENTIFIER="-SNAPSHOT"
+
+
 ARTIFACT_BUILD_NAME=$(ls "distribution/$TYPE/$TARGET/build/distributions/" | grep "wazuh-indexer-min.*$SUFFIX.$EXT")
+
+GIT_COMMIT=$(git rev-parse --short HEAD)
+
+WI_VERSION=$(<VERSION)
+
+ARTIFACT_PACKAGE_NAME=wazuh-indexer-min_"$WI_VERSION"-"$QUALIFIER"_"$SUFFIX"_"$GIT_COMMIT"."$EXT"
+
 # [WAZUH] Used by the GH workflow to upload the artifact
-echo "$ARTIFACT_BUILD_NAME" > "$OUTPUT/artifact_name.txt"
+
+echo "$ARTIFACT_PACKAGE_NAME" > "$OUTPUT/artifact_min_name.txt"
+
 mkdir -p "${OUTPUT}/dist"
-cp "distribution/$TYPE/$TARGET/build/distributions/$ARTIFACT_BUILD_NAME" "${OUTPUT}/dist/$ARTIFACT_BUILD_NAME"
+cp "distribution/$TYPE/$TARGET/build/distributions/$ARTIFACT_BUILD_NAME" "${OUTPUT}/dist/$ARTIFACT_PACKAGE_NAME"


### PR DESCRIPTION
### Description

Modifies `build.sh` and `assemble.sh` scripts to generate artifacts with naming convention outlined in #91 . Also modifies `r_build.yml`, `r_assemble.yml` and `build.yml` to use the generated artifacts accordingly.

### Issues Resolved
#91 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] GitHub issue/PR created in [OpenSearch documentation repo](https://github.com/opensearch-project/documentation-website) for the required public documentation changes (#[Issue/PR number])

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
