### PR TITLE
Add ID input to workflows

### DIFF
--- a/.github/workflows/build_single.yml
+++ b/.github/workflows/build_single.yml
@@ -1,4 +1,4 @@
-name: Build packages (single)
+name: Build packages (single) ${{ inputs.id }}
 
 # This workflow runs when any of the following occur:
 # - Run from another worklow of GH API
@@ -26,6 +26,11 @@ on:
         description: "Package architecture"
         type: string
         default: amd64
+      id:
+        description: "ID used to identify the workflow uniquely."
+        type: string
+        required: false
+
   workflow_dispatch:
     inputs:
       revision:
@@ -54,6 +59,10 @@ on:
           - amd64
           - x86_64
         default: amd64
+      id:
+        description: "ID used to identify the workflow uniquely."
+        type: string
+        required: false
 
 jobs:
   call-build-workflow:

--- a/.github/workflows/build_single.yml
+++ b/.github/workflows/build_single.yml
@@ -1,4 +1,4 @@
-name: Build packages (single) ${{ inputs.id }}
+run-name: Build packages (single) ${{ inputs.id }}
 
 # This workflow runs when any of the following occur:
 # - Run from another worklow of GH API


### PR DESCRIPTION
## Description

This PR adds the `id` input to the packages generation workflows so the workflow can be identified with a unique string

The workflow can be executed with or without the input, as it is not required

Tests:
- https://github.com/wazuh/wazuh-jenkins/issues/6371#issuecomment-2115914391
- https://github.com/wazuh/wazuh-indexer/actions/runs/9117724458 without ID
- https://github.com/wazuh/wazuh-indexer/actions/runs/9117724340 without ID
- https://github.com/wazuh/wazuh-indexer/actions/runs/9117723534 with ID
- https://github.com/wazuh/wazuh-indexer/actions/runs/9117723519 with ID