### PR TITLE
Bumping the systemd service timeout for backwards compatibility reasons

### DIFF
--- a/distribution/packages/src/common/systemd/wazuh-indexer.service
+++ b/distribution/packages/src/common/systemd/wazuh-indexer.service
@@ -59,7 +59,7 @@ SendSIGKILL=no
 SuccessExitStatus=143
 
 # Allow a slow startup before the systemd notifier module kicks in to extend the timeout
-TimeoutStartSec=75
+TimeoutStartSec=180
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
### Description
This PR increases the systemd service unit timeout to match the 180 seconds that were used with versions 4.8 and prior.

### Issues Resolved
Resolves #307 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
