### PR TITLE
Fix RPM package references to /var/run

### DIFF
--- a/distribution/packages/src/common/env/wazuh-indexer
+++ b/distribution/packages/src/common/env/wazuh-indexer
@@ -13,7 +13,7 @@
 OPENSEARCH_PATH_CONF=${path.conf}
 
 # wazuh-indexer PID directory
-#PID_DIR=/var/run/wazuh-indexer
+#PID_DIR=/run/wazuh-indexer
 
 # Additional Java OPTS
 #OPENSEARCH_JAVA_OPTS=

--- a/distribution/packages/src/common/scripts/postrm
+++ b/distribution/packages/src/common/scripts/postrm
@@ -72,9 +72,9 @@ if [ "$REMOVE_DIRS" = "true" ]; then
         echo " OK"
     fi
 
-    if [ -d /var/run/wazuh-indexer ]; then
+    if [ -d /run/wazuh-indexer ]; then
         echo -n "Deleting PID directory..."
-        rm -rf /var/run/wazuh-indexer
+        rm -rf /run/wazuh-indexer
         echo " OK"
     fi
 

--- a/distribution/packages/src/common/systemd/wazuh-indexer.conf
+++ b/distribution/packages/src/common/systemd/wazuh-indexer.conf
@@ -1,1 +1,1 @@
-d    /var/run/wazuh-indexer   0750 wazuh-indexer wazuh-indexer - -
+d    /run/wazuh-indexer   0750 wazuh-indexer wazuh-indexer - -

--- a/distribution/packages/src/common/systemd/wazuh-indexer.service
+++ b/distribution/packages/src/common/systemd/wazuh-indexer.service
@@ -10,7 +10,7 @@ RuntimeDirectory=wazuh-indexer
 PrivateTmp=true
 Environment=OPENSEARCH_HOME=/usr/share/wazuh-indexer
 Environment=OPENSEARCH_PATH_CONF=${path.conf}
-Environment=PID_DIR=/var/run/wazuh-indexer
+Environment=PID_DIR=/run/wazuh-indexer
 Environment=OPENSEARCH_SD_NOTIFY=true
 EnvironmentFile=-${path.env}
 

--- a/distribution/packages/src/deb/debmake_install.sh
+++ b/distribution/packages/src/deb/debmake_install.sh
@@ -36,10 +36,6 @@ if [ -d "${buildroot}${product_dir}"/plugins/opensearch-security ]; then
     chmod -c 0755 "${buildroot}${product_dir}"/plugins/opensearch-security/tools/*
 fi
 
-# Symlinks (do not symlink config dir as security demo installer has dependency, if no presense it will switch to rpm/deb mode)
-ln -s ${data_dir} "${buildroot}${product_dir}/data"
-ln -s ${log_dir} "${buildroot}${product_dir}/logs"
-
 # Change Permissions
 chmod -Rf a+rX,u+w,g-w,o-w "${buildroot}"/*
 

--- a/distribution/packages/src/deb/debmake_install.sh
+++ b/distribution/packages/src/deb/debmake_install.sh
@@ -21,7 +21,7 @@ product_dir=/usr/share/wazuh-indexer
 # config_dir=/etc/wazuh-indexer
 data_dir=/var/lib/wazuh-indexer
 log_dir=/var/log/wazuh-indexer
-pid_dir=/var/run/wazuh-indexer
+pid_dir=/run/wazuh-indexer
 buildroot=${curdir}/debian/wazuh-indexer
 
 # Create necessary directories

--- a/distribution/packages/src/rpm/init.d/wazuh-indexer
+++ b/distribution/packages/src/rpm/init.d/wazuh-indexer
@@ -39,7 +39,7 @@ MAX_OPEN_FILES=65535
 MAX_MAP_COUNT=262144
 OPENSEARCH_PATH_CONF="${path.conf}"
 
-PID_DIR="/var/run/wazuh-indexer"
+PID_DIR="/run/wazuh-indexer"
 
 # Source the default env file
 OPENSEARCH_ENV_FILE="${path.env}"

--- a/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
+++ b/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
@@ -104,10 +104,6 @@ exit 0
 
 %post
 set -e
-# Apply Security Settings
-if [ -d %{product_dir}/plugins/opensearch-security ]; then
-    sh %{product_dir}/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s > %{log_dir}/install_demo_configuration.log 2>&1
-fi
 chown -R %{name}.%{name} %{config_dir}
 chown -R %{name}.%{name} %{log_dir}
 # Apply PerformanceAnalyzer Settings

--- a/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
+++ b/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
@@ -72,9 +72,7 @@ fi
 mkdir -p %{buildroot}%{config_dir}/opensearch-observability
 mkdir -p %{buildroot}%{config_dir}/opensearch-reports-scheduler
 mkdir -p %{buildroot}%{product_dir}/performance-analyzer-rca
-# Symlinks (do not symlink config dir as security demo installer has dependency, if no presense it will switch to rpm/deb mode)
-ln -s %{data_dir} %{buildroot}%{product_dir}/data
-ln -s %{log_dir}  %{buildroot}%{product_dir}/logs
+
 # Pre-populate PA configs if not present
 if [ ! -f %{buildroot}%{data_dir}/rca_enabled.conf ]; then
     echo 'true' > %{buildroot}%{data_dir}/rca_enabled.conf
@@ -203,10 +201,6 @@ exit 0
 %{log_dir}
 %{pid_dir}
 %dir %{data_dir}
-
-# Symlinks
-%{product_dir}/data
-%{product_dir}/logs
 
 # Wazuh additional files
 %attr(440, %{name}, %{name}) %{product_dir}/VERSION

--- a/scripts/assemble.sh
+++ b/scripts/assemble.sh
@@ -173,6 +173,21 @@ function remove_unneeded_files() {
 }
 
 # ====
+# Add additional tools into packages
+# ====
+function add_wazuh_tools() {
+    local version
+    version=$(<VERSION)
+    version=${version%%.[[:digit:]]}
+    local download_url
+    download_url="https://packages-dev.wazuh.com/${version}"
+
+    wget -q "${download_url}/config.yml" -O $PATH_PLUGINS/opensearch-security/tools/config.yml
+    wget -q "${download_url}/wazuh-passwords-tool.sh "-O $PATH_PLUGINS/opensearch-security/tools/wazuh-passwords-tool.sh
+    wget -q "${download_url}/wazuh-certs-tool.sh" -O $PATH_PLUGINS/opensearch-security/tools/wazuh-certs-tool.sh
+}
+
+# ====
 # Copy performance analyzer service file
 # ====
 function enable_performance_analyzer() {
@@ -231,6 +246,7 @@ function assemble_tar() {
     # Swap configuration files
     add_configuration_files
     remove_unneeded_files
+    add_wazuh_tools
 
     # Pack
     archive_name="wazuh-indexer-$(cat VERSION)"
@@ -267,6 +283,7 @@ function assemble_rpm() {
     # Swap configuration files
     add_configuration_files
     remove_unneeded_files
+    add_wazuh_tools
 
     # Generate final package
     local topdir
@@ -274,7 +291,6 @@ function assemble_rpm() {
     local spec_file="wazuh-indexer.rpm.spec"
     topdir=$(pwd)
     version=$(cat ./usr/share/wazuh-indexer/VERSION)
-    # TODO validate architecture
     rpmbuild --bb \
         --define "_topdir ${topdir}" \
         --define "_version ${version}" \
@@ -283,9 +299,7 @@ function assemble_rpm() {
 
     # Move to the root folder, copy the package and clean.
     cd ../../..
-
     package_name="wazuh-indexer-${version}-1.${SUFFIX}.${EXT}"
-
     cp "${TMP_DIR}/RPMS/${SUFFIX}/${package_name}" "${OUTPUT}/dist/$ARTIFACT_PACKAGE_NAME"
 
     clean
@@ -319,6 +333,7 @@ function assemble_deb() {
     # Swap configuration files
     add_configuration_files
     remove_unneeded_files
+    add_wazuh_tools
 
     # Generate final package
     local version

--- a/scripts/assemble.sh
+++ b/scripts/assemble.sh
@@ -166,6 +166,13 @@ function add_configuration_files() {
 }
 
 # ====
+# Remove unneeded files
+# ====
+function remove_unneeded_files() {
+    rm "$PATH_PLUGINS/opensearch-security/tools/install_demo_configuration.sh"
+}
+
+# ====
 # Copy performance analyzer service file
 # ====
 function enable_performance_analyzer() {
@@ -212,6 +219,7 @@ function assemble_tar() {
     cd "${TMP_DIR}"
     PATH_CONF="./config"
     PATH_BIN="./bin"
+    PATH_PLUGINS="./plugins"
 
     # Extract
     echo "Extract ${ARTIFACT_BUILD_NAME} archive"
@@ -222,6 +230,7 @@ function assemble_tar() {
     install_plugins
     # Swap configuration files
     add_configuration_files
+    remove_unneeded_files
 
     # Pack
     archive_name="wazuh-indexer-$(cat VERSION)"
@@ -246,6 +255,7 @@ function assemble_rpm() {
     local src_path="./usr/share/wazuh-indexer"
     PATH_CONF="./etc/wazuh-indexer"
     PATH_BIN="${src_path}/bin"
+    PATH_PLUGINS="${src_path}/plugins"
 
     # Extract min-package. Creates usr/, etc/ and var/ in the current directory
     echo "Extract ${ARTIFACT_BUILD_NAME} archive"
@@ -256,6 +266,7 @@ function assemble_rpm() {
     enable_performance_analyzer_rca ${src_path}
     # Swap configuration files
     add_configuration_files
+    remove_unneeded_files
 
     # Generate final package
     local topdir
@@ -295,6 +306,7 @@ function assemble_deb() {
     local src_path="./usr/share/wazuh-indexer"
     PATH_CONF="./etc/wazuh-indexer"
     PATH_BIN="${src_path}/bin"
+    PATH_PLUGINS="${src_path}/plugins"
 
     # Extract min-package. Creates usr/, etc/ and var/ in the current directory
     echo "Extract ${ARTIFACT_BUILD_NAME} archive"
@@ -306,6 +318,7 @@ function assemble_deb() {
     enable_performance_analyzer_rca ${src_path}
     # Swap configuration files
     add_configuration_files
+    remove_unneeded_files
 
     # Generate final package
     local version
@@ -321,7 +334,7 @@ function assemble_deb() {
 
     # Move to the root folder, copy the package and clean.
     cd ../../..
-		package_name="wazuh-indexer_${version}_${SUFFIX}.${EXT}"
+    package_name="wazuh-indexer_${version}_${SUFFIX}.${EXT}"
     # debmake creates the package one level above
     cp "${TMP_DIR}/../${package_name}" "${OUTPUT}/dist/$ARTIFACT_PACKAGE_NAME"
 
@@ -338,9 +351,7 @@ function main() {
 
     ARTIFACT_BUILD_NAME=$(ls "${OUTPUT}/dist/" | grep "wazuh-indexer-min_.*$SUFFIX.*\.$EXT")
 
-		ARTIFACT_PACKAGE_NAME=${ARTIFACT_BUILD_NAME/min_/}
-
-		
+    ARTIFACT_PACKAGE_NAME=${ARTIFACT_BUILD_NAME/min_/}
 
     # Create temporal directory and copy the min package there for extraction
     TMP_DIR="${OUTPUT}/tmp/${TARGET}"


### PR DESCRIPTION
### Description
This PR replaces references to `/var/run` with `/run` in order to fix installation warnings referenced in issue #105 .

### Issues Resolved
Resolves #105 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] GitHub issue/PR created in [OpenSearch documentation repo](https://github.com/opensearch-project/documentation-website) for the required public documentation changes (#[Issue/PR number])

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
