### PR TITLE
Remove unneeded agent fields off non-agent indices

### DIFF
--- a/ecs/alerts/fields/custom/agent.yml
+++ b/ecs/alerts/fields/custom/agent.yml
@@ -10,23 +10,3 @@
       level: custom
       description: >
         List of groups the agent belong to.
-    - name: key
-      type: keyword
-      level: custom
-      description: >
-        The registration key of the agent.
-    - name: last_login
-      type: date
-      level: custom
-      description: >
-        The agent's last login.
-    - name: status
-      type: keyword
-      level: custom
-      description: >
-        Agents' interpreted connection status depending on `agent.last_login`.
-      allowed_values:
-        - name: active
-          description: Active agent status
-        - name: disconnected
-          description: Disconnected agent status

--- a/ecs/states-inventory-hardware/fields/custom/agent.yml
+++ b/ecs/states-inventory-hardware/fields/custom/agent.yml
@@ -10,23 +10,3 @@
       level: custom
       description: >
         List of groups the agent belong to.
-    - name: key
-      type: keyword
-      level: custom
-      description: >
-        The registration key of the agent.
-    - name: last_login
-      type: date
-      level: custom
-      description: >
-        The agent's last login.
-    - name: status
-      type: keyword
-      level: custom
-      description: >
-        Agents' interpreted connection status depending on `agent.last_login`.
-      allowed_values:
-        - name: active
-          description: Active agent status
-        - name: disconnected
-          description: Disconnected agent status

--- a/ecs/states-inventory-hotfixes/fields/custom/agent.yml
+++ b/ecs/states-inventory-hotfixes/fields/custom/agent.yml
@@ -10,23 +10,3 @@
       level: custom
       description: >
         List of groups the agent belong to.
-    - name: key
-      type: keyword
-      level: custom
-      description: >
-        The registration key of the agent.
-    - name: last_login
-      type: date
-      level: custom
-      description: >
-        The agent's last login.
-    - name: status
-      type: keyword
-      level: custom
-      description: >
-        Agents' interpreted connection status depending on `agent.last_login`.
-      allowed_values:
-        - name: active
-          description: Active agent status
-        - name: disconnected
-          description: Disconnected agent status

--- a/ecs/states-inventory-networks/fields/custom/agent.yml
+++ b/ecs/states-inventory-networks/fields/custom/agent.yml
@@ -10,23 +10,3 @@
       level: custom
       description: >
         List of groups the agent belong to.
-    - name: key
-      type: keyword
-      level: custom
-      description: >
-        The registration key of the agent.
-    - name: last_login
-      type: date
-      level: custom
-      description: >
-        The agent's last login.
-    - name: status
-      type: keyword
-      level: custom
-      description: >
-        Agents' interpreted connection status depending on `agent.last_login`.
-      allowed_values:
-        - name: active
-          description: Active agent status
-        - name: disconnected
-          description: Disconnected agent status

--- a/ecs/states-inventory-packages/fields/custom/agent.yml
+++ b/ecs/states-inventory-packages/fields/custom/agent.yml
@@ -10,23 +10,3 @@
       level: custom
       description: >
         List of groups the agent belong to.
-    - name: key
-      type: keyword
-      level: custom
-      description: >
-        The registration key of the agent.
-    - name: last_login
-      type: date
-      level: custom
-      description: >
-        The agent's last login.
-    - name: status
-      type: keyword
-      level: custom
-      description: >
-        Agents' interpreted connection status depending on `agent.last_login`.
-      allowed_values:
-        - name: active
-          description: Active agent status
-        - name: disconnected
-          description: Disconnected agent status

--- a/ecs/states-inventory-ports/fields/custom/agent.yml
+++ b/ecs/states-inventory-ports/fields/custom/agent.yml
@@ -10,23 +10,3 @@
       level: custom
       description: >
         List of groups the agent belong to.
-    - name: key
-      type: keyword
-      level: custom
-      description: >
-        The registration key of the agent.
-    - name: last_login
-      type: date
-      level: custom
-      description: >
-        The agent's last login.
-    - name: status
-      type: keyword
-      level: custom
-      description: >
-        Agents' interpreted connection status depending on `agent.last_login`.
-      allowed_values:
-        - name: active
-          description: Active agent status
-        - name: disconnected
-          description: Disconnected agent status

--- a/ecs/states-inventory-processes/fields/custom/agent.yml
+++ b/ecs/states-inventory-processes/fields/custom/agent.yml
@@ -10,23 +10,3 @@
       level: custom
       description: >
         List of groups the agent belong to.
-    - name: key
-      type: keyword
-      level: custom
-      description: >
-        The registration key of the agent.
-    - name: last_login
-      type: date
-      level: custom
-      description: >
-        The agent's last login.
-    - name: status
-      type: keyword
-      level: custom
-      description: >
-        Agents' interpreted connection status depending on `agent.last_login`.
-      allowed_values:
-        - name: active
-          description: Active agent status
-        - name: disconnected
-          description: Disconnected agent status

--- a/ecs/states-inventory-system/fields/custom/agent.yml
+++ b/ecs/states-inventory-system/fields/custom/agent.yml
@@ -10,23 +10,3 @@
       level: custom
       description: >
         List of groups the agent belong to.
-    - name: key
-      type: keyword
-      level: custom
-      description: >
-        The registration key of the agent.
-    - name: last_login
-      type: date
-      level: custom
-      description: >
-        The agent's last login.
-    - name: status
-      type: keyword
-      level: custom
-      description: >
-        Agents' interpreted connection status depending on `agent.last_login`.
-      allowed_values:
-        - name: active
-          description: Active agent status
-        - name: disconnected
-          description: Disconnected agent status

--- a/ecs/states-vulnerabilities/fields/custom/agent.yml
+++ b/ecs/states-vulnerabilities/fields/custom/agent.yml
@@ -10,23 +10,3 @@
       level: custom
       description: >
         List of groups the agent belong to.
-    - name: key
-      type: keyword
-      level: custom
-      description: >
-        The registration key of the agent.
-    - name: last_login
-      type: date
-      level: custom
-      description: >
-        The agent's last login.
-    - name: status
-      type: keyword
-      level: custom
-      description: >
-        Agents' interpreted connection status depending on `agent.last_login`.
-      allowed_values:
-        - name: active
-          description: Active agent status
-        - name: disconnected
-          description: Disconnected agent status


### PR DESCRIPTION
### Description
This PR intends to remove the `status`, `key` and `last_login` fields from the `agents` schema on indices other than `agent`, under which it is not needed.

### Related Issues
Resolves #525 

### Check List
- [x] Functionality includes testing.
