### PR TITLE
Add on.workflow_call to build_single.yml workflow

### DIFF
--- a/.github/workflows/build_single.yml
+++ b/.github/workflows/build_single.yml
@@ -1,8 +1,37 @@
 name: Build packages (single)
 
 # This workflow runs when any of the following occur:
+# - Run from another worklow of GH API
 # - Run manually
 on:
+  workflow_call:
+    inputs:
+      revision:
+        description: "Revision"
+        type: string
+        default: "0"
+      checksum:
+        description: "Checksum ?"
+        type: boolean
+        default: false
+      is_stage:
+        description: "Is stage ?"
+        type: boolean
+        default: false
+      system:
+        description: "Package OS"
+        type: choice
+        options:
+          - rpm
+          - deb
+        default: deb
+      architecture:
+        description: "Package architecture"
+        type: choice
+        options:
+          - amd64
+          - x86_64
+        default: amd64
   workflow_dispatch:
     inputs:
       revision:


### PR DESCRIPTION
### Description
This PR allows to invoke the workflow using the GH API (or from another workflow).

### Issues Resolved
Closes #199

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing ofinvocationf your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
