### PR TITLE
Use maven for plugin download

### DIFF
--- a/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
+++ b/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
@@ -64,9 +64,10 @@ mkdir -p %{buildroot}%{pid_dir}
 mkdir -p %{buildroot}%{product_dir}/plugins
 # Install directories/files
 cp -a etc usr var %{buildroot}
-chmod 0755 %{buildroot}%{product_dir}/bin/*
+chmod 0750 %{buildroot}%{product_dir}/bin/*
 if [ -d %{buildroot}%{product_dir}/plugins/opensearch-security ]; then
-    chmod 0755 %{buildroot}%{product_dir}/plugins/opensearch-security/tools/*
+    chmod 0640 %{buildroot}%{product_dir}/plugins/opensearch-security/tools/*
+    chmod 0740 %{buildroot}%{product_dir}/plugins/opensearch-security/tools/*.sh
 fi
 # Pre-populate the folders to ensure rpm build success even without all plugins
 mkdir -p %{buildroot}%{config_dir}/opensearch-observability
@@ -152,58 +153,47 @@ fi
 exit 0
 
 %files
-%defattr(640, %{name}, %{name}, 750)
+# Permissions
+%defattr(-, %{name}, %{name})
 
 # Root dirs/docs/licenses
-%{data_dir}
-%{config_dir}
-%dir %{log_dir}
-%dir %{pid_dir}
 %dir %{product_dir}
-%dir %{product_dir}/bin
 %doc %{product_dir}/NOTICE.txt
 %doc %{product_dir}/README.md
 %license %{product_dir}/LICENSE.txt
+
+# Config dirs/files
+%dir %{config_dir}
+%{config_dir}/jvm.options.d
+%{config_dir}/opensearch-*
+%config(noreplace) %{config_dir}/opensearch.yml
+%config(noreplace) %{config_dir}/jvm.options
+%config(noreplace) %{config_dir}/log4j2.properties
+%config(noreplace) %{data_dir}/rca_enabled.conf
+%config(noreplace) %{data_dir}/performance_analyzer_enabled.conf
 
 # Service files
 %attr(0644, root, root) %{_prefix}/lib/systemd/system/%{name}.service
 %attr(0644, root, root) %{_prefix}/lib/systemd/system/%{name}-performance-analyzer.service
 %attr(0644, root, root) %{_sysconfdir}/init.d/%{name}
+%attr(0644, root, root) %config(noreplace) %{_sysconfdir}/sysconfig/%{name}
 %attr(0644, root, root) %config(noreplace) %{_prefix}/lib/sysctl.d/%{name}.conf
 %attr(0644, root, root) %config(noreplace) %{_prefix}/lib/tmpfiles.d/%{name}.conf
 
-# Binary files
+# Main dirs
+%{product_dir}/bin
+%{product_dir}/jdk
 %{product_dir}/lib
 %{product_dir}/modules
-%{product_dir}/plugins
 %{product_dir}/performance-analyzer-rca
-%{product_dir}/jdk/{conf,include,jmods,legal,lib,man,release,NOTICE}
-%exclude %{product_dir}/plugins/opensearch-security/tools/*.sh
-%exclude %{product_dir}/performance-analyzer-rca/bin/{performance-analyzer-rca,performance-analyzer-agent}
-%exclude %{product_dir}/jdk/lib/{jspawnhelper,modules}
+%{product_dir}/plugins
+%{log_dir}
+%{pid_dir}
+%dir %{data_dir}
 
-# Configuration files
-%config(noreplace) %attr(0660, root, %{name}) "%{_sysconfdir}/sysconfig/%{name}"
-%config(noreplace) %attr(660, %{name}, %{name}) %{config_dir}/log4j2.properties
-%config(noreplace) %attr(660, %{name}, %{name}) %{config_dir}/jvm.options
-%config(noreplace) %attr(660, %{name}, %{name}) %{config_dir}/opensearch.yml
-
-
-###
-###	TODO: Need to make at least these two below dependent on whether plugins are built
-###
-#%%config(noreplace) %attr(660, %{name}, %{name}) %{config_dir}/opensearch-observability/observability.yml
-#%%config(noreplace) %attr(660, %{name}, %{name}) %{config_dir}/opensearch-reports-scheduler/reports-scheduler.yml
-
-
-# Files that need other permissions
+# Wazuh additional files
 %attr(440, %{name}, %{name}) %{product_dir}/VERSION
-%attr(740, %{name}, %{name}) %{product_dir}/plugins/opensearch-security/tools/*.sh
-%attr(750, %{name}, %{name}) %{product_dir}/bin/*
-%attr(750, %{name}, %{name}) %{product_dir}/jdk/bin/*
-%attr(750, %{name}, %{name}) %{product_dir}/jdk/lib/jspawnhelper
-%attr(750, %{name}, %{name}) %{product_dir}/jdk/lib/modules
-%attr(750, %{name}, %{name}) %{product_dir}/performance-analyzer-rca/bin/*
+%attr(660, %{name}, %{name}) %{config_dir}/wazuh-template.json
 
 %changelog
 * Thu Mar 28 2024 support <info@wazuh.com> - 4.9.0

--- a/docker/ci/images/Dockerfile
+++ b/docker/ci/images/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir /home/wazuh-indexer && \
     echo "deb http://repo.aptly.info/ squeeze main" | tee -a /etc/apt/sources.list.d/aptly.list && \
     apt-get update -y && \
     apt-get upgrade -y && \
-    apt-get install -y aptly build-essential cpio debhelper-compat debmake freeglut3 libasound2 libatk-bridge2.0-0 libatk1.0-0 libatspi2.0-dev libcairo2 libcairo2-dev libcups2 libdrm2 libgbm-dev libgconf-2-4 libnspr4 libnspr4-dev libnss3 libpangocairo-1.0-0 libxcomposite-dev libxdamage1 libxfixes-dev libxfixes3 libxi6 libxkbcommon-x11-0 libxrandr2 libxrender1 libxtst6 rpm rpm2cpio && \
+    apt-get install -y aptly build-essential cpio debhelper-compat debmake freeglut3 libasound2 libatk-bridge2.0-0 libatk1.0-0 libatspi2.0-dev libcairo2 libcairo2-dev libcups2 libdrm2 libgbm-dev libgconf-2-4 libnspr4 libnspr4-dev libnss3 libpangocairo-1.0-0 libxcomposite-dev libxdamage1 libxfixes-dev libxfixes3 libxi6 libxkbcommon-x11-0 libxrandr2 libxrender1 libxtst6 rpm rpm2cpio maven && \
     apt-get clean -y && \
     dpkg -r lintian && \
     addgroup --gid 1000 wazuh-indexer && \

--- a/docker/dev/images/Dockerfile
+++ b/docker/dev/images/Dockerfile
@@ -7,6 +7,7 @@ RUN gradle clean
 
 FROM eclipse-temurin:17-jdk-alpine
 RUN apk add git && \
+		apk add curl && \
     addgroup -g 1000 wazuh-indexer && \
     adduser -u 1000 -G wazuh-indexer -D -h /home/wazuh-indexer wazuh-indexer && \
     chmod 0775 /home/wazuh-indexer && \

--- a/scripts/assemble.sh
+++ b/scripts/assemble.sh
@@ -214,11 +214,12 @@ function enable_performance_analyzer_rca() {
 # Install plugins
 # ====
 function install_plugins() {
-    # Install plugins from Maven repository
     echo "Install plugins"
+		maven_repo_local="$HOME/maven"
     for plugin in "${plugins[@]}"; do
         plugin_from_maven="org.opensearch.plugin:${plugin}:$VERSION.0"
-        OPENSEARCH_PATH_CONF=$PATH_CONF "${PATH_BIN}/opensearch-plugin" install --batch --verbose "${plugin_from_maven}"
+				mvn -Dmaven.repo.local=$maven_repo_local org.apache.maven.plugins:maven-dependency-plugin:2.1:get -DrepoUrl=https://repo1.maven.org/maven2 -Dartifact=$plugin_from_maven:zip
+        OPENSEARCH_PATH_CONF=$PATH_CONF "${PATH_BIN}/opensearch-plugin" install --batch --verbose "file:${maven_repo_local}/org/opensearch/plugin/${plugin}/$VERSION.0/${plugin}-$VERSION.0.zip"
     done
 }
 

--- a/scripts/assemble.sh
+++ b/scripts/assemble.sh
@@ -14,33 +14,32 @@ set -ex
 
 TEST=${TEST:-false}
 
-if ( $TEST )
-then
-		plugins=(
-		    "performance-analyzer"
-		    "opensearch-security"
-		)
+if ($TEST); then
+    plugins=(
+        "performance-analyzer"
+        "opensearch-security"
+    )
 else
-		plugins=(
-		    "alerting" # "opensearch-alerting"
-		    "opensearch-job-scheduler"
-		    "opensearch-anomaly-detection" # Requires "opensearch-job-scheduler"
-		    "asynchronous-search"          # "opensearch-asynchronous-search"
-		    "opensearch-cross-cluster-replication"
-		    "geospatial" # "opensearch-geospatial"
-		    "opensearch-index-management"
-		    "opensearch-knn"
-		    "opensearch-ml-plugin" # "opensearch-ml"
-		    "neural-search"        # "opensearch-neural-search"
-		    "opensearch-notifications-core"
-		    "notifications" # "opensearch-notifications". Requires "opensearch-notifications-core"
-		    "opensearch-observability"
-		    "performance-analyzer" # "opensearch-performance-analyzer"
-		    "opensearch-reports-scheduler"
-		    "opensearch-security"
-		    "opensearch-security-analytics"
-		    "opensearch-sql-plugin" # "opensearch-sql"
-		)
+    plugins=(
+        "alerting" # "opensearch-alerting"
+        "opensearch-job-scheduler"
+        "opensearch-anomaly-detection" # Requires "opensearch-job-scheduler"
+        "asynchronous-search"          # "opensearch-asynchronous-search"
+        "opensearch-cross-cluster-replication"
+        "geospatial" # "opensearch-geospatial"
+        "opensearch-index-management"
+        "opensearch-knn"
+        "opensearch-ml-plugin" # "opensearch-ml"
+        "neural-search"        # "opensearch-neural-search"
+        "opensearch-notifications-core"
+        "notifications" # "opensearch-notifications". Requires "opensearch-notifications-core"
+        "opensearch-observability"
+        "performance-analyzer" # "opensearch-performance-analyzer"
+        "opensearch-reports-scheduler"
+        "opensearch-security"
+        "opensearch-security-analytics"
+        "opensearch-sql-plugin" # "opensearch-sql"
+    )
 fi
 
 # ====
@@ -215,10 +214,10 @@ function enable_performance_analyzer_rca() {
 # ====
 function install_plugins() {
     echo "Install plugins"
-		maven_repo_local="$HOME/maven"
+    maven_repo_local="$HOME/maven"
     for plugin in "${plugins[@]}"; do
         plugin_from_maven="org.opensearch.plugin:${plugin}:$VERSION.0"
-				mvn -Dmaven.repo.local=$maven_repo_local org.apache.maven.plugins:maven-dependency-plugin:2.1:get -DrepoUrl=https://repo1.maven.org/maven2 -Dartifact=$plugin_from_maven:zip
+        mvn -Dmaven.repo.local=$maven_repo_local org.apache.maven.plugins:maven-dependency-plugin:2.1:get -DrepoUrl=https://repo1.maven.org/maven2 -Dartifact=$plugin_from_maven:zip
         OPENSEARCH_PATH_CONF=$PATH_CONF "${PATH_BIN}/opensearch-plugin" install --batch --verbose "file:${maven_repo_local}/org/opensearch/plugin/${plugin}/$VERSION.0/${plugin}-$VERSION.0.zip"
     done
 }


### PR DESCRIPTION
### Description
This PR makes `assemble.sh` use `mvn` for retrieving the OpenSearch plugin artifacts instead of grabbing them directly using `opensearch-plugin`.
This allows the use `mvn`'s local cache to avoid re-downloading plugins' `zip` files on each run, thus speeding testing.

### Issues Resolved
Resolves #138 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] GitHub issue/PR created in [OpenSearch documentation repo](https://github.com/opensearch-project/documentation-website) for the required public documentation changes (#[Issue/PR number])

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
