### PR TITLE
Fix mapping to Detection Finding OCSF class

### DIFF
--- a/integrations/amazon-security-lake/src/models/ocsf.py
+++ b/integrations/amazon-security-lake/src/models/ocsf.py
@@ -22,7 +22,7 @@ class AttackInfo(pydantic.BaseModel):
 
 class FindingInfo(pydantic.BaseModel):
     analytic: AnalyticInfo
-    attacks: AttackInfo
+    attacks: typing.List[AttackInfo]
     title: str
     types: typing.List[str]
     uid: str
@@ -61,6 +61,6 @@ class DetectionFinding(pydantic.BaseModel):
     risk_score: int
     severity_id: int
     status_id: int = 99
-    time: str
+    time: int
     type_uid: int = 200401
     unmapped: typing.Dict[str, typing.List[str]] = pydantic.Field()


### PR DESCRIPTION
### Description
This PR fixes the mapping to the _Detection Finding_ class of OCSF.


**Resulting parquet**
```
+---------------+-----------------+----------------+-------------------+-------------+---------+-------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+------------+-------------------------------------+--------------+---------------+-------------+------------+------------+-----------------------------------------------------------------------------------------------+
|   activity_id | category_name   |   category_uid | class_name        |   class_uid |   count | message                       | finding_info                                                                                                                                                                                                                  | metadata                                                                                                                                                | raw_data   | resources                           |   risk_score |   severity_id |   status_id |       time |   type_uid | unmapped                                                                                      |
|---------------+-----------------+----------------+-------------------+-------------+---------+-------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+------------+-------------------------------------+--------------+---------------+-------------+------------+------------+-----------------------------------------------------------------------------------------------|
|             1 | Findings        |              2 | Detection Finding |        2004 |      17 | Audit: Command: /usr/sbin/sh  | {'analytic': {'category': 'audit, audit_command', 'name': 'N/A', 'type_id': 1, 'uid': '80790'}, 'attacks': array([{'tactic': {'name': 'N/A', 'uid': 'N/A'}, 'technique': {'name': 'N/A', 'uid': 'N/A'}, 'version': 'v13.1'}], | {'log_name': 'Security events', 'log_provider': 'Wazuh', 'product': {'lang': 'en', 'name': 'Wazuh', 'vendor_name': 'Wazuh, Inc,.'}, 'version': '1.1.0'} |            | [{'name': 'Ubuntu', 'uid': '004'}]  |            3 |             1 |          99 | 1714140790 |     200401 | {'data_sources': array(['', 'wazuh-manager'], dtype=object), 'nist': array([], dtype=object)} |
|               |                 |                |                   |             |         |                               |       dtype=object), 'title': 'Audit: Command: /usr/sbin/sh', 'types': array(['N/A'], dtype=object), 'uid': '1580123327.49031'}                                                                                               |                                                                                                                                                         |            |                                     |              |               |             |            |            |                                                                                               |
|             1 | Findings        |              2 | Detection Finding |        2004 |       0 | Sample alert 1                | {'analytic': {'category': 'ciscat', 'name': 'N/A', 'type_id': 1, 'uid': '4746'}, 'attacks': array([{'tactic': {'name': 'N/A', 'uid': 'N/A'}, 'technique': {'name': 'N/A', 'uid': 'N/A'}, 'version': 'v13.1'}],                | {'log_name': 'Security events', 'log_provider': 'Wazuh', 'product': {'lang': 'en', 'name': 'Wazuh', 'vendor_name': 'Wazuh, Inc,.'}, 'version': '1.1.0'} |            | [{'name': 'Windows', 'uid': '006'}] |           10 |             3 |          99 | 1714140805 |     200401 | {'data_sources': array(['', 'wazuh-manager'], dtype=object), 'nist': array([], dtype=object)} |
|               |                 |                |                   |             |         |                               |       dtype=object), 'title': 'Sample alert 1', 'types': array(['N/A'], dtype=object), 'uid': '1580123327.49031'}                                                                                                             |                                                                                                                                                         |            |                                     |              |               |             |            |            |                                                                                               |
|             1 | Findings        |              2 | Detection Finding |        2004 |      11 | Audit: Command: /usr/sbin/id  | {'analytic': {'category': 'audit, audit_command', 'name': 'N/A', 'type_id': 1, 'uid': '80784'}, 'attacks': array([{'tactic': {'name': 'N/A', 'uid': 'N/A'}, 'technique': {'name': 'N/A', 'uid': 'N/A'}, 'version': 'v13.1'}], | {'log_name': 'Security events', 'log_provider': 'Wazuh', 'product': {'lang': 'en', 'name': 'Wazuh', 'vendor_name': 'Wazuh, Inc,.'}, 'version': '1.1.0'} |            | [{'name': 'Centos', 'uid': '005'}]  |            3 |             1 |          99 | 1714140783 |     200401 | {'data_sources': array(['', 'wazuh-manager'], dtype=object), 'nist': array([], dtype=object)} |
|               |                 |                |                   |             |         |                               |       dtype=object), 'title': 'Audit: Command: /usr/sbin/id', 'types': array(['N/A'], dtype=object), 'uid': '1580123327.49031'}                                                                                               |                                                                                                                                                         |            |                                     |              |               |             |            |            |                                                                                               |
|             1 | Findings        |              2 | Detection Finding |        2004 |      17 | Audit: Command: /usr/sbin/sh  | {'analytic': {'category': 'audit, audit_command', 'name': 'N/A', 'type_id': 1, 'uid': '80790'}, 'attacks': array([{'tactic': {'name': 'N/A', 'uid': 'N/A'}, 'technique': {'name': 'N/A', 'uid': 'N/A'}, 'version': 'v13.1'}], | {'log_name': 'Security events', 'log_provider': 'Wazuh', 'product': {'lang': 'en', 'name': 'Wazuh', 'vendor_name': 'Wazuh, Inc,.'}, 'version': '1.1.0'} |            | [{'name': 'RHEL7', 'uid': '001'}]   |            3 |             1 |          99 | 1714140800 |     200401 | {'data_sources': array(['', 'wazuh-manager'], dtype=object), 'nist': array([], dtype=object)} |
|               |                 |                |                   |             |         |                               |       dtype=object), 'title': 'Audit: Command: /usr/sbin/sh', 'types': array(['N/A'], dtype=object), 'uid': '1580123327.49031'}                                                                                               |                                                                                                                                                         |            |                                     |              |               |             |            |            |                                                                                               |
|             1 | Findings        |              2 | Detection Finding |        2004 |       3 | Audit: Command: /usr/sbin/ssh | {'analytic': {'category': 'audit, audit_command', 'name': 'N/A', 'type_id': 1, 'uid': '80791'}, 'attacks': array([{'tactic': {'name': 'N/A', 'uid': 'N/A'}, 'technique': {'name': 'N/A', 'uid': 'N/A'}, 'version': 'v13.1'}], | {'log_name': 'Security events', 'log_provider': 'Wazuh', 'product': {'lang': 'en', 'name': 'Wazuh', 'vendor_name': 'Wazuh, Inc,.'}, 'version': '1.1.0'} |            | [{'name': 'RHEL7', 'uid': '001'}]   |            3 |             1 |          99 | 1714140795 |     200401 | {'data_sources': array(['', 'wazuh-manager'], dtype=object), 'nist': array([], dtype=object)} |
|               |                 |                |                   |             |         |                               |       dtype=object), 'title': 'Audit: Command: /usr/sbin/ssh', 'types': array(['N/A'], dtype=object), 'uid': '1580123327.49031'}                                                                                              |                                                                                                                                                         |            |                                     |              |               |             |            |            |                                                                                               |
+---------------+-----------------+----------------+-------------------+-------------+---------+-------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+------------+-------------------------------------+--------------+---------------+-------------+------------+------------+-----------------------------------------------------------------------------------------------+
```

**Validation evidence**
```
(.venv) @alex-GL66 ➜ amazon-security-lake-ocsf-validation git:(main) ✗ python validate.py -i parquet/

ATTEMPTING TO VALIDATE FILE: ext_wazuh_region=us-east-1_accountId=111111111111_eventDay=20240426_16c8c6c68f4845949f41ea1d6098913f.parquet

VALID OCSF.

VALID OCSF.

VALID OCSF.

VALID OCSF.

VALID OCSF.

Sending verbose output to: /home/alex/wazuh/amazon-security-lake-ocsf-validation/output.txt
```


### Issues Resolved
Closes #219 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
