### PR TITLE
Update `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,3 +11,12 @@
 *.crt binary
 *.p12 binary
 *.txt text=auto
+
+# Image
+*.ai filter=lfs diff=lfs merge=lfs -text
+*.gif filter=lfs diff=lfs merge=lfs -text
+*.jpg filter=lfs diff=lfs merge=lfs -text
+*.jpeg filter=lfs diff=lfs merge=lfs -text
+*.png filter=lfs diff=lfs merge=lfs -text
+*.psd filter=lfs diff=lfs merge=lfs -text
+*.tga filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
### Description
This PR fixes a problem with images line endings, causing the files to be detected as modified by Git, even if they are not.


