### PR TITLE
Update Vagrantfile

### DIFF
--- a/test-tools/Vagrantfile
+++ b/test-tools/Vagrantfile
@@ -19,7 +19,7 @@ Vagrant.configure("2") do |config|
             systemctl stop firewalld
             systemctl disable firewalld
             yum clean all
-            yum install curl jq unzip tar -y
+            yum install jq unzip tar -y
             # Add node-2 to /etc/hosts
             echo "192.168.56.11 node-2" >> /etc/hosts
             # Copy generated certificates


### PR DESCRIPTION
### Description
This PR removes `curl` from the provision of the test-tools/Vagrantfile as it breaks the communication with the VM from the host due to the latest curl update, as it forces an update of the OpenSSL libs.

### Related Issues
N/A

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
