### PR TITLE
Test to fix #277

### DIFF
--- a/packaging_scripts/assemble.sh
+++ b/packaging_scripts/assemble.sh
@@ -358,7 +358,7 @@ function assemble_deb() {
     add_wazuh_tools "${version}"
 
     # Configure debmake to only generate binaries
-    echo 'DEBUILD_DPKG_BUILDPACKAGE_OPTS="-us -uc -ui -b"' >~/.devscripts
+    echo 'DEBUILD_DPKG_BUILDPACKAGE_OPTS="-us -uc -b"' >~/.devscripts
 
     # Generate final package
     debmake \


### PR DESCRIPTION
### Description
On this PR I try to fix the missing revision on the DEB package metadata by removing the `-ui` option when invoking `debuild`, to make it identical to [the previous package builder](https://github.com/wazuh/wazuh-packages/blob/master/stack/indexer/deb/builder.sh#L64C98-L64C106).

https://man7.org/linux/man-pages/man1/dpkg-buildpackage.1.html

### Issues Resolved
#277 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
