### PR TITLE
Removing post-install message from wazuh-indexer.rpm.spec

### DIFF
--- a/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
+++ b/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
@@ -136,19 +136,11 @@ if command -v systemd-tmpfiles > /dev/null; then
 fi
 
 # Messages
-echo "### NOT starting on installation, please execute the following statements to configure opensearch service to start automatically using systemd"
+echo "### NOT starting on installation, please execute the following statements to configure wazuh-indexer service to start automatically using systemd"
 echo " sudo systemctl daemon-reload"
-echo " sudo systemctl enable opensearch.service"
-echo "### You can start opensearch service by executing"
-echo " sudo systemctl start opensearch.service"
-if [ -d %{product_dir}/plugins/opensearch-security ]; then
-    echo "### Create opensearch demo certificates in %{config_dir}/"
-    echo " See demo certs creation log in %{log_dir}/install_demo_configuration.log"
-fi
-echo "### Upcoming breaking change in packaging"
-echo " In a future release of OpenSearch, we plan to change the permissions associated with access to installed files"
-echo " If you are configuring tools that require read access to the OpenSearch configuration files, we recommend you add the user that runs these tools to the 'opensearch' group"
-echo " For more information, see https://github.com/opensearch-project/opensearch-build/pull/4043"
+echo " sudo systemctl enable wazuh-indexer.service"
+echo "### You can start wazuh-indexer service by executing"
+echo " sudo systemctl start wazuh-indexer.service"
 exit 0
 
 %preun


### PR DESCRIPTION
### Description
This PR switches references to the `opensearch.service` systemd unit in `wazuh-indexer.rpm.spec` and other redundant messages.

### Issues Resolved
Resolves #123 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] GitHub issue/PR created in [OpenSearch documentation repo](https://github.com/opensearch-project/documentation-website) for the required public documentation changes (#[Issue/PR number])

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
