### PR TITLE
Preserve state of wazuh-indexer service on upgrade

### DIFF
--- a/distribution/packages/src/deb/debian/postinst
+++ b/distribution/packages/src/deb/debian/postinst
@@ -19,7 +19,7 @@ data_dir=/var/lib/wazuh-indexer
 log_dir=/var/log/wazuh-indexer
 pid_dir=/run/wazuh-indexer
 tmp_dir=/var/log/wazuh-indexer/tmp
-
+restart_service=/tmp/wazuh-indexer.restart
 
 # Create needed directories
 mkdir -p ${tmp_dir}
@@ -46,6 +46,15 @@ if command -v systemd-tmpfiles > /dev/null; then
     systemd-tmpfiles --create wazuh-indexer.conf
 fi
 
+if [ -f $restart_service ]; then
+    rm -f $restart_service
+    echo "Restarting wazuh-indexer service..."
+    if command -v systemctl > /dev/null; then
+        systemctl restart wazuh-indexer.service > /dev/null 2>&1
+    fi
+    exit 0
+fi
+
 # Messages
 echo "### NOT starting on installation, please execute the following statements to configure wazuh-indexer service to start automatically using systemd"
 echo " sudo systemctl daemon-reload"
@@ -54,5 +63,3 @@ echo "### You can start wazuh-indexer service by executing"
 echo " sudo systemctl start wazuh-indexer.service"
 
 exit 0
-
-

--- a/distribution/packages/src/deb/debian/preinst
+++ b/distribution/packages/src/deb/debian/preinst
@@ -13,10 +13,14 @@ set -e
 
 echo "Running Wazuh Indexer Pre-Installation Script"
 
+# Reference to restore actual service status
+restart_service=/tmp/wazuh-indexer.restart
+
 # Stop existing service
 if command -v systemctl >/dev/null && systemctl is-active wazuh-indexer.service >/dev/null; then
     echo "Stop existing wazuh-indexer.service"
     systemctl --no-reload stop wazuh-indexer.service
+    touch $restart_service
 fi
 if command -v systemctl >/dev/null && systemctl is-active wazuh-indexer-performance-analyzer.service >/dev/null; then
     echo "Stop existing wazuh-indexer-performance-analyzer.service"

--- a/distribution/packages/src/deb/debian/prerm
+++ b/distribution/packages/src/deb/debian/prerm
@@ -14,7 +14,6 @@ set -e
 case "$1" in
     upgrade|deconfigure)
     ;;
-
     remove)
         echo "Running Wazuh Indexer Pre-Removal Script"
         # Stop existing service
@@ -27,15 +26,12 @@ case "$1" in
             systemctl --no-reload stop wazuh-indexer-performance-analyzer.service
         fi
     ;;
-
     failed-upgrade)
     ;;
-
     *)
         echo "prerm called with unknown argument \`$1'" >&2
         exit 0
     ;;
-
 esac
 
 exit 0

--- a/distribution/packages/src/deb/debian/prerm
+++ b/distribution/packages/src/deb/debian/prerm
@@ -11,16 +11,31 @@
 
 set -e
 
-echo "Running Wazuh Indexer Pre-Removal Script"
+case "$1" in
+    upgrade|deconfigure)
+    ;;
 
-# Stop existing service
-if command -v systemctl >/dev/null && systemctl is-active wazuh-indexer.service >/dev/null; then
-    echo "Stop existing wazuh-indexer.service"
-    systemctl --no-reload stop wazuh-indexer.service
-fi
-if command -v systemctl >/dev/null && systemctl is-active wazuh-indexer-performance-analyzer.service >/dev/null; then
-    echo "Stop existing wazuh-indexer-performance-analyzer.service"
-    systemctl --no-reload stop wazuh-indexer-performance-analyzer.service
-fi
+    remove)
+        echo "Running Wazuh Indexer Pre-Removal Script"
+        # Stop existing service
+        if command -v systemctl >/dev/null && systemctl is-active wazuh-indexer.service >/dev/null; then
+            echo "Stop existing wazuh-indexer.service"
+            systemctl --no-reload stop wazuh-indexer.service
+        fi
+        if command -v systemctl >/dev/null && systemctl is-active wazuh-indexer-performance-analyzer.service >/dev/null; then
+            echo "Stop existing wazuh-indexer-performance-analyzer.service"
+            systemctl --no-reload stop wazuh-indexer-performance-analyzer.service
+        fi
+    ;;
+
+    failed-upgrade)
+    ;;
+
+    *)
+        echo "prerm called with unknown argument \`$1'" >&2
+        exit 0
+    ;;
+
+esac
 
 exit 0

--- a/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
+++ b/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
@@ -162,6 +162,7 @@ set -e
 if command -v systemctl >/dev/null && systemctl is-active %{name}.service >/dev/null; then
     echo "Stop existing %{name}.service"
     systemctl --no-reload stop %{name}.service
+    touch %{tmp_dir}/wazuh-indexer.restart
 fi
 if command -v systemctl >/dev/null && systemctl is-active %{name}-performance-analyzer.service >/dev/null; then
     echo "Stop existing %{name}-performance-analyzer.service"
@@ -202,6 +203,15 @@ fi
 
 if command -v systemd-tmpfiles > /dev/null; then
     systemd-tmpfiles --create %{name}.conf
+fi
+
+if [ -f %{tmp_dir}/wazuh-indexer.restart ]; then
+    rm -f %{tmp_dir}/wazuh-indexer.restart
+    if command -v systemctl > /dev/null; then
+        echo "Restarting wazuh-indexer service..."
+        systemctl restart wazuh-server.service > /dev/null 2>&1
+        exit 0
+    fi
 fi
 
 # Messages

--- a/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
+++ b/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
@@ -209,7 +209,7 @@ if [ -f %{tmp_dir}/wazuh-indexer.restart ]; then
     rm -f %{tmp_dir}/wazuh-indexer.restart
     if command -v systemctl > /dev/null; then
         echo "Restarting wazuh-indexer service..."
-        systemctl restart wazuh-server.service > /dev/null 2>&1
+        systemctl restart wazuh-indexer.service > /dev/null 2>&1
         exit 0
     fi
 fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

Update wazuh-indexer pre, and post installation scripts to preserve the previous service status, maintaining consistency with the rest of Wazuh central components packages.

### Related Issues
Resolves #487
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

---

### Testing evidence

**Upgrade .deb package validation**

1. <details><summary>Upgrade with service running</summary>

    - Service is running before upgrade
        ```bash
        systemctl status wazuh-indexer
        ● wazuh-indexer.service - wazuh-indexer
             Loaded: loaded (/lib/systemd/system/wazuh-indexer.service; enabled; preset: enabled)
             Active: active (running) since Fri 2024-10-25 07:22:28 PDT; 7s ago
               Docs: https://documentation.wazuh.com
           Main PID: 4018 (java)
              Tasks: 72 (limit: 4571)
             Memory: 1.4G
                CPU: 14.054s
             CGroup: /system.slice/wazuh-indexer.service
                     └─4018 /usr/share/wazuh-indexer/jdk/bin/java -Xshare:auto -Dopensearch.networkaddress.cache.ttl=60 -Dope>
        ```
    - Upgrade wazuh-indexer
        ```bash
        dpkg -i wazuh-indexer_5.0.0-0_arm64_b2d1265.deb 
        (Reading database ... 151060 files and directories currently installed.)
        Preparing to unpack wazuh-indexer_5.0.0-0_arm64_da70239.deb ...
        Running Wazuh Indexer Pre-Installation Script
        Stop existing wazuh-indexer.service
        Unpacking wazuh-indexer (5.0.0-0) over (5.0.0-0) ...
        Setting up wazuh-indexer (5.0.0-0) ...
        Running Wazuh Indexer Post-Installation Script
        Restarting wazuh-indexer service...
        ```
    - Service is running after upgrade
        ```bash
        systemctl status wazuh-indexer
        ● wazuh-indexer.service - wazuh-indexer
             Loaded: loaded (/lib/systemd/system/wazuh-indexer.service; enabled; preset: enabled)
             Active: active (running) since Fri 2024-10-25 07:23:23 PDT; 7s ago
               Docs: https://documentation.wazuh.com
           Main PID: 4313 (java)
              Tasks: 73 (limit: 4571)
             Memory: 1.3G
                CPU: 13.464s
             CGroup: /system.slice/wazuh-indexer.service
                     └─4313 /usr/share/wazuh-indexer/jdk/bin/java -Xshare:auto -Dopensearch.networkaddress.cache.ttl=60 -Dope>
        ```
    </details>

2. <details><summary>Upgrade with service stopped</summary>

    - Service is stopped before upgrade
        ```bash
        systemctl status wazuh-indexer
        ○ wazuh-indexer.service - wazuh-indexer
             Loaded: loaded (/lib/systemd/system/wazuh-indexer.service; enabled; preset: enabled)
             Active: inactive (dead) since Fri 2024-10-25 07:25:05 PDT; 8s ago
           Duration: 1min 41.067s
               Docs: https://documentation.wazuh.com
            Process: 4313 ExecStart=/usr/share/wazuh-indexer/bin/systemd-entrypoint -p ${PID_DIR}/wazuh-indexer.pid --quiet (>
           Main PID: 4313 (code=exited, status=143)
                CPU: 16.562s
        ```
    - Upgrade wazuh-indexer
        ```
        (Reading database ... 151060 files and directories currently installed.)
        Preparing to unpack wazuh-indexer_5.0.0-0_arm64_da70239.deb ...
        Running Wazuh Indexer Pre-Installation Script
        Unpacking wazuh-indexer (5.0.0-0) over (5.0.0-0) ...
        Setting up wazuh-indexer (5.0.0-0) ...
        Running Wazuh Indexer Post-Installation Script
        ### NOT starting on installation, please execute the following statements to configure wazuh-indexer service to start automatically using systemd
         sudo systemctl daemon-reload
         sudo systemctl enable wazuh-indexer.service
        ### You can start wazuh-indexer service by executing
         sudo systemctl start wazuh-indexer.service
        ```
    - Service is stopped after upgrade
        ```bash
        systemctl status wazuh-indexer
        ○ wazuh-indexer.service - wazuh-indexer
             Loaded: loaded (/lib/systemd/system/wazuh-indexer.service; enabled; preset: enabled)
             Active: inactive (dead) since Fri 2024-10-25 07:25:05 PDT; 19s ago
           Duration: 1min 41.067s
               Docs: https://documentation.wazuh.com
           Main PID: 4313 (code=exited, status=143)
                CPU: 16.562s
        ```

</details>

**Upgrade .rpm package validation**

1. <details><summary>Upgrade with service running</summary>

    - Service is running before upgrade
        ```bash
        systemctl status wazuh-indexer
        ● wazuh-indexer.service - wazuh-indexer
             Loaded: loaded (/usr/lib/systemd/system/wazuh-indexer.service; disabled; preset: disabled)
             Active: active (running) since Fri 2024-10-25 14:14:44 -03; 1min 4s ago
               Docs: https://documentation.wazuh.com
           Main PID: 38161 (java)
              Tasks: 69 (limit: 22569)
             Memory: 1.3G
                CPU: 15.619s
             CGroup: /system.slice/wazuh-indexer.service
                     └─38161 /usr/share/wazuh-indexer/jdk/bin/java -Xshare:auto -Dopensearch.networkaddress.cache.ttl=60 -Dop>

        ```
    - Upgrade wazuh-indexer
        ```bash
        rpm -i wazuh-indexer_5.0.0-0_aarch64_da70239.rpm --force 
        Stop existing wazuh-indexer.service
        Restarting wazuh-indexer service...

        ```
    - Service is running after upgrade
        ```bash
        ● wazuh-indexer.service - wazuh-indexer
             Loaded: loaded (/usr/lib/systemd/system/wazuh-indexer.service; disabled; preset: disabled)
             Active: active (running) since Fri 2024-10-25 14:31:53 -03; 14s ago
               Docs: https://documentation.wazuh.com
           Main PID: 38490 (java)
              Tasks: 72 (limit: 22569)
             Memory: 1.4G
                CPU: 13.157s
             CGroup: /system.slice/wazuh-indexer.service
                     └─38490 /usr/share/wazuh-indexer/jdk/bin/java -Xshare:auto -Dopensearch.networkaddress.cache.ttl=60 -Dop>


        ```
    </details>

2. <details><summary>Upgrade with service stopped</summary>

    - Service is stopped before upgrade
        ```bash
        systemctl status wazuh-indexer
        ○ wazuh-indexer.service - wazuh-indexer
             Loaded: loaded (/usr/lib/systemd/system/wazuh-indexer.service; disabled; preset: disabled)
             Active: inactive (dead)
               Docs: https://documentation.wazuh.com
        ```
    - Upgrade wazuh-indexer
        ```
        rpm -i wazuh-indexer_5.0.0-0_aarch64_da70239.rpm --force 
        ### NOT starting on installation, please execute the following statements to configure wazuh-indexer service to start automatically using systemd
         sudo systemctl daemon-reload
         sudo systemctl enable wazuh-indexer.service
        ### You can start wazuh-indexer service by executing
         sudo systemctl start wazuh-indexer.service
        ```
    - Service is stopped after upgrade
        ```bash
        systemctl status wazuh-indexer
        ○ wazuh-indexer.service - wazuh-indexer
             Loaded: loaded (/usr/lib/systemd/system/wazuh-indexer.service; disabled; preset: disabled)
             Active: inactive (dead)
               Docs: https://documentation.wazuh.com
        ```

</details>