### PR TITLE
Add `wazuh.manager.name` to VD mappings

### DIFF
--- a/ecs/vulnerability-detector/event-generator/event_generator.py
+++ b/ecs/vulnerability-detector/event-generator/event_generator.py
@@ -173,6 +173,9 @@ def generate_random_wazuh():
         'cluster': {
             'name': f'wazuh-cluster-{random.randint(0,10)}',
             'node': f'wazuh-cluster-node-{random.randint(0,10)}'
+        },
+        'manager': {
+            'name': f'wazuh-manager-{random.randint(0,10)}'
         }
     }
     return wazuh

--- a/ecs/vulnerability-detector/fields/custom/wazuh.yml
+++ b/ecs/vulnerability-detector/fields/custom/wazuh.yml
@@ -14,3 +14,8 @@
       level: custom
       description: >
         Wazuh cluster node name.
+    - name: manager.name
+      type: keyword
+      level: custom
+      description: >
+        Wazuh manager name. Used by dashboards to filter results on single node deployments.


### PR DESCRIPTION
### Description
This PR adds a new field `wazuh.manager.name` to the `wazuh-states-vulnerabilities` index mappings.

To upload the template:

```console
curl -u admin:admin -k -X PUT "https://localhost:9200/_index_template/wazuh-vulnerability-detector" -H "Content-Type: application/json" -d @legacy-template.json
```

### Issues Resolved
Closes #157 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] GitHub issue/PR created in [OpenSearch documentation repo](https://github.com/opensearch-project/documentation-website) for the required public documentation changes (#[Issue/PR number])

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
