### PR TITLE
Add new custom field to the vulnerability detector index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # build files
 artifacts/
 
+.java
+.m2
+
 # intellij files
 .idea/
 *.iml

--- a/ecs/generate.sh
+++ b/ecs/generate.sh
@@ -27,6 +27,7 @@ generate_mappings() {
     --subset "$IN_FILES_DIR/subset.yml" \
     --template-settings "$IN_FILES_DIR/template-settings.json" \
     --template-settings-legacy "$IN_FILES_DIR/template-settings-legacy.json" \
+    --mapping-settings "$IN_FILES_DIR/mapping-settings.json" \
     --out "$OUT_DIR" || exit 1
 
   # Replace "match_only_text" type (not supported by OpenSearch) with "text"

--- a/ecs/vulnerability-detector/event-generator/event_generator.py
+++ b/ecs/vulnerability-detector/event-generator/event_generator.py
@@ -163,7 +163,7 @@ def generate_random_vulnerability():
             'temporal': round(random.uniform(0, 10), 1),
             'version': round(random.uniform(0, 10), 1)
         },
-        'severity': random.choice(['low', 'medium', 'high', 'critical'])
+        'severity': random.choice(['Low', 'Medium', 'High', 'Critical'])
     }
     return vulnerability
 
@@ -187,7 +187,7 @@ def generate_random_data(number):
             'ecs': {'version': '1.7.0'},
             # 'event': generate_random_event(),
             'host': generate_random_host(),
-            'labels': generate_random_labels(),
+            # 'labels': generate_random_labels(),
             'message': f'message{random.randint(0, 99999)}',
             'package': generate_random_package(),
             'tags': generate_random_tags(),

--- a/ecs/vulnerability-detector/event-generator/event_generator.py
+++ b/ecs/vulnerability-detector/event-generator/event_generator.py
@@ -171,7 +171,8 @@ def generate_random_vulnerability():
 def generate_random_wazuh():
     wazuh = {
         'cluster': {
-            'name': f'wazuh-cluster-{random.randint(0,10)}'
+            'name': f'wazuh-cluster-{random.randint(0,10)}',
+            'node': f'wazuh-cluster-node-{random.randint(0,10)}'
         }
     }
     return wazuh

--- a/ecs/vulnerability-detector/fields/custom/wazuh.yml
+++ b/ecs/vulnerability-detector/fields/custom/wazuh.yml
@@ -9,3 +9,8 @@
       level: custom
       description: >
         Wazuh cluster name.
+    - name: cluster.node
+      type: keyword
+      level: custom
+      description: >
+        Wazuh cluster node name.

--- a/ecs/vulnerability-detector/fields/mapping-settings.json
+++ b/ecs/vulnerability-detector/fields/mapping-settings.json
@@ -1,0 +1,4 @@
+{
+    "dynamic": "strict",
+    "date_detection": false
+}

--- a/ecs/vulnerability-detector/fields/subset.yml
+++ b/ecs/vulnerability-detector/fields/subset.yml
@@ -2,7 +2,10 @@
 name: vulnerability_detector
 fields:
   base:
-    fields: "*"
+    fields: 
+      "@timestamp": {}
+      tags: []
+      message: ""
   agent:
     fields: "*"
   ecs:


### PR DESCRIPTION
### Description
This PR updates the ECS generation tools for the vulnerability detector module to add a new custom field `wazuh.cluster.node`.

It also adds **strict** dynamic mapping mode.

### Issues Resolved
Closes #140 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] GitHub issue/PR created in [OpenSearch documentation repo](https://github.com/opensearch-project/documentation-website) for the required public documentation changes (#[Issue/PR number])

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
