### PR TITLE
Remove unneeded symbolic links from assembled packages

### DIFF
--- a/distribution/packages/src/deb/debmake_install.sh
+++ b/distribution/packages/src/deb/debmake_install.sh
@@ -36,10 +36,6 @@ if [ -d "${buildroot}${product_dir}"/plugins/opensearch-security ]; then
     chmod -c 0755 "${buildroot}${product_dir}"/plugins/opensearch-security/tools/*
 fi
 
-# Symlinks (do not symlink config dir as security demo installer has dependency, if no presense it will switch to rpm/deb mode)
-ln -s ${data_dir} "${buildroot}${product_dir}/data"
-ln -s ${log_dir} "${buildroot}${product_dir}/logs"
-
 # Change Permissions
 chmod -Rf a+rX,u+w,g-w,o-w "${buildroot}"/*
 

--- a/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
+++ b/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
@@ -72,9 +72,7 @@ fi
 mkdir -p %{buildroot}%{config_dir}/opensearch-observability
 mkdir -p %{buildroot}%{config_dir}/opensearch-reports-scheduler
 mkdir -p %{buildroot}%{product_dir}/performance-analyzer-rca
-# Symlinks (do not symlink config dir as security demo installer has dependency, if no presense it will switch to rpm/deb mode)
-ln -s %{data_dir} %{buildroot}%{product_dir}/data
-ln -s %{log_dir}  %{buildroot}%{product_dir}/logs
+
 # Pre-populate PA configs if not present
 if [ ! -f %{buildroot}%{data_dir}/rca_enabled.conf ]; then
     echo 'true' > %{buildroot}%{data_dir}/rca_enabled.conf
@@ -203,10 +201,6 @@ exit 0
 %{log_dir}
 %{pid_dir}
 %dir %{data_dir}
-
-# Symlinks
-%{product_dir}/data
-%{product_dir}/logs
 
 # Wazuh additional files
 %attr(440, %{name}, %{name}) %{product_dir}/VERSION


### PR DESCRIPTION
### Description
This PR removes symbolic linking from `/var/lib/wazuh-indexer` and `/var/log/wazuh-indexer` into `/usr/share/wazuh-indexer/data` and `/usr/share/wazuh-indexer/logs`.

### Issues Resolved
Resolves #107 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] GitHub issue/PR created in [OpenSearch documentation repo](https://github.com/opensearch-project/documentation-website) for the required public documentation changes (#[Issue/PR number])

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
