### PR TITLE
Remove ecs.version from query.default_fields

### DIFF
--- a/ecs/vulnerability-detector/fields/template-settings-legacy.json
+++ b/ecs/vulnerability-detector/fields/template-settings-legacy.json
@@ -17,7 +17,6 @@
       "query.default_field": [
         "base.tags",
         "agent.id",
-        "ecs.version",
         "host.os.family",
         "host.os.full.text",
         "host.os.version",

--- a/ecs/vulnerability-detector/fields/template-settings.json
+++ b/ecs/vulnerability-detector/fields/template-settings.json
@@ -18,7 +18,6 @@
         "query.default_field": [
           "base.tags",
           "agent.id",
-          "ecs.version",
           "host.os.family",
           "host.os.full.text",
           "host.os.version",


### PR DESCRIPTION
### Description
Remove `ecs.version` from `query.default_fields`.

### Issues Resolved
Closes #176 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] GitHub issue/PR created in [OpenSearch documentation repo](https://github.com/opensearch-project/documentation-website) for the required public documentation changes (#[Issue/PR number])

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
