### PR TITLE
Fix release date for 4.10.0 in RPM spec file

### DIFF
--- a/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
+++ b/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
@@ -266,9 +266,9 @@ exit 0
 %attr(750, %{name}, %{name}) %{product_dir}/performance-analyzer-rca/bin/*
 
 %changelog
-* Fri Nov 06 2024 support <info@wazuh.com> - 4.10.1
+* Tue Jan 28 2025 support <info@wazuh.com> - 4.10.1
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-10-1.html
-* Thu Oct 10 2024 support <info@wazuh.com> - 4.10.0
+* Tue Nov 26 2024 support <info@wazuh.com> - 4.10.0
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-10-0.html
 * Tue Oct 15 2024 support <info@wazuh.com> - 4.9.1
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-9-1.html


### PR DESCRIPTION
### Description
This PR fixes the release date for 4.10.0 in the RPM spec file. Having a greater version on a date before a previous version causes the build of RPM to fail.

### Related Issues
Resolves #468 

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
