### PR TITLE
Fix startup errors on STIG compliant systems due to noexec filesystems

### DIFF
--- a/distribution/packages/src/deb/debian/postinst
+++ b/distribution/packages/src/deb/debian/postinst
@@ -18,11 +18,8 @@ config_dir=/etc/wazuh-indexer
 data_dir=/var/lib/wazuh-indexer
 log_dir=/var/log/wazuh-indexer
 pid_dir=/run/wazuh-indexer
-tmp_dir=/var/log/wazuh-indexer/tmp
-restart_service=/tmp/wazuh-indexer.restart
-
-# Create needed directories
-mkdir -p ${tmp_dir}
+tmp_dir=${data_dir}/tmp
+restart_service=${tmp_dir}/wazuh-indexer.restart
 
 # Set owner
 chown -R wazuh-indexer:wazuh-indexer ${product_dir}

--- a/distribution/packages/src/deb/debian/preinst
+++ b/distribution/packages/src/deb/debian/preinst
@@ -11,10 +11,17 @@
 
 set -e
 
-echo "Running Wazuh Indexer Pre-Installation Script"
+# Reference to temp directory
+tmp_dir=/var/lib/wazuh-indexer/tmp
+restart_service=${tmp_dir}/wazuh-indexer.restart
 
-# Reference to restore actual service status
-restart_service=/tmp/wazuh-indexer.restart
+# Create needed directories
+if [ -d ${tmp_dir} ]; then
+    rm -r ${tmp_dir}
+fi
+mkdir -p ${tmp_dir}
+
+echo "Running Wazuh Indexer Pre-Installation Script"
 
 # Stop existing service
 if command -v systemctl >/dev/null && systemctl is-active wazuh-indexer.service >/dev/null; then

--- a/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
+++ b/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
@@ -27,7 +27,7 @@
 %define data_dir %{_sharedstatedir}/%{name}
 %define log_dir %{_localstatedir}/log/%{name}
 %define pid_dir %{_localstatedir}/run/%{name}
-%define tmp_dir %{log_dir}/tmp
+%define tmp_dir %{data_dir}/tmp
 %{!?_version: %define _version 0.0.0 }
 %{!?_architecture: %define _architecture x86_64 }
 


### PR DESCRIPTION
### Description

To avoid errors when starting `wazuh-indexer` on STIG compliant systems, where the `/var/log` directory is _noexec_, we have moved the temporary directory to `/var/lib`, which (almost every case) is not set to _noexec_. Additionally, the `.restart` file, which indicates when the system should be restarted after an upgrade, has been relocated to the new `../tmp` directory (previously located in `/tmp`).

The creation of the `../tmp` directory has been moved from the `postinst` step to the `preinst` step for consistency.


### Related Issues
Resolves #501
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
