### PR TITLE
Fix template-settings fields

### DIFF
--- a/ecs/alerts/fields/custom/agent.yml
+++ b/ecs/alerts/fields/custom/agent.yml
@@ -1,0 +1,12 @@
+---
+- name: agent
+  title: Wazuh Agents
+  short: Wazuh Inc. custom fields.
+  type: group
+  group: 2
+  fields:
+    - name: groups
+      type: keyword
+      level: custom
+      description: >
+        The groups the agent belongs to.

--- a/ecs/states-vulnerabilities/fields/custom/agent.yml
+++ b/ecs/states-vulnerabilities/fields/custom/agent.yml
@@ -1,0 +1,12 @@
+---
+- name: agent
+  title: Wazuh Agents
+  short: Wazuh Inc. custom fields.
+  type: group
+  group: 2
+  fields:
+    - name: groups
+      type: keyword
+      level: custom
+      description: >
+        The groups the agent belongs to.

--- a/ecs/states-vulnerabilities/fields/template-settings-legacy.json
+++ b/ecs/states-vulnerabilities/fields/template-settings-legacy.json
@@ -8,7 +8,7 @@
       "refresh_interval": "5s",
       "query.default_field": [
         "agent.id",
-        "agent.group",
+        "agent.groups",
         "host.os.full",
         "host.os.version",
         "package.name",

--- a/ecs/states-vulnerabilities/fields/template-settings.json
+++ b/ecs/states-vulnerabilities/fields/template-settings.json
@@ -9,7 +9,7 @@
         "refresh_interval": "5s",
         "query.default_field": [
           "agent.id",
-          "agent.group",
+          "agent.groups",
           "host.os.full",
           "host.os.version",
           "package.name",


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

This PR modifies the `agent.group` field of the vulnerability template to `agent.groups` matching with the rest of the templates.

### Related Issues
Resolves https://github.com/wazuh/wazuh-indexer/issues/489
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
