### PR TITLE
Add missing tools and files back into Wazuh Indexer packages

### DIFF
--- a/scripts/assemble.sh
+++ b/scripts/assemble.sh
@@ -173,16 +173,18 @@ function remove_unneeded_files() {
 }
 
 # ====
-# Get missing Wazuh tools and files into packages
+# Add additional tools into packages
 # ====
-function get_wazuh_files() {
-
-    local version=$(<VERSION)
+function add_wazuh_tools() {
+    local version
+    version=$(<VERSION)
     version=${version%%.[[:digit:]]}
+    local download_url
+    download_url="https://packages-dev.wazuh.com/${version}"
 
-    wget -q https://packages-dev.wazuh.com/4.9/config.yml -O $PATH_PLUGINS/opensearch-security/tools/config.yml
-    wget -q https://packages-dev.wazuh.com/4.9/wazuh-passwords-tool.sh -O $PATH_PLUGINS/opensearch-security/tools/wazuh-passwords-tool.sh
-    wget -q https://packages-dev.wazuh.com/4.9/wazuh-certs-tool.sh -O $PATH_PLUGINS/opensearch-security/tools/wazuh-certs-tool.sh
+    wget -q "${download_url}/config.yml" -O $PATH_PLUGINS/opensearch-security/tools/config.yml
+    wget -q "${download_url}/wazuh-passwords-tool.sh "-O $PATH_PLUGINS/opensearch-security/tools/wazuh-passwords-tool.sh
+    wget -q "${download_url}/wazuh-certs-tool.sh" -O $PATH_PLUGINS/opensearch-security/tools/wazuh-certs-tool.sh
 }
 
 # ====
@@ -244,7 +246,7 @@ function assemble_tar() {
     # Swap configuration files
     add_configuration_files
     remove_unneeded_files
-    get_wazuh_files
+    add_wazuh_tools
 
     # Pack
     archive_name="wazuh-indexer-$(cat VERSION)"
@@ -281,7 +283,7 @@ function assemble_rpm() {
     # Swap configuration files
     add_configuration_files
     remove_unneeded_files
-    get_wazuh_files
+    add_wazuh_tools
 
     # Generate final package
     local topdir
@@ -289,7 +291,6 @@ function assemble_rpm() {
     local spec_file="wazuh-indexer.rpm.spec"
     topdir=$(pwd)
     version=$(cat ./usr/share/wazuh-indexer/VERSION)
-    # TODO validate architecture
     rpmbuild --bb \
         --define "_topdir ${topdir}" \
         --define "_version ${version}" \
@@ -298,9 +299,7 @@ function assemble_rpm() {
 
     # Move to the root folder, copy the package and clean.
     cd ../../..
-
     package_name="wazuh-indexer-${version}-1.${SUFFIX}.${EXT}"
-
     cp "${TMP_DIR}/RPMS/${SUFFIX}/${package_name}" "${OUTPUT}/dist/$ARTIFACT_PACKAGE_NAME"
 
     clean
@@ -334,7 +333,7 @@ function assemble_deb() {
     # Swap configuration files
     add_configuration_files
     remove_unneeded_files
-    get_wazuh_files
+    add_wazuh_tools
 
     # Generate final package
     local version

--- a/scripts/assemble.sh
+++ b/scripts/assemble.sh
@@ -173,6 +173,15 @@ function remove_unneeded_files() {
 }
 
 # ====
+# Get missing Wazuh tools and files into packages
+# ====
+function get_wazuh_files() {
+    wget -q https://packages-dev.wazuh.com/4.9/config.yml -O $PATH_PLUGINS/opensearch-security/tools/config.yml
+    wget -q https://packages-dev.wazuh.com/4.9/wazuh-passwords-tool.sh -O $PATH_PLUGINS/opensearch-security/tools/wazuh-passwords-tool.sh
+    wget -q https://packages-dev.wazuh.com/4.9/wazuh-certs-tool.sh -O $PATH_PLUGINS/opensearch-security/tools/wazuh-certs-tool.sh
+}
+
+# ====
 # Copy performance analyzer service file
 # ====
 function enable_performance_analyzer() {
@@ -231,6 +240,7 @@ function assemble_tar() {
     # Swap configuration files
     add_configuration_files
     remove_unneeded_files
+    get_wazuh_files
 
     # Pack
     archive_name="wazuh-indexer-$(cat VERSION)"
@@ -267,6 +277,7 @@ function assemble_rpm() {
     # Swap configuration files
     add_configuration_files
     remove_unneeded_files
+    get_wazuh_files
 
     # Generate final package
     local topdir
@@ -319,6 +330,7 @@ function assemble_deb() {
     # Swap configuration files
     add_configuration_files
     remove_unneeded_files
+    get_wazuh_files
 
     # Generate final package
     local version

--- a/scripts/assemble.sh
+++ b/scripts/assemble.sh
@@ -176,6 +176,10 @@ function remove_unneeded_files() {
 # Get missing Wazuh tools and files into packages
 # ====
 function get_wazuh_files() {
+
+		local version=$(<VERSION)
+    version=${version%%.[[:digit:]]}
+
     wget -q https://packages-dev.wazuh.com/4.9/config.yml -O $PATH_PLUGINS/opensearch-security/tools/config.yml
     wget -q https://packages-dev.wazuh.com/4.9/wazuh-passwords-tool.sh -O $PATH_PLUGINS/opensearch-security/tools/wazuh-passwords-tool.sh
     wget -q https://packages-dev.wazuh.com/4.9/wazuh-certs-tool.sh -O $PATH_PLUGINS/opensearch-security/tools/wazuh-certs-tool.sh

--- a/scripts/assemble.sh
+++ b/scripts/assemble.sh
@@ -169,24 +169,7 @@ function add_configuration_files() {
 # Remove unneeded files
 # ====
 function remove_unneeded_files() {
-		rm $PATH_PLUGINS/opensearch-security/tools/install_demo_configuration.sh
-}
-
-# ====
-# Set up configuration files
-# ====
-function add_configuration_files() {
-    # swap configuration files
-    cp $PATH_CONF/security/* $PATH_CONF/opensearch-security/
-    cp $PATH_CONF/jvm.prod.options $PATH_CONF/jvm.options
-    cp $PATH_CONF/opensearch.prod.yml $PATH_CONF/opensearch.yml
-
-    rm -r $PATH_CONF/security
-    rm $PATH_CONF/jvm.prod.options $PATH_CONF/opensearch.prod.yml
-
-    # Remove symbolic links and bat files
-    find . -type l -exec rm -rf {} \;
-    find . -name "*.bat" -exec rm -rf {} \;
+    rm "$PATH_PLUGINS/opensearch-security/tools/install_demo_configuration.sh"
 }
 
 # ====
@@ -236,7 +219,7 @@ function assemble_tar() {
     cd "${TMP_DIR}"
     PATH_CONF="./config"
     PATH_BIN="./bin"
-    PATH_BIN="./plugins"
+    PATH_PLUGINS="./plugins"
 
     # Extract
     echo "Extract ${ARTIFACT_BUILD_NAME} archive"
@@ -247,8 +230,7 @@ function assemble_tar() {
     install_plugins
     # Swap configuration files
     add_configuration_files
-
-		remove_unneeded_files
+    remove_unneeded_files
 
     # Pack
     archive_name="wazuh-indexer-$(cat VERSION)"
@@ -284,8 +266,7 @@ function assemble_rpm() {
     enable_performance_analyzer_rca ${src_path}
     # Swap configuration files
     add_configuration_files
-
-		remove_unneeded_files
+    remove_unneeded_files
 
     # Generate final package
     local topdir
@@ -337,8 +318,7 @@ function assemble_deb() {
     enable_performance_analyzer_rca ${src_path}
     # Swap configuration files
     add_configuration_files
-
-		remove_unneeded_files
+    remove_unneeded_files
 
     # Generate final package
     local version
@@ -354,7 +334,7 @@ function assemble_deb() {
 
     # Move to the root folder, copy the package and clean.
     cd ../../..
-		package_name="wazuh-indexer_${version}_${SUFFIX}.${EXT}"
+    package_name="wazuh-indexer_${version}_${SUFFIX}.${EXT}"
     # debmake creates the package one level above
     cp "${TMP_DIR}/../${package_name}" "${OUTPUT}/dist/$ARTIFACT_PACKAGE_NAME"
 
@@ -371,9 +351,7 @@ function main() {
 
     ARTIFACT_BUILD_NAME=$(ls "${OUTPUT}/dist/" | grep "wazuh-indexer-min_.*$SUFFIX.*\.$EXT")
 
-		ARTIFACT_PACKAGE_NAME=${ARTIFACT_BUILD_NAME/min_/}
-
-		
+    ARTIFACT_PACKAGE_NAME=${ARTIFACT_BUILD_NAME/min_/}
 
     # Create temporal directory and copy the min package there for extraction
     TMP_DIR="${OUTPUT}/tmp/${TARGET}"

--- a/scripts/assemble.sh
+++ b/scripts/assemble.sh
@@ -236,6 +236,7 @@ function assemble_tar() {
     cd "${TMP_DIR}"
     PATH_CONF="./config"
     PATH_BIN="./bin"
+    PATH_BIN="./plugins"
 
     # Extract
     echo "Extract ${ARTIFACT_BUILD_NAME} archive"
@@ -246,6 +247,8 @@ function assemble_tar() {
     install_plugins
     # Swap configuration files
     add_configuration_files
+
+		remove_unneeded_files
 
     # Pack
     archive_name="wazuh-indexer-$(cat VERSION)"

--- a/scripts/assemble.sh
+++ b/scripts/assemble.sh
@@ -166,6 +166,30 @@ function add_configuration_files() {
 }
 
 # ====
+# Remove unneeded files
+# ====
+function remove_unneeded_files() {
+		rm $PATH_PLUGINS/opensearch-security/tools/install_demo_configuration.sh
+}
+
+# ====
+# Set up configuration files
+# ====
+function add_configuration_files() {
+    # swap configuration files
+    cp $PATH_CONF/security/* $PATH_CONF/opensearch-security/
+    cp $PATH_CONF/jvm.prod.options $PATH_CONF/jvm.options
+    cp $PATH_CONF/opensearch.prod.yml $PATH_CONF/opensearch.yml
+
+    rm -r $PATH_CONF/security
+    rm $PATH_CONF/jvm.prod.options $PATH_CONF/opensearch.prod.yml
+
+    # Remove symbolic links and bat files
+    find . -type l -exec rm -rf {} \;
+    find . -name "*.bat" -exec rm -rf {} \;
+}
+
+# ====
 # Copy performance analyzer service file
 # ====
 function enable_performance_analyzer() {
@@ -246,6 +270,7 @@ function assemble_rpm() {
     local src_path="./usr/share/wazuh-indexer"
     PATH_CONF="./etc/wazuh-indexer"
     PATH_BIN="${src_path}/bin"
+    PATH_PLUGINS="${src_path}/plugins"
 
     # Extract min-package. Creates usr/, etc/ and var/ in the current directory
     echo "Extract ${ARTIFACT_BUILD_NAME} archive"
@@ -256,6 +281,8 @@ function assemble_rpm() {
     enable_performance_analyzer_rca ${src_path}
     # Swap configuration files
     add_configuration_files
+
+		remove_unneeded_files
 
     # Generate final package
     local topdir
@@ -295,6 +322,7 @@ function assemble_deb() {
     local src_path="./usr/share/wazuh-indexer"
     PATH_CONF="./etc/wazuh-indexer"
     PATH_BIN="${src_path}/bin"
+    PATH_PLUGINS="${src_path}/plugins"
 
     # Extract min-package. Creates usr/, etc/ and var/ in the current directory
     echo "Extract ${ARTIFACT_BUILD_NAME} archive"
@@ -306,6 +334,8 @@ function assemble_deb() {
     enable_performance_analyzer_rca ${src_path}
     # Swap configuration files
     add_configuration_files
+
+		remove_unneeded_files
 
     # Generate final package
     local version


### PR DESCRIPTION
### Description
This PR adds a function to `assemble.sh` that adds the following files

```shell
/usr/share/wazuh-indexer/plugins/opensearch-security/tools/config.yml
/usr/share/wazuh-indexer/plugins/opensearch-security/tools/wazuh-passwords-tool.sh
/usr/share/wazuh-indexer/plugins/opensearch-security/tools/wazuh-certs-tool.sh
```
to the assembled Wazuh Indexer packages.

### Issues Resolved
Resolves #102 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] GitHub issue/PR created in [OpenSearch documentation repo](https://github.com/opensearch-project/documentation-website) for the required public documentation changes (#[Issue/PR number])

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
