### PR TITLE
Replace choice with string on workflow_call

### DIFF
--- a/.github/workflows/build_single.yml
+++ b/.github/workflows/build_single.yml
@@ -20,17 +20,11 @@ on:
         default: false
       system:
         description: "Package OS"
-        type: choice
-        options:
-          - rpm
-          - deb
+        type: string
         default: deb
       architecture:
         description: "Package architecture"
-        type: choice
-        options:
-          - amd64
-          - x86_64
+        type: string
         default: amd64
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
### Description
This PR fixes the `build_single` workflow by replacing the `choice` type by `string` for the `workflow_call` trigger.

### Issues Resolved
Closes #206 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
