### PR TITLE
Change . for : in debian's postinst

### DIFF
--- a/distribution/packages/src/deb/debian/postinst
+++ b/distribution/packages/src/deb/debian/postinst
@@ -25,12 +25,12 @@ tmp_dir=/var/log/wazuh-indexer/tmp
 mkdir -p ${tmp_dir}
 
 # Set owner
-chown -R wazuh-indexer.wazuh-indexer ${product_dir}
-chown -R wazuh-indexer.wazuh-indexer ${config_dir}
-chown -R wazuh-indexer.wazuh-indexer ${log_dir}
-chown -R wazuh-indexer.wazuh-indexer ${data_dir}
-chown -R wazuh-indexer.wazuh-indexer ${pid_dir}
-chown -R wazuh-indexer.wazuh-indexer ${tmp_dir}
+chown -R wazuh-indexer:wazuh-indexer ${product_dir}
+chown -R wazuh-indexer:wazuh-indexer ${config_dir}
+chown -R wazuh-indexer:wazuh-indexer ${log_dir}
+chown -R wazuh-indexer:wazuh-indexer ${data_dir}
+chown -R wazuh-indexer:wazuh-indexer ${pid_dir}
+chown -R wazuh-indexer:wazuh-indexer ${tmp_dir}
 
 # Reload systemctl daemon
 if command -v systemctl > /dev/null; then


### PR DESCRIPTION
### Description
This PR fixes an error in `chown`'s syntax within debian's `postinst` script that issues a warning on packages installation.

### Issues Resolved
Resolves #244 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
