### PR TITLE
Save intermediate OCSF files to an S3 bucket

### DIFF
--- a/integrations/README.md
+++ b/integrations/README.md
@@ -43,8 +43,6 @@ After 5 minutes, the first batch of data will show up in http://localhost:9444/u
 You'll need to invoke the Lambda function manually, selecting the log file to process.
 
 ```bash
-export AUX_BUCKET=wazuh-indexer-aux-bucket
-
 bash amazon-security-lake/src/invoke-lambda.sh <file>
 ```
 

--- a/integrations/amazon-security-lake/Dockerfile
+++ b/integrations/amazon-security-lake/Dockerfile
@@ -19,7 +19,7 @@ ENV LOGSTASH_KEYSTORE_PASS="SecretPassword"
 # Add the application source code.
 COPY --chown=logstash:logstash ./src /home/app
 # Add execution persmissions.
-RUN chmod a+x /home/app/run.py
+RUN chmod a+x /home/app/lambda_function.py
 # Copy the application's dependencies.
 COPY --from=builder /env /env
 

--- a/integrations/amazon-security-lake/invoke-lambda.sh
+++ b/integrations/amazon-security-lake/invoke-lambda.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export AUX_BUCKET=wazuh-indexer-aux-bucket
+export S3_BUCKET_RAW=wazuh-aws-security-lake-raw
 
 curl -X POST "http://localhost:9000/2015-03-31/functions/function/invocations" -d '{
   "Records": [
@@ -24,11 +24,11 @@ curl -X POST "http://localhost:9000/2015-03-31/functions/function/invocations" -
         "s3SchemaVersion": "1.0",
         "configurationId": "testConfigRule",
         "bucket": {
-          "name": "'"${AUX_BUCKET}"'",
+          "name": "'"${S3_BUCKET_RAW}"'",
           "ownerIdentity": {
             "principalId":"A3NL1KOZZKExample"
           },
-          "arn": "'"arn:aws:s3:::${AUX_BUCKET}"'"
+          "arn": "'"arn:aws:s3:::${S3_BUCKET_RAW}"'"
         },
         "object": {
           "key": "'"${1}"'",

--- a/integrations/amazon-security-lake/logstash/pipeline/indexer-to-s3.conf
+++ b/integrations/amazon-security-lake/logstash/pipeline/indexer-to-s3.conf
@@ -30,7 +30,7 @@ output {
       secret_access_key => "${AWS_SECRET_ACCESS_KEY}"
       region => "${AWS_REGION}"
       endpoint => "${AWS_ENDPOINT}"
-      bucket => "${AUX_BUCKET}"
+      bucket => "${S3_BUCKET_RAW}"
       codec => "json_lines"
       retry_count => 0
       validate_credentials_on_root_bucket => false

--- a/integrations/docker/amazon-security-lake.yml
+++ b/integrations/docker/amazon-security-lake.yml
@@ -83,7 +83,7 @@ services:
       AWS_ACCESS_KEY_ID: "AKIAIOSFODNN7EXAMPLE"
       AWS_SECRET_ACCESS_KEY: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
       AWS_REGION: "us-east-1"
-      AUX_BUCKET: "indexer-amazon-security-lake-bucket"
+      S3_BUCKET_RAW: "wazuh-aws-security-lake-raw"
       AWS_ENDPOINT: "http://s3.ninja:9000"
     ports:
       - "5000:5000/tcp"
@@ -117,7 +117,8 @@ services:
       AWS_ACCESS_KEY_ID: "AKIAIOSFODNN7EXAMPLE"
       AWS_SECRET_ACCESS_KEY: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
       AWS_REGION: "us-east-1"
-      AWS_BUCKET: "wazuh-indexer-amazon-security-lake-bucket"
+      AWS_BUCKET: "wazuh-aws-security-lake-parquet"
+      S3_BUCKET_OCSF: "wazuh-aws-security-lake-ocsf"
       AWS_ENDPOINT: "http://s3.ninja:9000"
       SOURCE_LOCATION: "wazuh"
       ACCOUNT_ID: "111111111111"


### PR DESCRIPTION
### Description
This PR adds the ability to save intermediate events in OCSF format to an S3 bucket for the Amazon Security Lake integration.

### Issues Resolved
Closes #216 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
