### PR TITLE
Edit assemble script to use in Debian the scripts of OpenSearch

### DIFF
--- a/build-scripts/assemble.sh
+++ b/build-scripts/assemble.sh
@@ -353,6 +353,7 @@ function assemble_deb() {
     cp "distribution/packages/src/deb/Makefile" "${TMP_DIR}"
     cp "distribution/packages/src/deb/debmake_install.sh" "${TMP_DIR}"
     cp -r "distribution/packages/src/deb/debian" "${TMP_DIR}"
+    cp -r "distribution/packages/src/common/scripts" "${TMP_DIR}"
     chmod a+x "${TMP_DIR}/debmake_install.sh"
     # Copy performance analyzer service file
     enable_performance_analyzer

--- a/distribution/packages/src/common/scripts/postinst
+++ b/distribution/packages/src/common/scripts/postinst
@@ -12,7 +12,7 @@
 if [ -f "${path.env}" ]; then
     . "${path.env}"
 fi
-
+echo "SCRIPTS/POSTINST"
 export OPENSEARCH_PATH_CONF=${OPENSEARCH_PATH_CONF:-${path.conf}}
 
 IS_UPGRADE=false

--- a/distribution/packages/src/common/scripts/postrm
+++ b/distribution/packages/src/common/scripts/postrm
@@ -13,7 +13,7 @@
 if [ -f "${path.env}" ]; then
     . "${path.env}"
 fi
-
+echo "SCRIPTS/POSTRM"
 export OPENSEARCH_PATH_CONF=${OPENSEARCH_PATH_CONF:-${path.conf}}
 
 REMOVE_DIRS=false

--- a/distribution/packages/src/common/scripts/preinst
+++ b/distribution/packages/src/common/scripts/preinst
@@ -11,7 +11,7 @@
 #       $1=2       : indicates an upgrade
 
 set -e -o pipefail
-
+echo "SCRIPTS/PREINST"
 err_exit() {
     echo "$@" >&2
     exit 1

--- a/distribution/packages/src/common/scripts/prerm
+++ b/distribution/packages/src/common/scripts/prerm
@@ -13,7 +13,7 @@
 if [ -f "${path.env}" ]; then
     . "${path.env}"
 fi
-
+echo "SCRIPTS/PRERM"
 export OPENSEARCH_PATH_CONF=${OPENSEARCH_PATH_CONF:-${path.conf}}
 
 STOP_REQUIRED=false

--- a/distribution/packages/src/deb/debian/postinst
+++ b/distribution/packages/src/deb/debian/postinst
@@ -56,6 +56,7 @@ if [ -f $restart_service ]; then
 fi
 
 # Messages
+echo "DEBIAN/POSTINST"
 echo "### NOT starting on installation, please execute the following statements to configure wazuh-indexer service to start automatically using systemd"
 echo " sudo systemctl daemon-reload"
 echo " sudo systemctl enable wazuh-indexer.service"

--- a/distribution/packages/src/deb/debian/preinst
+++ b/distribution/packages/src/deb/debian/preinst
@@ -10,6 +10,7 @@
 # deb wazuh-indexer preinst script
 
 set -e
+echo "DEBIAN/PREINST"
 
 echo "Running Wazuh Indexer Pre-Installation Script"
 

--- a/distribution/packages/src/deb/debian/prerm
+++ b/distribution/packages/src/deb/debian/prerm
@@ -10,6 +10,7 @@
 # deb wazuh-indexer prerm script
 
 set -e
+echo "DEBIAN/PREIRM"
 
 case "$1" in
     upgrade|deconfigure)


### PR DESCRIPTION
### Description
Reuse the scripts of OpenSearch to install, upgrade and delete wazuh-indexer.

### Related Issues
Resolves #[527]

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
