### PR TITLE
Update `.agents` index data model

### DIFF
--- a/ecs/agent/fields/custom/host.yml
+++ b/ecs/agent/fields/custom/host.yml
@@ -1,18 +1,6 @@
 ---
 - name: host
-  title: Wazuh Agents
-  short: Wazuh Inc. custom fields.
-  level: core
-  type: group
-  group: 0
   reusable:
     top_level: false
     expected:
       - agent
-  fields:
-    - name: os
-      title: Operating system
-      level: custom
-      type: keyword
-      description: >
-        Agent's operating system

--- a/ecs/agent/fields/custom/host.yml
+++ b/ecs/agent/fields/custom/host.yml
@@ -1,0 +1,18 @@
+---
+- name: host
+  title: Wazuh Agents
+  short: Wazuh Inc. custom fields.
+  level: core
+  type: group
+  group: 0
+  reusable:
+    top_level: false
+    expected:
+      - agent
+  fields:
+    - name: os
+      title: Operating system
+      level: custom
+      type: keyword
+      description: >
+        Agent's operating system

--- a/ecs/agent/fields/custom/os.yml
+++ b/ecs/agent/fields/custom/os.yml
@@ -1,0 +1,6 @@
+---
+- name: os
+  reusable:
+    top_level: false
+    expected:
+      - agent.host

--- a/ecs/agent/fields/custom/risk.yml
+++ b/ecs/agent/fields/custom/risk.yml
@@ -1,0 +1,6 @@
+---
+- name: risk
+  reusable:
+    top_level: false
+    expected:
+      - agent.host

--- a/ecs/agent/fields/custom/wazuh-agent.yml
+++ b/ecs/agent/fields/custom/wazuh-agent.yml
@@ -30,9 +30,3 @@
           description: Active agent status
         - name: disconnected
           description: Disconnected agent status
-    - name: host
-      type: group
-      level: custom
-      description: >
-        Agents' interpreted connection status depending on `agent.last_login`.
-      fields: "*"

--- a/ecs/agent/fields/custom/wazuh-agent.yml
+++ b/ecs/agent/fields/custom/wazuh-agent.yml
@@ -20,8 +20,19 @@
       level: custom
       description: >
         The agent's last login.
-    - name: is_connected
-      type: boolean
+    - name: status
+      type: keyword
       level: custom
       description: >
         Agents' interpreted connection status depending on `agent.last_login`.
+      allowed_values:
+        - name: active
+          description: Active agent status
+        - name: disconnected
+          description: Disconnected agent status
+    - name: host
+      type: group
+      level: custom
+      description: >
+        Agents' interpreted connection status depending on `agent.last_login`.
+      fields: "*"

--- a/ecs/agent/fields/subset.yml
+++ b/ecs/agent/fields/subset.yml
@@ -13,10 +13,11 @@ fields:
       groups: {}
       key: {}
       last_login: {}
-      is_connected: {}
-  host:
-    fields:
-      ip: {}
-      os:
-        fields:
-          full: {}
+      status: {}
+      host:
+        fields: "*"
+#        fields: "*"
+#      ip: {}
+#      os:
+#        fields:
+#          full: {}

--- a/ecs/agent/fields/subset.yml
+++ b/ecs/agent/fields/subset.yml
@@ -16,8 +16,3 @@ fields:
       status: {}
       host:
         fields: "*"
-#        fields: "*"
-#      ip: {}
-#      os:
-#        fields:
-#          full: {}


### PR DESCRIPTION
### Description
This PR renames the `agent.is_connected` field to `agent.status`. It also adds all the `core` fields from the `host` schema nested below the `agent` field in order to facilitate cross index correlation.

### Related Issues
Resolves #525, resolves #539 
