### PR TITLE
Fix pre-start.sh script for Vagrant environment

### DIFF
--- a/test-tools/pre-start.sh
+++ b/test-tools/pre-start.sh
@@ -12,7 +12,7 @@ curl -sO https://packages.wazuh.com/4.9/wazuh-certs-tool.sh
 chmod +x ./wazuh-certs-tool.sh
 
 # Run the Wazuh certs tool
-bash ./wazuh-certs-tool.sh -A
+OPENSSL_CONF="/etc/ssl/openssl.cnf" ./wazuh-certs-tool.sh -A
 
 # Create a tarball of the generated certificates
 tar -cvf ./wazuh-certificates.tar -C ./wazuh-certificates/ .


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Fixes the openssl error at certificates generation when Vagrant executes the pre-start script.

The error was caused because Vagrant modifies the context of the shell session overriding some environment variables, one of them being `OPENSSL_CONF` required by the cert generation tool. The fix consists on re-overwrite that variable

### Related Issues
Resolves #459
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.
