### PR TITLE
Add demo certificates to Indexer packages

### DIFF
--- a/build-scripts/assemble.sh
+++ b/build-scripts/assemble.sh
@@ -159,9 +159,9 @@ function parse_args() {
 # ====
 function add_configuration_files() {
     # Add our settings to the configuration files
-    cat "$PATH_CONF/security/roles.wazuh.yml" >> "$PATH_CONF/opensearch-security/roles.yml"
-    cat "$PATH_CONF/security/roles_mapping.wazuh.yml" >> "$PATH_CONF/opensearch-security/roles_mapping.yml"
-    
+    cat "$PATH_CONF/security/roles.wazuh.yml" >>"$PATH_CONF/opensearch-security/roles.yml"
+    cat "$PATH_CONF/security/roles_mapping.wazuh.yml" >>"$PATH_CONF/opensearch-security/roles_mapping.yml"
+
     cp "$PATH_CONF/opensearch.prod.yml" "$PATH_CONF/opensearch.yml"
 
     rm -r "$PATH_CONF/security"
@@ -193,6 +193,9 @@ function add_wazuh_tools() {
     curl -sL "${download_url}/wazuh-certs-tool.sh" -o "$PATH_PLUGINS"/opensearch-security/tools/wazuh-certs-tool.sh
 }
 
+# ====
+# Add demo certificates installer
+# ====
 function add_demo_certs_installer() {
     cp install-demo-certificates.sh "$PATH_PLUGINS"/opensearch-security/tools/
 }

--- a/build-scripts/assemble.sh
+++ b/build-scripts/assemble.sh
@@ -188,9 +188,13 @@ function add_wazuh_tools() {
     local download_url
     download_url="https://packages-dev.wazuh.com/${version}"
 
-    curl -sL "${download_url}/config.yml" -o "$PATH_PLUGINS/opensearch-security/tools/config.yml"
-    curl -sL "${download_url}/wazuh-passwords-tool.sh" -o "$PATH_PLUGINS/opensearch-security/tools/wazuh-passwords-tool.sh"
-    curl -sL "${download_url}/wazuh-certs-tool.sh" -o "$PATH_PLUGINS/opensearch-security/tools/wazuh-certs-tool.sh"
+    curl -sL "${download_url}/config.yml" -o "$PATH_PLUGINS"/opensearch-security/tools/config.yml
+    curl -sL "${download_url}/wazuh-passwords-tool.sh" -o "$PATH_PLUGINS"/opensearch-security/tools/wazuh-passwords-tool.sh
+    curl -sL "${download_url}/wazuh-certs-tool.sh" -o "$PATH_PLUGINS"/opensearch-security/tools/wazuh-certs-tool.sh
+}
+
+function add_demo_certs_installer() {
+    cp install-demo-certificates.sh "$PATH_PLUGINS"/opensearch-security/tools/
 }
 
 # ====
@@ -282,6 +286,7 @@ function assemble_tar() {
     # Install plugins
     install_plugins "${version}"
     fix_log_rotation "${PATH_CONF}"
+    add_demo_certs_installer
     # Swap configuration files
     add_configuration_files
     remove_unneeded_files
@@ -322,6 +327,7 @@ function assemble_rpm() {
     install_plugins "${version}"
     fix_log_rotation ${PATH_CONF}
     enable_performance_analyzer_rca ${src_path}
+    add_demo_certs_installer
     # Swap configuration files
     add_configuration_files
     remove_unneeded_files
@@ -376,6 +382,7 @@ function assemble_deb() {
     install_plugins "${version}"
     fix_log_rotation ${PATH_CONF}
     enable_performance_analyzer_rca ${src_path}
+    add_demo_certs_installer
     # Swap configuration files
     add_configuration_files
     remove_unneeded_files
@@ -421,6 +428,8 @@ function main() {
     TMP_DIR="${OUTPUT}/tmp/${TARGET}"
     mkdir -p "$TMP_DIR"
     cp "${OUTPUT}/dist/$ARTIFACT_BUILD_NAME" "${TMP_DIR}"
+    # Copy the demo certificates generator
+    cp distribution/packages/src/common/scripts/install-demo-certificates.sh "$TMP_DIR"
 
     case $PACKAGE in
     tar)

--- a/distribution/packages/src/common/scripts/install-demo-certificates.sh
+++ b/distribution/packages/src/common/scripts/install-demo-certificates.sh
@@ -13,159 +13,21 @@ CERTS_DIR="/etc/wazuh-indexer/certs"
 # Create directories
 mkdir -p "$TMP_DIR"
 
-# If demo certificates are explicitly solicited
-# (ie. for dockerized cluster test environments)
-# then, use hardcoded certs.
-if [ "${USE_DEMO_CERTS:-false}" = "true" ]; then
-  cat <<'ADMIN_KEY' >$TMP_DIR/admin-key.pem
------BEGIN PRIVATE KEY-----
-MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC3ebYoJC7NR6YU
-aYDnhRlawrb6BD4Oj3VkLsk4hIEKLo0afcexZWhW2iKqK1d7KLQir7ZqmodyQpzR
-0/EbnwBEQXsWqxcACdestzADpLiX7J+RWKrLuQ1+wSOAAI/Y0pIEdrf9/5Jnj78o
-I9xDEQxGlQjiJgvwJCkJXv4UD5LAXoKRnP1FRLWJxvCsLBKWuceNCVYu0QUPLkA7
-XkshDSDYvsxD8G7hE/o7lKm9GjHduBDTmZ3dvcOzMtbxsGk5qMtHvXWgTK1YUkz4
-f34m6E1ESLvxYveDzmcLMu4JJZEPIYWBUZV7ufeiDWhhXtT4vHoh6iLZdq4olIx3
-fPsA8kEdAgMBAAECggEAOrEMFL4yXIeJeKkhS653pGF6T/MweM7qYhBXXSWB8+Rd
-TfajfTtvy6y+/wmbU/H64cesxmBFaMcnTDYMwGW2G5+IxQEY+/GqFP2Ktfeo9yyC
-BOhExqOdTglxlj5XxafiftwNUorBZjCFGU2TZb7b2u5M5679DaY7nFxPUdKDgtaO
-IXRr7LYO2hQs57/e64UZvac994nwZBW17TWSmERGVGQs7fdSaPGwloA6phiyQflD
-EmYxzMUFetpAu5Bk35hqLolw6htirkHzd8f0tFf3JvO1xvcZeVw1JDM/pV6Cfd9e
-LZ8rabcwNYTuTFA/2bISSkReTvGebMJnIfl7g7nBTwKBgQDeQZr7MBww9n5LYdGS
-B9z7DuAGZUWGIDqWPZT6pBNCbBhcQdrBEjSTUY/YQL1ofM/i/7A4xey5LZUZelUy
-IgNSqpCC4McEkx565KcN3uNxXyJzwFsD4PhBkyQC5fYsjU9kGLKfv0MKy95ky9Y3
-pbu7eegNEBvr1l9h/rtyRfchnwKBgQDTVNGBzaAxMjYN7z40+oo2Oc3B4OGqGXON
-Ci5BABajFqvtudpUDAl06v95X1tY9f4EnpBtqNmnKu796aN8yycD+VTWIXttzqPX
-uOqSgWQOkO/vAWcxbMHhyjv92wvJZAV0BeuaQgv+SKey3yqGn9rDIjV/xOX6yW1L
-rmwl4ow7wwKBgD81620LNslaIXsw+9iLcfbZOS+4d7h4zBDUvN038t5OPfNnK18D
-3X4UkVOQvg3MiZdm3uiWqgfUhfY0C6zxbX6CUg1W/mM3sFCFXVmdjZQ92V+QUpJc
-1l5YCcLlQklTe0Pdnle+nsOgTcTfEDLNaQId3rhwX3CIjKIjP451hZ7DAoGBAL/m
-WmSrSxbBSJJ4uB01kIHTFYNDaMekWugs4XmG0geAU9kIFjiRwZiYuCoHrBRpNCQP
-tIjPde01sFWDbkCo3SHfq+jR+JnqtZ7zPJaSxj/v3uBCfulDn/8fPEC1Qsu6drU3
-lwy5gtiCMz3bJmufBvCAxOHj8w47EHNTzMLOKJcvAoGAOrMBDVn4e4OPc138sef5
-R+sgl2DWtKGUFFBYwT9oUFu2Jq6+ARSXg+gi9LBKfswWcJtiWyeDd54tyNdH+GBD
-Oc76auI2UkXUJ99XCOzo1z85cBi9cIB14vdGAhLCrGXIJRx1VTlEcHtVOpWwbkfM
-V4hJcul3lbTnrbuRHvVEOGk=
------END PRIVATE KEY-----
-ADMIN_KEY
+# Root CA
+openssl genrsa -out "$TMP_DIR/root-ca-key-temp.pem" 2048
+openssl req -new -x509 -sha256 -key "$TMP_DIR/root-ca-key-temp.pem" -subj "/OU=Wazuh/O=Wazuh/L=California/" -out "$TMP_DIR/root-ca.pem" -days 3650
 
-  cat <<'ADMIN_CERT' >$TMP_DIR/admin.pem
------BEGIN CERTIFICATE-----
-MIIDDjCCAfYCFD71oGZblxldV2/96zP2kZpIKOYgMA0GCSqGSIb3DQEBCwUAMDUx
-DjAMBgNVBAsMBVdhenVoMQ4wDAYDVQQKDAVXYXp1aDETMBEGA1UEBwwKQ2FsaWZv
-cm5pYTAeFw0yNDExMjAxNjUxMDRaFw0zNDExMTgxNjUxMDRaMFIxCzAJBgNVBAYT
-AlVTMRMwEQYDVQQHDApDYWxpZm9ybmlhMQ4wDAYDVQQKDAVXYXp1aDEOMAwGA1UE
-CwwFV2F6dWgxDjAMBgNVBAMMBWFkbWluMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A
-MIIBCgKCAQEAt3m2KCQuzUemFGmA54UZWsK2+gQ+Do91ZC7JOISBCi6NGn3HsWVo
-VtoiqitXeyi0Iq+2apqHckKc0dPxG58AREF7FqsXAAnXrLcwA6S4l+yfkViqy7kN
-fsEjgACP2NKSBHa3/f+SZ4+/KCPcQxEMRpUI4iYL8CQpCV7+FA+SwF6CkZz9RUS1
-icbwrCwSlrnHjQlWLtEFDy5AO15LIQ0g2L7MQ/Bu4RP6O5SpvRox3bgQ05md3b3D
-szLW8bBpOajLR711oEytWFJM+H9+JuhNREi78WL3g85nCzLuCSWRDyGFgVGVe7n3
-og1oYV7U+Lx6Ieoi2XauKJSMd3z7APJBHQIDAQABMA0GCSqGSIb3DQEBCwUAA4IB
-AQCOYHh3KgCfVyJdt9xMqGmb/GNeitxt8dZtatEiwE29O2ABUK3i24SYAb/fGZ1F
-eSc184njF/9rD8SCNEo8rfD6HjP6EsdoPFtekvEC1Ykrxk1chvpC1EHNZPGWZ6Wk
-UKuEORYyv4rzngvT9K/77iw8clW225uGp1GtcNgw45LnIdCEGf+Uy8uKOkzKs7Uf
-Mnl2zHy0S6gYV5aBWDW9WuuUQnoVTNdnAs6e4UGIw5T/l5W7WKDG9Q+F+Xrt4Cvx
-W8evS+3vVVF+EYwBXBQRZhkL7f+sJnizhdzCUMqztGZR1rsjl+Vz+S6u77KrKIop
-BzcZ+J6GzTHIZXHI77PvXHtf
------END CERTIFICATE-----
-ADMIN_CERT
+# Admin cert
+openssl genrsa -out "$TMP_DIR/admin-key-temp.pem" 2048
+openssl pkcs8 -inform PEM -outform PEM -in "$TMP_DIR/admin-key-temp.pem" -topk8 -nocrypt -v1 PBE-SHA1-3DES -out "$TMP_DIR/admin-key.pem"
+openssl req -new -key "$TMP_DIR/admin-key.pem" -subj "/C=US/L=California/O=Wazuh/OU=Wazuh/CN=admin" -out "$TMP_DIR/admin.csr"
+openssl x509 -req -in "$TMP_DIR/admin.csr" -CA "$TMP_DIR/root-ca.pem" -CAkey "$TMP_DIR/root-ca-key-temp.pem" -CAcreateserial -sha256 -out "$TMP_DIR/admin.pem" -days 3650
 
-  cat <<'INDEXER_KEY' >$TMP_DIR/indexer-key.pem
------BEGIN PRIVATE KEY-----
-MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDJZsCQdRwFIszQ
-XtccbLLs3aUquhbIdGwpDALXtOa8XWBRhusSLgftmNfIQg4adPVgqzXvij546wiQ
-mVOsmyLht1C5UwoKzsDfQYrbyzrw8dGYmCDnrBPbB///XskQeChIygRHgfrqZM6E
-l1BbL2FZ8SvdoKSemRgQ7YaVh94ZF9H4u9IDDldKX5kYEia2tMV9lrv7gbtLBhK0
-6Ec2mFL/cKp6fFFynaPgWg+5AfbCygVitAt2OG9kNLbI6cZ/MvrkWrnIciWluwna
-mmf9RJaHBNIvcu6Wf1gtaDMyPf8Non/35B3uccYh0dkonIrcpeiWmBtoY0K6+2AV
-ottNt4wXAgMBAAECggEAFgHoYOCrIyneVOvyzY8DLjw6Ds/ZgCYDUP5DAUHUmhi0
-rF6gfpK7wwwZ6C7E+RchXmLXDfR+nG/yYPqgLhL1s3x4kbJakpEXz6LgguFTm33m
-d/+Ho557Z5/EKtTiBlla7Y6a+8Ve9GX3kH2IW65zENpNqiDNBuzruE3RkF1nDjle
-L/ShZp/MaLdUDRGucRfSg/QtulEk1swjsakB7gA+UVbi0N3bAYDIjC/0sQkD9AW/
-Z7c98oiA6V7vIaUynVYNO1u7jfKMTskYZdMT9BqYxduvHKf3q9vHQWx5z+OTclb6
-I5tZljoe6ksd0R0TLHJMVMjP4xf8dAEvcmqXB6y+wQKBgQDLFNkG4LrnJJDaMSjt
-gfEnyxXUv0ZIjZq0Om/0mNZeNddfjLeGeQ1LDsUFnyzKKUKWLhgaQcvaUHuQt9zU
-dGICNj9ivsY0BZq7zN5th0MIKwYaWjYH0jdmQeWU8U7nUp20vtYxaCRB8WAi1Pmh
-fXAe3e49iL5AJD8la4V+wibf6QKBgQD94dS7Yle29QJ7EBPyhHjANqxP6QEvocmO
-40G3FBNmyhR/OW8ldn9CADoExlxcIXOsr8WiyGEFHULs8fZX/7wM+2HffFJ+kOtI
-5Z7XE4mmvyqIolGTXK428PQVlvbitUKYm3lET9WBvlxa5m54vJPlNU9gqlBUF/CV
-SW2fYjOL/wKBgHmthReE4ReLJitFlzMvTzG7kdoFvPPNvGrONLRGOvL5qZC7fF7a
-+ucE83GZ3LlIHXhkJ9bbo2usG00rjOnSzcJrhHECwzj6PqrVZlQT3krvlFmHwaXQ
-A5eGVit2pgMd0hYw3Z9+uXK1UBeuqd9jjCFCcfN2kh9WWGtwT+0SIT65AoGAFVpR
-EhGLXw/sTX1ksBkELuZqR65JM0BgO2xRspw1pYeJgcnK11PIED0EpDIqwnTtzbBa
-5v4DavKzFkqjdXNE1bKu4KUMKyj1IQRu/5fdE/EwGp3MTqCU5noNjWNNEHQ+TaeF
-44DzbB4elmabE/yIU9bP/klUyD3bNjMezTDtNPECgYEAk9Ffhaw0Y/xgofCmvLRI
-79SbEbPSTXG4ICCAjEm/7oE8/BDEg8sV4fFSWFrUSfroQHX/AogRB9aAOPwoVwsd
-vkfzHxhsATJGZftq1XvdRpoHGYpZXO8FZ9BlFLeS7Y156RgLl6rAtoG6EWQwzoB2
-KhyfqIhMJFSEqFwz8nsLcDo=
------END PRIVATE KEY-----
-INDEXER_KEY
-
-  cat <<'INDEXER_CERT' >$TMP_DIR/indexer.pem
------BEGIN CERTIFICATE-----
-MIIDrTCCApWgAwIBAgIUXrjOPxnJtoICOqL+z9QzqccrhE0wDQYJKoZIhvcNAQEL
-BQAwNTEOMAwGA1UECwwFV2F6dWgxDjAMBgNVBAoMBVdhenVoMRMwEQYDVQQHDApD
-YWxpZm9ybmlhMB4XDTI0MTEyMDE2NTEwNVoXDTM0MTExODE2NTEwNVowYTELMAkG
-A1UEBhMCVVMxEzARBgNVBAcMCkNhbGlmb3JuaWExDjAMBgNVBAoMBVdhenVoMQ4w
-DAYDVQQLDAVXYXp1aDEdMBsGA1UEAwwUbm9kZS0wLndhenVoLmluZGV4ZXIwggEi
-MA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDJZsCQdRwFIszQXtccbLLs3aUq
-uhbIdGwpDALXtOa8XWBRhusSLgftmNfIQg4adPVgqzXvij546wiQmVOsmyLht1C5
-UwoKzsDfQYrbyzrw8dGYmCDnrBPbB///XskQeChIygRHgfrqZM6El1BbL2FZ8Svd
-oKSemRgQ7YaVh94ZF9H4u9IDDldKX5kYEia2tMV9lrv7gbtLBhK06Ec2mFL/cKp6
-fFFynaPgWg+5AfbCygVitAt2OG9kNLbI6cZ/MvrkWrnIciWluwnammf9RJaHBNIv
-cu6Wf1gtaDMyPf8Non/35B3uccYh0dkonIrcpeiWmBtoY0K6+2AVottNt4wXAgMB
-AAGjgYgwgYUwQwYDVR0RBDwwOoIJbG9jYWxob3N0gg8qLndhenVoLmluZGV4ZXKI
-BCoDBAWHBH8AAAGHEAAAAAAAAAAAAAAAAAAAAAEwHQYDVR0OBBYEFMAV32UwZfmX
-Mdi7/yQgHIGLc1GNMB8GA1UdIwQYMBaAFLiKwlbLzv/mfFaa/vd8PmlIFEl4MA0G
-CSqGSIb3DQEBCwUAA4IBAQAFH8WX5+WEFICfLeHL8QDeMefkyVgNAl1jo8OPKKbA
-fhmHin54DWrfSC3V3Xeo1olj53N/2G5dsfUWJ1fb7rnrkwqSV3yVak8z4lWPRfgW
-pBf48rwt2UCvAIzZZawyU74jKjcA938ZIm9jz1mFSgvfLVPWz0d6ENt/9VFHJHq2
-yNaP/ymON5Z7bCXbpztr73cUYQmDzIH9Kj/tzxaYhomR2U/Zk92Ow+ZEtH7866CQ
-51ombiWxQB2MqfZbZH0BcfaeFqiu6DF0b26xbqqH/8qcNtljc/I5u3EbXny7n0Pi
-mVGWK9t6LlKwb/u1zTKn+Ayy24fzELpG/y5CF35BW+Zy
------END CERTIFICATE-----
-INDEXER_CERT
-
-  cat <<'ROOT_CA' >$TMP_DIR/root-ca.pem
------BEGIN CERTIFICATE-----
-MIIDSzCCAjOgAwIBAgIUI7nMX6wJ4fcTo1JfSUNtuFNlgNIwDQYJKoZIhvcNAQEL
-BQAwNTEOMAwGA1UECwwFV2F6dWgxDjAMBgNVBAoMBVdhenVoMRMwEQYDVQQHDApD
-YWxpZm9ybmlhMB4XDTI0MTEyMDE2NTEwNFoXDTM0MTExODE2NTEwNFowNTEOMAwG
-A1UECwwFV2F6dWgxDjAMBgNVBAoMBVdhenVoMRMwEQYDVQQHDApDYWxpZm9ybmlh
-MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqbtN6t/RHs29r9qg4759
-2R71qRmSaPU+MW3oZA4XzqTa9p/BCcmmemLIUalp+WeUCBlUB34eMEpA9vZ7cT0j
-UQQNnTCx/6iWY95qAl8dIQUZeuYM6FmIMuZhzmIgdamMHh9YKYctuBBNJ2ySwnwe
-G4lON+1wvBipMGM5OjXkhnYhg2lz9EfjjBdBgpAMjBgULZ2vKc8u+xX9ILk0v507
-wDO4sLkXzes63wX/I98R1XJ8ttqLjUvVxxDkeFZmoNa9t2nZkweQrwYJc/NiF1u9
-VqIFYJM/3MAfYR/pAaB/ma+0Aq81JkEmh0wj6HayRtIrU36SFoGP/xdip6RhGSbJ
-AQIDAQABo1MwUTAdBgNVHQ4EFgQUuIrCVsvO/+Z8Vpr+93w+aUgUSXgwHwYDVR0j
-BBgwFoAUuIrCVsvO/+Z8Vpr+93w+aUgUSXgwDwYDVR0TAQH/BAUwAwEB/zANBgkq
-hkiG9w0BAQsFAAOCAQEAor0/yTsFn1/sd+CkcqpBharEX1Xq1FRVDN1DJYXJ/eUS
-cl+Yyg72fe+cbwOHMbwhiJxWhX1nlWby6RO+vbNADXy+GCxNnpNnVe3maYk3DA2q
-G5VNJtXv7OYjdIP5/4rOmbhTPoZfmsmKRGCMJEtJ0uq+VLrtPJsH10nAp8vceoMc
-PQB0He59izGVDwH47iJKVJVb7AnMFALFzlSYdjA0gVSXwj4n+VnVK2inBRwQ3MFl
-u2MM6NS9vE8IgX4+3X7cJkg2i6dLxGX69vTDyh6Y2obh4FgcY1PQfsUVZcWlSVvf
-kV0DupKzxHxUDXX8TvzihxGEkEi8HIYOQes7pTNTiw==
------END CERTIFICATE-----
-ROOT_CA
-
-# Otherwise, default to randomized certs generation
-else
-  # Root CA
-  openssl genrsa -out "$TMP_DIR/root-ca-key-temp.pem" 2048
-  openssl req -new -x509 -sha256 -key "$TMP_DIR/root-ca-key-temp.pem" -subj "/OU=Wazuh/O=Wazuh/L=California/" -out "$TMP_DIR/root-ca.pem" -days 3650
-
-  # Admin cert
-  openssl genrsa -out "$TMP_DIR/admin-key-temp.pem" 2048
-  openssl pkcs8 -inform PEM -outform PEM -in "$TMP_DIR/admin-key-temp.pem" -topk8 -nocrypt -v1 PBE-SHA1-3DES -out "$TMP_DIR/admin-key.pem"
-  openssl req -new -key "$TMP_DIR/admin-key.pem" -subj "/C=US/L=California/O=Wazuh/OU=Wazuh/CN=admin" -out "$TMP_DIR/admin.csr"
-  openssl x509 -req -in "$TMP_DIR/admin.csr" -CA "$TMP_DIR/root-ca.pem" -CAkey "$TMP_DIR/root-ca-key-temp.pem" -CAcreateserial -sha256 -out "$TMP_DIR/admin.pem" -days 3650
-
-  # Node cert
-  openssl genrsa -out "$TMP_DIR/indexer-key-temp.pem" 2048
-  openssl pkcs8 -inform PEM -outform PEM -in "$TMP_DIR/indexer-key-temp.pem" -topk8 -nocrypt -v1 PBE-SHA1-3DES -out "$TMP_DIR/indexer-key.pem"
-  openssl req -new -key "$TMP_DIR/indexer-key.pem" -subj "/C=US/L=California/O=Wazuh/OU=Wazuh/CN=node-0.wazuh.indexer" -out "$TMP_DIR/indexer.csr"
-  cat <<'INDEXER_EXT' >$TMP_DIR/indexer.ext
+# Node cert
+openssl genrsa -out "$TMP_DIR/indexer-key-temp.pem" 2048
+openssl pkcs8 -inform PEM -outform PEM -in "$TMP_DIR/indexer-key-temp.pem" -topk8 -nocrypt -v1 PBE-SHA1-3DES -out "$TMP_DIR/indexer-key.pem"
+openssl req -new -key "$TMP_DIR/indexer-key.pem" -subj "/C=US/L=California/O=Wazuh/OU=Wazuh/CN=node-0.wazuh.indexer" -out "$TMP_DIR/indexer.csr"
+cat <<'INDEXER_EXT' >$TMP_DIR/indexer.ext
 subjectAltName = @alt_names
 [alt_names]
 DNS.1 = localhost
@@ -175,11 +37,10 @@ IP.1 = 127.0.0.1
 IP.2 =  0:0:0:0:0:0:0:1
 INDEXER_EXT
 
-  openssl x509 -req -in "$TMP_DIR/indexer.csr" -CA "$TMP_DIR/root-ca.pem" -CAkey "$TMP_DIR/root-ca-key-temp.pem" -CAcreateserial -sha256 -out "$TMP_DIR/indexer.pem" -days 3650 -extfile "$TMP_DIR/indexer.ext"
+openssl x509 -req -in "$TMP_DIR/indexer.csr" -CA "$TMP_DIR/root-ca.pem" -CAkey "$TMP_DIR/root-ca-key-temp.pem" -CAcreateserial -sha256 -out "$TMP_DIR/indexer.pem" -days 3650 -extfile "$TMP_DIR/indexer.ext"
 
-  # Cleanup temporary files
-  rm "$TMP_DIR/"*.csr "$TMP_DIR"/*.ext "$TMP_DIR"/*.srl "$TMP_DIR"/*-temp.pem
-fi
+# Cleanup temporary files
+rm "$TMP_DIR/"*.csr "$TMP_DIR"/*.ext "$TMP_DIR"/*.srl "$TMP_DIR"/*-temp.pem
 
 # Move certs to permanent location
 mkdir -p "$CERTS_DIR"

--- a/distribution/packages/src/common/scripts/install-demo-certificates.sh
+++ b/distribution/packages/src/common/scripts/install-demo-certificates.sh
@@ -16,9 +16,8 @@ mkdir -p "$TMP_DIR"
 # If demo certificates are explicitly solicited
 # (ie. for dockerized cluster test environments)
 # then, use hardcoded certs.
-if [ ${USE_DEMO_CERTS:-false} = "true" ]
-then
-cat <<'ADMIN_KEY' > $TMP_DIR/admin-key.pem
+if [ "${USE_DEMO_CERTS:-false}" = "true" ]; then
+  cat <<'ADMIN_KEY' >$TMP_DIR/admin-key.pem
 -----BEGIN PRIVATE KEY-----
 MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC3ebYoJC7NR6YU
 aYDnhRlawrb6BD4Oj3VkLsk4hIEKLo0afcexZWhW2iKqK1d7KLQir7ZqmodyQpzR
@@ -49,7 +48,7 @@ V4hJcul3lbTnrbuRHvVEOGk=
 -----END PRIVATE KEY-----
 ADMIN_KEY
 
-cat <<'ADMIN_CERT' > $TMP_DIR/admin.pem
+  cat <<'ADMIN_CERT' >$TMP_DIR/admin.pem
 -----BEGIN CERTIFICATE-----
 MIIDDjCCAfYCFD71oGZblxldV2/96zP2kZpIKOYgMA0GCSqGSIb3DQEBCwUAMDUx
 DjAMBgNVBAsMBVdhenVoMQ4wDAYDVQQKDAVXYXp1aDETMBEGA1UEBwwKQ2FsaWZv
@@ -71,7 +70,7 @@ BzcZ+J6GzTHIZXHI77PvXHtf
 -----END CERTIFICATE-----
 ADMIN_CERT
 
-cat <<'INDEXER_KEY' > $TMP_DIR/indexer-key.pem
+  cat <<'INDEXER_KEY' >$TMP_DIR/indexer-key.pem
 -----BEGIN PRIVATE KEY-----
 MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDJZsCQdRwFIszQ
 XtccbLLs3aUquhbIdGwpDALXtOa8XWBRhusSLgftmNfIQg4adPVgqzXvij546wiQ
@@ -102,7 +101,7 @@ KhyfqIhMJFSEqFwz8nsLcDo=
 -----END PRIVATE KEY-----
 INDEXER_KEY
 
-cat <<'INDEXER_CERT' > $TMP_DIR/indexer.pem
+  cat <<'INDEXER_CERT' >$TMP_DIR/indexer.pem
 -----BEGIN CERTIFICATE-----
 MIIDrTCCApWgAwIBAgIUXrjOPxnJtoICOqL+z9QzqccrhE0wDQYJKoZIhvcNAQEL
 BQAwNTEOMAwGA1UECwwFV2F6dWgxDjAMBgNVBAoMBVdhenVoMRMwEQYDVQQHDApD
@@ -127,7 +126,7 @@ mVGWK9t6LlKwb/u1zTKn+Ayy24fzELpG/y5CF35BW+Zy
 -----END CERTIFICATE-----
 INDEXER_CERT
 
-cat <<'ROOT_CA' > $TMP_DIR/root-ca.pem
+  cat <<'ROOT_CA' >$TMP_DIR/root-ca.pem
 -----BEGIN CERTIFICATE-----
 MIIDSzCCAjOgAwIBAgIUI7nMX6wJ4fcTo1JfSUNtuFNlgNIwDQYJKoZIhvcNAQEL
 BQAwNTEOMAwGA1UECwwFV2F6dWgxDjAMBgNVBAoMBVdhenVoMRMwEQYDVQQHDApD
@@ -166,7 +165,7 @@ else
   openssl genrsa -out "$TMP_DIR/indexer-key-temp.pem" 2048
   openssl pkcs8 -inform PEM -outform PEM -in "$TMP_DIR/indexer-key-temp.pem" -topk8 -nocrypt -v1 PBE-SHA1-3DES -out "$TMP_DIR/indexer-key.pem"
   openssl req -new -key "$TMP_DIR/indexer-key.pem" -subj "/C=US/L=California/O=Wazuh/OU=Wazuh/CN=node-0.wazuh.indexer" -out "$TMP_DIR/indexer.csr"
-cat <<'INDEXER_EXT' > $TMP_DIR/indexer.ext
+  cat <<'INDEXER_EXT' >$TMP_DIR/indexer.ext
 subjectAltName = @alt_names
 [alt_names]
 DNS.1 = localhost

--- a/distribution/packages/src/common/scripts/install-demo-certificates.sh
+++ b/distribution/packages/src/common/scripts/install-demo-certificates.sh
@@ -1,0 +1,194 @@
+#!/bin/sh
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# Directories
+TMP_DIR="/tmp/wazuh-indexer/certs"
+CERTS_DIR="/etc/wazuh-indexer/certs"
+
+# Create directories
+mkdir -p "$TMP_DIR"
+
+# If demo certificates are explicitly solicited
+# (ie. for dockerized cluster test environments)
+# then, use hardcoded certs.
+if [ ${USE_DEMO_CERTS:-false} = "true" ]
+then
+cat <<'ADMIN_KEY' > $TMP_DIR/admin-key.pem
+-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC3ebYoJC7NR6YU
+aYDnhRlawrb6BD4Oj3VkLsk4hIEKLo0afcexZWhW2iKqK1d7KLQir7ZqmodyQpzR
+0/EbnwBEQXsWqxcACdestzADpLiX7J+RWKrLuQ1+wSOAAI/Y0pIEdrf9/5Jnj78o
+I9xDEQxGlQjiJgvwJCkJXv4UD5LAXoKRnP1FRLWJxvCsLBKWuceNCVYu0QUPLkA7
+XkshDSDYvsxD8G7hE/o7lKm9GjHduBDTmZ3dvcOzMtbxsGk5qMtHvXWgTK1YUkz4
+f34m6E1ESLvxYveDzmcLMu4JJZEPIYWBUZV7ufeiDWhhXtT4vHoh6iLZdq4olIx3
+fPsA8kEdAgMBAAECggEAOrEMFL4yXIeJeKkhS653pGF6T/MweM7qYhBXXSWB8+Rd
+TfajfTtvy6y+/wmbU/H64cesxmBFaMcnTDYMwGW2G5+IxQEY+/GqFP2Ktfeo9yyC
+BOhExqOdTglxlj5XxafiftwNUorBZjCFGU2TZb7b2u5M5679DaY7nFxPUdKDgtaO
+IXRr7LYO2hQs57/e64UZvac994nwZBW17TWSmERGVGQs7fdSaPGwloA6phiyQflD
+EmYxzMUFetpAu5Bk35hqLolw6htirkHzd8f0tFf3JvO1xvcZeVw1JDM/pV6Cfd9e
+LZ8rabcwNYTuTFA/2bISSkReTvGebMJnIfl7g7nBTwKBgQDeQZr7MBww9n5LYdGS
+B9z7DuAGZUWGIDqWPZT6pBNCbBhcQdrBEjSTUY/YQL1ofM/i/7A4xey5LZUZelUy
+IgNSqpCC4McEkx565KcN3uNxXyJzwFsD4PhBkyQC5fYsjU9kGLKfv0MKy95ky9Y3
+pbu7eegNEBvr1l9h/rtyRfchnwKBgQDTVNGBzaAxMjYN7z40+oo2Oc3B4OGqGXON
+Ci5BABajFqvtudpUDAl06v95X1tY9f4EnpBtqNmnKu796aN8yycD+VTWIXttzqPX
+uOqSgWQOkO/vAWcxbMHhyjv92wvJZAV0BeuaQgv+SKey3yqGn9rDIjV/xOX6yW1L
+rmwl4ow7wwKBgD81620LNslaIXsw+9iLcfbZOS+4d7h4zBDUvN038t5OPfNnK18D
+3X4UkVOQvg3MiZdm3uiWqgfUhfY0C6zxbX6CUg1W/mM3sFCFXVmdjZQ92V+QUpJc
+1l5YCcLlQklTe0Pdnle+nsOgTcTfEDLNaQId3rhwX3CIjKIjP451hZ7DAoGBAL/m
+WmSrSxbBSJJ4uB01kIHTFYNDaMekWugs4XmG0geAU9kIFjiRwZiYuCoHrBRpNCQP
+tIjPde01sFWDbkCo3SHfq+jR+JnqtZ7zPJaSxj/v3uBCfulDn/8fPEC1Qsu6drU3
+lwy5gtiCMz3bJmufBvCAxOHj8w47EHNTzMLOKJcvAoGAOrMBDVn4e4OPc138sef5
+R+sgl2DWtKGUFFBYwT9oUFu2Jq6+ARSXg+gi9LBKfswWcJtiWyeDd54tyNdH+GBD
+Oc76auI2UkXUJ99XCOzo1z85cBi9cIB14vdGAhLCrGXIJRx1VTlEcHtVOpWwbkfM
+V4hJcul3lbTnrbuRHvVEOGk=
+-----END PRIVATE KEY-----
+ADMIN_KEY
+
+cat <<'ADMIN_CERT' > $TMP_DIR/admin.pem
+-----BEGIN CERTIFICATE-----
+MIIDDjCCAfYCFD71oGZblxldV2/96zP2kZpIKOYgMA0GCSqGSIb3DQEBCwUAMDUx
+DjAMBgNVBAsMBVdhenVoMQ4wDAYDVQQKDAVXYXp1aDETMBEGA1UEBwwKQ2FsaWZv
+cm5pYTAeFw0yNDExMjAxNjUxMDRaFw0zNDExMTgxNjUxMDRaMFIxCzAJBgNVBAYT
+AlVTMRMwEQYDVQQHDApDYWxpZm9ybmlhMQ4wDAYDVQQKDAVXYXp1aDEOMAwGA1UE
+CwwFV2F6dWgxDjAMBgNVBAMMBWFkbWluMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A
+MIIBCgKCAQEAt3m2KCQuzUemFGmA54UZWsK2+gQ+Do91ZC7JOISBCi6NGn3HsWVo
+VtoiqitXeyi0Iq+2apqHckKc0dPxG58AREF7FqsXAAnXrLcwA6S4l+yfkViqy7kN
+fsEjgACP2NKSBHa3/f+SZ4+/KCPcQxEMRpUI4iYL8CQpCV7+FA+SwF6CkZz9RUS1
+icbwrCwSlrnHjQlWLtEFDy5AO15LIQ0g2L7MQ/Bu4RP6O5SpvRox3bgQ05md3b3D
+szLW8bBpOajLR711oEytWFJM+H9+JuhNREi78WL3g85nCzLuCSWRDyGFgVGVe7n3
+og1oYV7U+Lx6Ieoi2XauKJSMd3z7APJBHQIDAQABMA0GCSqGSIb3DQEBCwUAA4IB
+AQCOYHh3KgCfVyJdt9xMqGmb/GNeitxt8dZtatEiwE29O2ABUK3i24SYAb/fGZ1F
+eSc184njF/9rD8SCNEo8rfD6HjP6EsdoPFtekvEC1Ykrxk1chvpC1EHNZPGWZ6Wk
+UKuEORYyv4rzngvT9K/77iw8clW225uGp1GtcNgw45LnIdCEGf+Uy8uKOkzKs7Uf
+Mnl2zHy0S6gYV5aBWDW9WuuUQnoVTNdnAs6e4UGIw5T/l5W7WKDG9Q+F+Xrt4Cvx
+W8evS+3vVVF+EYwBXBQRZhkL7f+sJnizhdzCUMqztGZR1rsjl+Vz+S6u77KrKIop
+BzcZ+J6GzTHIZXHI77PvXHtf
+-----END CERTIFICATE-----
+ADMIN_CERT
+
+cat <<'INDEXER_KEY' > $TMP_DIR/indexer-key.pem
+-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDJZsCQdRwFIszQ
+XtccbLLs3aUquhbIdGwpDALXtOa8XWBRhusSLgftmNfIQg4adPVgqzXvij546wiQ
+mVOsmyLht1C5UwoKzsDfQYrbyzrw8dGYmCDnrBPbB///XskQeChIygRHgfrqZM6E
+l1BbL2FZ8SvdoKSemRgQ7YaVh94ZF9H4u9IDDldKX5kYEia2tMV9lrv7gbtLBhK0
+6Ec2mFL/cKp6fFFynaPgWg+5AfbCygVitAt2OG9kNLbI6cZ/MvrkWrnIciWluwna
+mmf9RJaHBNIvcu6Wf1gtaDMyPf8Non/35B3uccYh0dkonIrcpeiWmBtoY0K6+2AV
+ottNt4wXAgMBAAECggEAFgHoYOCrIyneVOvyzY8DLjw6Ds/ZgCYDUP5DAUHUmhi0
+rF6gfpK7wwwZ6C7E+RchXmLXDfR+nG/yYPqgLhL1s3x4kbJakpEXz6LgguFTm33m
+d/+Ho557Z5/EKtTiBlla7Y6a+8Ve9GX3kH2IW65zENpNqiDNBuzruE3RkF1nDjle
+L/ShZp/MaLdUDRGucRfSg/QtulEk1swjsakB7gA+UVbi0N3bAYDIjC/0sQkD9AW/
+Z7c98oiA6V7vIaUynVYNO1u7jfKMTskYZdMT9BqYxduvHKf3q9vHQWx5z+OTclb6
+I5tZljoe6ksd0R0TLHJMVMjP4xf8dAEvcmqXB6y+wQKBgQDLFNkG4LrnJJDaMSjt
+gfEnyxXUv0ZIjZq0Om/0mNZeNddfjLeGeQ1LDsUFnyzKKUKWLhgaQcvaUHuQt9zU
+dGICNj9ivsY0BZq7zN5th0MIKwYaWjYH0jdmQeWU8U7nUp20vtYxaCRB8WAi1Pmh
+fXAe3e49iL5AJD8la4V+wibf6QKBgQD94dS7Yle29QJ7EBPyhHjANqxP6QEvocmO
+40G3FBNmyhR/OW8ldn9CADoExlxcIXOsr8WiyGEFHULs8fZX/7wM+2HffFJ+kOtI
+5Z7XE4mmvyqIolGTXK428PQVlvbitUKYm3lET9WBvlxa5m54vJPlNU9gqlBUF/CV
+SW2fYjOL/wKBgHmthReE4ReLJitFlzMvTzG7kdoFvPPNvGrONLRGOvL5qZC7fF7a
++ucE83GZ3LlIHXhkJ9bbo2usG00rjOnSzcJrhHECwzj6PqrVZlQT3krvlFmHwaXQ
+A5eGVit2pgMd0hYw3Z9+uXK1UBeuqd9jjCFCcfN2kh9WWGtwT+0SIT65AoGAFVpR
+EhGLXw/sTX1ksBkELuZqR65JM0BgO2xRspw1pYeJgcnK11PIED0EpDIqwnTtzbBa
+5v4DavKzFkqjdXNE1bKu4KUMKyj1IQRu/5fdE/EwGp3MTqCU5noNjWNNEHQ+TaeF
+44DzbB4elmabE/yIU9bP/klUyD3bNjMezTDtNPECgYEAk9Ffhaw0Y/xgofCmvLRI
+79SbEbPSTXG4ICCAjEm/7oE8/BDEg8sV4fFSWFrUSfroQHX/AogRB9aAOPwoVwsd
+vkfzHxhsATJGZftq1XvdRpoHGYpZXO8FZ9BlFLeS7Y156RgLl6rAtoG6EWQwzoB2
+KhyfqIhMJFSEqFwz8nsLcDo=
+-----END PRIVATE KEY-----
+INDEXER_KEY
+
+cat <<'INDEXER_CERT' > $TMP_DIR/indexer.pem
+-----BEGIN CERTIFICATE-----
+MIIDrTCCApWgAwIBAgIUXrjOPxnJtoICOqL+z9QzqccrhE0wDQYJKoZIhvcNAQEL
+BQAwNTEOMAwGA1UECwwFV2F6dWgxDjAMBgNVBAoMBVdhenVoMRMwEQYDVQQHDApD
+YWxpZm9ybmlhMB4XDTI0MTEyMDE2NTEwNVoXDTM0MTExODE2NTEwNVowYTELMAkG
+A1UEBhMCVVMxEzARBgNVBAcMCkNhbGlmb3JuaWExDjAMBgNVBAoMBVdhenVoMQ4w
+DAYDVQQLDAVXYXp1aDEdMBsGA1UEAwwUbm9kZS0wLndhenVoLmluZGV4ZXIwggEi
+MA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDJZsCQdRwFIszQXtccbLLs3aUq
+uhbIdGwpDALXtOa8XWBRhusSLgftmNfIQg4adPVgqzXvij546wiQmVOsmyLht1C5
+UwoKzsDfQYrbyzrw8dGYmCDnrBPbB///XskQeChIygRHgfrqZM6El1BbL2FZ8Svd
+oKSemRgQ7YaVh94ZF9H4u9IDDldKX5kYEia2tMV9lrv7gbtLBhK06Ec2mFL/cKp6
+fFFynaPgWg+5AfbCygVitAt2OG9kNLbI6cZ/MvrkWrnIciWluwnammf9RJaHBNIv
+cu6Wf1gtaDMyPf8Non/35B3uccYh0dkonIrcpeiWmBtoY0K6+2AVottNt4wXAgMB
+AAGjgYgwgYUwQwYDVR0RBDwwOoIJbG9jYWxob3N0gg8qLndhenVoLmluZGV4ZXKI
+BCoDBAWHBH8AAAGHEAAAAAAAAAAAAAAAAAAAAAEwHQYDVR0OBBYEFMAV32UwZfmX
+Mdi7/yQgHIGLc1GNMB8GA1UdIwQYMBaAFLiKwlbLzv/mfFaa/vd8PmlIFEl4MA0G
+CSqGSIb3DQEBCwUAA4IBAQAFH8WX5+WEFICfLeHL8QDeMefkyVgNAl1jo8OPKKbA
+fhmHin54DWrfSC3V3Xeo1olj53N/2G5dsfUWJ1fb7rnrkwqSV3yVak8z4lWPRfgW
+pBf48rwt2UCvAIzZZawyU74jKjcA938ZIm9jz1mFSgvfLVPWz0d6ENt/9VFHJHq2
+yNaP/ymON5Z7bCXbpztr73cUYQmDzIH9Kj/tzxaYhomR2U/Zk92Ow+ZEtH7866CQ
+51ombiWxQB2MqfZbZH0BcfaeFqiu6DF0b26xbqqH/8qcNtljc/I5u3EbXny7n0Pi
+mVGWK9t6LlKwb/u1zTKn+Ayy24fzELpG/y5CF35BW+Zy
+-----END CERTIFICATE-----
+INDEXER_CERT
+
+cat <<'ROOT_CA' > $TMP_DIR/root-ca.pem
+-----BEGIN CERTIFICATE-----
+MIIDSzCCAjOgAwIBAgIUI7nMX6wJ4fcTo1JfSUNtuFNlgNIwDQYJKoZIhvcNAQEL
+BQAwNTEOMAwGA1UECwwFV2F6dWgxDjAMBgNVBAoMBVdhenVoMRMwEQYDVQQHDApD
+YWxpZm9ybmlhMB4XDTI0MTEyMDE2NTEwNFoXDTM0MTExODE2NTEwNFowNTEOMAwG
+A1UECwwFV2F6dWgxDjAMBgNVBAoMBVdhenVoMRMwEQYDVQQHDApDYWxpZm9ybmlh
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqbtN6t/RHs29r9qg4759
+2R71qRmSaPU+MW3oZA4XzqTa9p/BCcmmemLIUalp+WeUCBlUB34eMEpA9vZ7cT0j
+UQQNnTCx/6iWY95qAl8dIQUZeuYM6FmIMuZhzmIgdamMHh9YKYctuBBNJ2ySwnwe
+G4lON+1wvBipMGM5OjXkhnYhg2lz9EfjjBdBgpAMjBgULZ2vKc8u+xX9ILk0v507
+wDO4sLkXzes63wX/I98R1XJ8ttqLjUvVxxDkeFZmoNa9t2nZkweQrwYJc/NiF1u9
+VqIFYJM/3MAfYR/pAaB/ma+0Aq81JkEmh0wj6HayRtIrU36SFoGP/xdip6RhGSbJ
+AQIDAQABo1MwUTAdBgNVHQ4EFgQUuIrCVsvO/+Z8Vpr+93w+aUgUSXgwHwYDVR0j
+BBgwFoAUuIrCVsvO/+Z8Vpr+93w+aUgUSXgwDwYDVR0TAQH/BAUwAwEB/zANBgkq
+hkiG9w0BAQsFAAOCAQEAor0/yTsFn1/sd+CkcqpBharEX1Xq1FRVDN1DJYXJ/eUS
+cl+Yyg72fe+cbwOHMbwhiJxWhX1nlWby6RO+vbNADXy+GCxNnpNnVe3maYk3DA2q
+G5VNJtXv7OYjdIP5/4rOmbhTPoZfmsmKRGCMJEtJ0uq+VLrtPJsH10nAp8vceoMc
+PQB0He59izGVDwH47iJKVJVb7AnMFALFzlSYdjA0gVSXwj4n+VnVK2inBRwQ3MFl
+u2MM6NS9vE8IgX4+3X7cJkg2i6dLxGX69vTDyh6Y2obh4FgcY1PQfsUVZcWlSVvf
+kV0DupKzxHxUDXX8TvzihxGEkEi8HIYOQes7pTNTiw==
+-----END CERTIFICATE-----
+ROOT_CA
+
+# Otherwise, default to randomized certs generation
+else
+  # Root CA
+  openssl genrsa -out "$TMP_DIR/root-ca-key-temp.pem" 2048
+  openssl req -new -x509 -sha256 -key "$TMP_DIR/root-ca-key-temp.pem" -subj "/OU=Wazuh/O=Wazuh/L=California/" -out "$TMP_DIR/root-ca.pem" -days 3650
+
+  # Admin cert
+  openssl genrsa -out "$TMP_DIR/admin-key-temp.pem" 2048
+  openssl pkcs8 -inform PEM -outform PEM -in "$TMP_DIR/admin-key-temp.pem" -topk8 -nocrypt -v1 PBE-SHA1-3DES -out "$TMP_DIR/admin-key.pem"
+  openssl req -new -key "$TMP_DIR/admin-key.pem" -subj "/C=US/L=California/O=Wazuh/OU=Wazuh/CN=admin" -out "$TMP_DIR/admin.csr"
+  openssl x509 -req -in "$TMP_DIR/admin.csr" -CA "$TMP_DIR/root-ca.pem" -CAkey "$TMP_DIR/root-ca-key-temp.pem" -CAcreateserial -sha256 -out "$TMP_DIR/admin.pem" -days 3650
+
+  # Node cert
+  openssl genrsa -out "$TMP_DIR/indexer-key-temp.pem" 2048
+  openssl pkcs8 -inform PEM -outform PEM -in "$TMP_DIR/indexer-key-temp.pem" -topk8 -nocrypt -v1 PBE-SHA1-3DES -out "$TMP_DIR/indexer-key.pem"
+  openssl req -new -key "$TMP_DIR/indexer-key.pem" -subj "/C=US/L=California/O=Wazuh/OU=Wazuh/CN=node-0.wazuh.indexer" -out "$TMP_DIR/indexer.csr"
+cat <<'INDEXER_EXT' > $TMP_DIR/indexer.ext
+subjectAltName = @alt_names
+[alt_names]
+DNS.1 = localhost
+DNS.2 = *.wazuh.indexer
+RID.1 = 1.2.3.4.5
+IP.1 = 127.0.0.1
+IP.2 =  0:0:0:0:0:0:0:1
+INDEXER_EXT
+
+  openssl x509 -req -in "$TMP_DIR/indexer.csr" -CA "$TMP_DIR/root-ca.pem" -CAkey "$TMP_DIR/root-ca-key-temp.pem" -CAcreateserial -sha256 -out "$TMP_DIR/indexer.pem" -days 3650 -extfile "$TMP_DIR/indexer.ext"
+
+  # Cleanup temporary files
+  rm "$TMP_DIR/"*.csr "$TMP_DIR"/*.ext "$TMP_DIR"/*.srl "$TMP_DIR"/*-temp.pem
+fi
+
+# Move certs to permanent location
+mkdir -p "$CERTS_DIR"
+mv "$TMP_DIR"/* "$CERTS_DIR/"
+
+chmod 500 "$CERTS_DIR"
+chmod 400 "$CERTS_DIR"/*
+chown -R wazuh-indexer:wazuh-indexer "$CERTS_DIR"
+
+# Cleanup /tmp directory
+rm -r "$TMP_DIR"

--- a/distribution/packages/src/deb/debian/postinst
+++ b/distribution/packages/src/deb/debian/postinst
@@ -61,6 +61,14 @@ if command -v systemd-tmpfiles > /dev/null; then
     systemd-tmpfiles --create wazuh-indexer.conf
 fi
 
+
+if ! [ -d "${config_dir}/certs" ] && [ -f "${product_dir}/plugins/opensearch-security/tools/install-demo-certificates.sh" ]; then
+    echo "No certificates detected in ${config_dir}, installing demo certificates..."
+    echo "### If you are using a custom certificates path, ignore this message."
+    export USE_DEMO_CERTS
+    bash "${product_dir}/plugins/opensearch-security/tools/install-demo-certificates.sh" > "${log_dir}/install_demo_certificates.log" 2>&1
+fi
+
 if [ -f $restart_service ]; then
     rm -f $restart_service
     echo "Restarting wazuh-indexer service..."

--- a/distribution/packages/src/deb/debian/postinst
+++ b/distribution/packages/src/deb/debian/postinst
@@ -32,7 +32,6 @@ chown -R wazuh-indexer:wazuh-indexer ${data_dir}
 chown -R wazuh-indexer:wazuh-indexer ${pid_dir}
 chown -R wazuh-indexer:wazuh-indexer ${tmp_dir}
 
-
 export OPENSEARCH_PATH_CONF=${OPENSEARCH_PATH_CONF:-${config_dir}}
 # Apply Performance Analyzer settings, as per https://github.com/opensearch-project/opensearch-build/blob/2.18.0/scripts/pkg/build_templates/current/opensearch/deb/debian/postinst#L28-L37
 if ! grep -q '## OpenSearch Performance Analyzer' "$OPENSEARCH_PATH_CONF/jvm.options"; then
@@ -44,36 +43,35 @@ if ! grep -q '## OpenSearch Performance Analyzer' "$OPENSEARCH_PATH_CONF/jvm.opt
         echo "-Djdk.attach.allowAttachSelf=true"
         echo "-Djava.security.policy=file://$OPENSEARCH_PATH_CONF/opensearch-performance-analyzer/opensearch_security.policy"
         echo "--add-opens=jdk.attach/sun.tools.attach=ALL-UNNAMED"
-    } >> "$OPENSEARCH_PATH_CONF/jvm.options"
+    } >>"$OPENSEARCH_PATH_CONF/jvm.options"
 fi
 
 # Reload systemctl daemon
-if command -v systemctl > /dev/null; then
+if command -v systemctl >/dev/null; then
     systemctl daemon-reload
 fi
 
 # Reload other configs
-if command -v systemctl > /dev/null; then
+if command -v systemctl >/dev/null; then
     systemctl restart systemd-sysctl.service || true
 fi
 
-if command -v systemd-tmpfiles > /dev/null; then
+if command -v systemd-tmpfiles >/dev/null; then
     systemd-tmpfiles --create wazuh-indexer.conf
 fi
-
 
 if ! [ -d "${config_dir}/certs" ] && [ -f "${product_dir}/plugins/opensearch-security/tools/install-demo-certificates.sh" ]; then
     echo "No certificates detected in ${config_dir}, installing demo certificates..."
     echo "### If you are using a custom certificates path, ignore this message."
     export USE_DEMO_CERTS
-    bash "${product_dir}/plugins/opensearch-security/tools/install-demo-certificates.sh" > "${log_dir}/install_demo_certificates.log" 2>&1
+    bash "${product_dir}/plugins/opensearch-security/tools/install-demo-certificates.sh" >"${log_dir}/install_demo_certificates.log" 2>&1
 fi
 
 if [ -f $restart_service ]; then
     rm -f $restart_service
     echo "Restarting wazuh-indexer service..."
-    if command -v systemctl > /dev/null; then
-        systemctl restart wazuh-indexer.service > /dev/null 2>&1
+    if command -v systemctl >/dev/null; then
+        systemctl restart wazuh-indexer.service >/dev/null 2>&1
     fi
     exit 0
 fi

--- a/distribution/packages/src/deb/debian/postinst
+++ b/distribution/packages/src/deb/debian/postinst
@@ -63,7 +63,6 @@ fi
 if ! [ -d "${config_dir}/certs" ] && [ -f "${product_dir}/plugins/opensearch-security/tools/install-demo-certificates.sh" ]; then
     echo "No certificates detected in ${config_dir}, installing demo certificates..."
     echo "### If you are using a custom certificates path, ignore this message."
-    export USE_DEMO_CERTS
     bash "${product_dir}/plugins/opensearch-security/tools/install-demo-certificates.sh" >"${log_dir}/install_demo_certificates.log" 2>&1
 fi
 

--- a/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
+++ b/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
@@ -210,7 +210,6 @@ fi
 if ! [ -d %{config_dir}/certs ] && [ -f %{product_dir}/plugins/opensearch-security/tools/install-demo-certificates.sh ]; then
     echo "No certificates detected in %{config_dir}, installing demo certificates..."
     echo "### If you are using a custom certificates path, ignore this message."
-    export USE_DEMO_CERTS
     bash %{product_dir}/plugins/opensearch-security/tools/install-demo-certificates.sh > %{log_dir}/install_demo_certificates.log 2>&1
 fi
 

--- a/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
+++ b/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
@@ -207,6 +207,13 @@ if command -v systemd-tmpfiles > /dev/null; then
     systemd-tmpfiles --create %{name}.conf
 fi
 
+if ! [ -d %{config_dir}/certs ] && [ -f %{product_dir}/plugins/opensearch-security/tools/install-demo-certificates.sh ]; then
+    echo "No certificates detected in %{config_dir}, installing demo certificates..."
+    echo "### If you are using a custom certificates path, ignore this message."
+    export USE_DEMO_CERTS
+    bash %{product_dir}/plugins/opensearch-security/tools/install-demo-certificates.sh > %{log_dir}/install_demo_certificates.log 2>&1
+fi
+
 if [ -f %{tmp_dir}/wazuh-indexer.restart ]; then
     rm -f %{tmp_dir}/wazuh-indexer.restart
     if command -v systemctl > /dev/null; then


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Add `install-demo-certificates.sh` that generates and configure the demo certificates for the current `wazuh-indexer` installation.
It is being used at the `post-install` packaging step

### Related Issues
Resolves #183

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
