### PR TITLE
Fix Build workflow to run on push events 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,10 +10,10 @@ on:
   workflow_dispatch:
     inputs:
       revision:
-        # description:
-        default: "1"
-        required: true
+        description: "Any string or number used to extend the package's identifier"
         type: string
+        required: true
+        default: "1"
 
 # ==========================
 # Bibliography

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,8 @@ on:
 #   | https://docs.github.com/en/actions/using-workflows/reusing-workflows#using-a-matrix-strategy-with-a-reusable-workflow
 # * Reading input from the called workflow
 #   | https://docs.github.com/en/enterprise-cloud@latest/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_callinputs
+# * Ternary operator
+#   | https://docs.github.com/en/actions/learn-github-actions/expressions#example
 
 jobs:
   version:
@@ -44,7 +46,7 @@ jobs:
       architecture: ${{ matrix.architecture }}
       distribution: ${{ matrix.distribution }}
       revision: ${{ inputs.revision }}
-      name: wazuh-indexer-min_${{ needs.version.outputs.version }}-${{ inputs.revision }}-${{ matrix.architecture }}_${{ needs.commit_sha.outputs.commit_sha }}.${{ matrix.distribution }}
+      name: wazuh-indexer-min_${{ needs.version.outputs.version }}-${{ github.event_name == 'push' && '1' || inputs.revision }}-${{ matrix.architecture }}_${{ needs.commit_sha.outputs.commit_sha }}.${{ matrix.distribution }}
 
   assemble:
     needs: [version, commit_sha, build]
@@ -61,4 +63,4 @@ jobs:
     with:
       architecture: ${{ matrix.architecture }}
       distribution: ${{ matrix.distribution }}
-      min: wazuh-indexer-min_${{ needs.version.outputs.version }}-${{ inputs.revision }}-${{ matrix.architecture }}_${{ needs.commit_sha.outputs.commit_sha }}.${{ matrix.distribution }}
+      min: wazuh-indexer-min_${{ needs.version.outputs.version }}-${{ github.event_name == 'push' && '1' || inputs.revision }}-${{ matrix.architecture }}_${{ needs.commit_sha.outputs.commit_sha }}.${{ matrix.distribution }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build packages
 # This workflow runs when any of the following occur:
 # - Run manually
 on:
-  pull_request:
+  push:
     # Sequence of patterns matched against refs/heads
     branches:
       - 'ci/*'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
     with:
       architecture: ${{ matrix.architecture }}
       distribution: ${{ matrix.distribution }}
-      revision: ${{ inputs.revision }}
+      revision: ${{ github.event_name == 'push' && '1' || inputs.revision }}
       name: wazuh-indexer-min_${{ needs.version.outputs.version }}-${{ github.event_name == 'push' && '1' || inputs.revision }}-${{ matrix.architecture }}_${{ needs.commit_sha.outputs.commit_sha }}.${{ matrix.distribution }}
 
   assemble:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ on:
       revision:
         # description:
         default: "1"
-        required: false
+        required: true
         type: string
 
 # ==========================

--- a/.github/workflows/r_assemble.yml
+++ b/.github/workflows/r_assemble.yml
@@ -6,17 +6,17 @@ on:
   workflow_call:
     inputs:
       distribution:
-        description: 'One of [ "tar", "rpm", "deb" ]'
+        description: "One of [ 'tar', 'rpm', 'deb' ]"
         default: "rpm"
         required: true
         type: string
       architecture:
-        description: 'One of [ "x64", "arm64" ]'
+        description: "One of [ 'x64', 'arm64' ]"
         default: "x64"
         required: true
         type: string
       min:
-        description: The name of the package to download.
+        description: "The name of the package to download."
         required: true
         type: string
 

--- a/.github/workflows/r_assemble.yml
+++ b/.github/workflows/r_assemble.yml
@@ -8,12 +8,12 @@ on:
       distribution:
         description: 'One of [ "tar", "rpm", "deb" ]'
         default: "rpm"
-        required: false
+        required: true
         type: string
       architecture:
         description: 'One of [ "x64", "arm64" ]'
         default: "x64"
-        required: false
+        required: true
         type: string
       min:
         description: The name of the package to download.

--- a/.github/workflows/r_build.yml
+++ b/.github/workflows/r_build.yml
@@ -8,15 +8,17 @@ on:
       distribution:
         description: 'One of [ "tar", "rpm", "deb" ]'
         default: "rpm"
-        required: false
+        required: true
         type: string
       architecture:
         description: 'One of [ "x64", "arm64" ]'
         default: "x64"
-        required: false
+        required: true
         type: string
       revision:
         type: string
+        required: true
+        default: "1"
       name:
         description: The name of the package to upload.
         required: true

--- a/.github/workflows/r_build.yml
+++ b/.github/workflows/r_build.yml
@@ -6,21 +6,22 @@ on:
   workflow_call:
     inputs:
       distribution:
-        description: 'One of [ "tar", "rpm", "deb" ]'
+        description: "One of [ 'tar', 'rpm', 'deb' ]"
         default: "rpm"
         required: true
         type: string
       architecture:
-        description: 'One of [ "x64", "arm64" ]'
+        description: "One of [ 'x64', 'arm64' ]"
         default: "x64"
         required: true
         type: string
       revision:
+        description: "Any string or number used to extend the package's identifier."
         type: string
         required: true
         default: "1"
       name:
-        description: The name of the package to upload.
+        description: "The name of the package to upload."
         required: true
         type: string
 


### PR DESCRIPTION
### Description
> Runs the workflow on push

This PR extends the events that trigger the "Build packages" workflow. If the branch name matches the pattern `ci/*`.

Any changes related to the building process will include under a branch name that matches that pattern, effectively testing if the incoming changes.

### Issues Resolved
Related to #132 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] GitHub issue/PR created in [OpenSearch documentation repo](https://github.com/opensearch-project/documentation-website) for the required public documentation changes (#[Issue/PR number])

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
