### PR TITLE
Fix access denied error during log rotation

### DIFF
--- a/packaging_scripts/assemble.sh
+++ b/packaging_scripts/assemble.sh
@@ -196,6 +196,17 @@ function enable_performance_analyzer() {
 }
 
 # ====
+# Fix https://github.com/wazuh/wazuh-indexer/issues/205
+# ====
+function fix_log_rotation() {
+    {
+        echo 'grant {'
+        echo '  permission java.lang.RuntimePermission "accessUserInformation";'
+        echo '};'
+    } >> "${1}/opensearch-performance-analyzer/opensearch_security.policy"
+}
+
+# ====
 # Move performance-analyzer-rca to its final location
 # ====
 function enable_performance_analyzer_rca() {
@@ -245,6 +256,7 @@ function assemble_tar() {
 
     # Install plugins
     install_plugins
+    fix_log_rotation ${PATH_CONF}
     # Swap configuration files
     add_configuration_files
     remove_unneeded_files
@@ -284,6 +296,7 @@ function assemble_rpm() {
 
     # Install plugins
     install_plugins
+    fix_log_rotation ${PATH_CONF}
     enable_performance_analyzer_rca ${src_path}
     # Swap configuration files
     add_configuration_files
@@ -337,6 +350,7 @@ function assemble_deb() {
 
     # Install plugins
     install_plugins
+    fix_log_rotation ${PATH_CONF}
     enable_performance_analyzer_rca ${src_path}
     # Swap configuration files
     add_configuration_files


### PR DESCRIPTION
### Description
This PR adds a temporal solution (until OpenSearch provides a final solution) to the access denied error that raises during the daily log file rotation.

### Issues Resolved
Closes #205 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
