### PR TITLE
Include Command Manager plugin to the build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,7 +114,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        plugins: ["wazuh-indexer-setup"]
+        plugins: ["setup", "command-manager"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,14 +103,14 @@ jobs:
       - id: setup
         run: |
           matrix=$(jq -cn \
-              --argjson distribution '${{ github.event.inputs.distribution }}' \
-              --argjson architecture '${{ github.event.inputs.architecture }}' \
+              --argjson distribution '${{ inputs.distribution }}' \
+              --argjson architecture '${{ inputs.architecture }}' \
               '{distribution: $distribution, architecture: $architecture}'
           )
           echo "matrix=$matrix" >> $GITHUB_OUTPUT
 
   build-plugins:
-    if: ${{ github.event.inputs.plugins_reference != '' }}
+    if: ${{ inputs.plugins_reference != '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -120,7 +120,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: wazuh/wazuh-indexer-plugins
-          ref: ${{ github.event.inputs.plugins_reference }}
+          ref: ${{ inputs.plugins_reference }}
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
@@ -136,14 +136,14 @@ jobs:
       - name: Build with Gradle
         working-directory: .//plugins/${{ matrix.plugins }}
         run: |
-          ./gradlew build -Dversion=${{ steps.version.outputs.version }} -Drevision=${{ github.event.inputs.revision }}
+          ./gradlew build -Dversion=${{ steps.version.outputs.version }} -Drevision=${{ inputs.revision }}
           ls -lR build/distributions/
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.plugins }}
-          path: "./plugins/${{ matrix.plugins }}/build/distributions/${{ matrix.plugins }}-${{ steps.version.outputs.version }}.${{ github.event.inputs.revision }}.zip"
+          path: "./plugins/${{ matrix.plugins }}/build/distributions/${{ matrix.plugins }}-${{ steps.version.outputs.version }}.${{ inputs.revision }}.zip"
           if-no-files-found: error
 
   build:
@@ -157,13 +157,13 @@ jobs:
 
       # Download plugins
       - uses: actions/download-artifact@v4
-        if: ${{ github.event.inputs.plugins_reference != '' }}
+        if: ${{ inputs.plugins_reference != '' }}
         with:
           path: ./artifacts/plugins
           merge-multiple: true
 
       - name: Display structure of downloaded files
-        if: ${{ github.event.inputs.plugins_reference != '' }}
+        if: ${{ inputs.plugins_reference != '' }}
         run: ls -lR ./artifacts/plugins
 
       - uses: actions/setup-java@v4
@@ -184,8 +184,8 @@ jobs:
           name=$(bash build-scripts/baptizer.sh -m \
             -a ${{ matrix.architecture }} \
             -d ${{ matrix.distribution }}  \
-            -r ${{ github.event.inputs.revision }} \
-            ${{ github.event.inputs.is_stage && '-x' || '' }} \
+            -r ${{ inputs.revision }} \
+            ${{ inputs.is_stage && '-x' || '' }} \
           )
           echo "name=$name" >> $GITHUB_OUTPUT
         id: min_package
@@ -195,8 +195,8 @@ jobs:
           name=$(bash build-scripts/baptizer.sh \
             -a ${{ matrix.architecture }} \
             -d ${{ matrix.distribution }}  \
-            -r ${{ github.event.inputs.revision }} \
-            ${{ github.event.inputs.is_stage && '-x' || '' }} \
+            -r ${{ inputs.revision }} \
+            ${{ inputs.is_stage && '-x' || '' }} \
           )
           echo "name=$name" >> $GITHUB_OUTPUT
         id: package
@@ -213,7 +213,7 @@ jobs:
           bash build-scripts/assemble.sh \
             -a ${{ matrix.architecture }} \
             -d ${{ matrix.distribution }} \
-            -r ${{ github.event.inputs.revision }}
+            -r ${{ inputs.revision }}
 
       - name: Test RPM package
         if: ${{ matrix.distribution == 'rpm' }}
@@ -237,7 +237,7 @@ jobs:
           if-no-files-found: error
 
       - name: Set up AWS CLI
-        if: ${{ github.event.inputs.upload }}
+        if: ${{ inputs.upload }}
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.CI_INTERNAL_DEVELOPMENT_BUCKET_USER_ACCESS_KEY }}
@@ -245,7 +245,7 @@ jobs:
           aws-region: ${{ secrets.CI_AWS_REGION }}
 
       - name: Upload package to S3
-        if: ${{ github.event.inputs.upload }}
+        if: ${{ inputs.upload }}
         run: |
           src="artifacts/dist/${{ steps.package.outputs.name }}"
           dest="s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/main/packages/"
@@ -254,7 +254,7 @@ jobs:
           echo "S3 URI: ${s3uri}"
 
       - name: Upload checksum to S3
-        if: ${{ github.event.inputs.upload && github.event.inputs.checksum }}
+        if: ${{ inputs.upload && inputs.checksum }}
         run: |
           src="artifacts/dist/${{ steps.package.outputs.name }}.sha512"
           dest="s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/main/packages/"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,7 +134,7 @@ jobs:
         run: echo "version=$(<VERSION)" >> "$GITHUB_OUTPUT"
 
       - name: Build with Gradle
-        working-directory: .//plugins/${{ matrix.plugins }}
+        working-directory: ./plugins/${{ matrix.plugins }}
         run: |
           ./gradlew build -Dversion=${{ steps.version.outputs.version }} -Drevision=${{ inputs.revision }}
           ls -lR build/distributions/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,7 +143,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.plugins }}
-          path: "./plugins/${{ matrix.plugins }}/build/distributions/${{ matrix.plugins }}-${{ steps.version.outputs.version }}.${{ inputs.revision }}.zip"
+          path: "./plugins/${{ matrix.plugins }}/build/distributions/wazuh-indexer-${{ matrix.plugins }}-${{ steps.version.outputs.version }}.${{ inputs.revision }}.zip"
           if-no-files-found: error
 
   build:


### PR DESCRIPTION
### Description
This PR includes the building of the Command Manager into the build workflow of the `wazuh-indexer`.

### Issues Resolved
Closes #407 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
