### PR TITLE
Enable assembly of ARM packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ on:
       architecture:
         description: '[ "x64", "arm64" ]'
         type: string
-        default: '[ "x64" ]'
+        default: '[ "x64", "arm64"  ]'
       checksum:
         description: "Checksum ?"
         type: boolean
@@ -56,7 +56,7 @@ on:
       architecture:
         description: '[ "x64", "arm64" ]'
         type: string
-        default: '[ "x64" ]'
+        default: '[ "x64", "arm64"  ]'
       checksum:
         description: "Checksum ?"
         type: boolean
@@ -88,7 +88,7 @@ on:
 jobs:
   matrix:
     name: Set up matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       matrix: ${{ steps.setup.outputs.matrix }}
     steps:
@@ -103,7 +103,7 @@ jobs:
 
   build:
     needs: [matrix]
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.architecture == 'arm64' && 'wz-linux-arm64' || 'ubuntu-22.04' }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.matrix.outputs.matrix) }}


### PR DESCRIPTION
### Description
This PR enables the generation of ARM packages for `wazuh-indexer` using GitHub Workflows.

### Issues Resolved
Closes #111 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
