### PR TITLE
Fixing the gradle version to 8.7

### DIFF
--- a/docker/dev/images/Dockerfile
+++ b/docker/dev/images/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:jdk21-alpine AS builder
+FROM gradle:8.7.0-jdk21-alpine AS builder
 USER gradle
 WORKDIR /home/wazuh-indexer
 COPY --chown=gradle:gradle . /home/wazuh-indexer


### PR DESCRIPTION
### Description
This PR fixes the docker images gradle version to `8.7`, just before their `InstallationLocation` constructor was modified.
As detailed in the issue, there is already [a merged PR from opensearch](https://github.com/opensearch-project/OpenSearch/pull/13584), but it's beyond version `2.15`, so this is a temporary fix.

### Issues Resolved
Resolves #318 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
