### PR TITLE
Add interface at root level on state-inventory-port index

### DIFF
--- a/ecs/states-inventory-ports/event-generator/event_generator.py
+++ b/ecs/states-inventory-ports/event-generator/event_generator.py
@@ -188,7 +188,10 @@ def generate_random_data(number):
                 'protocol': random.choice(['TCP', 'UDP', 'ICMP'])
             },
             'process': generate_random_process(),
-            'source': generate_random_source()
+            'source': generate_random_source(),
+            'interface': {
+                'state': random.choice(['Active', 'Inactive', 'Unknown'])
+            }
         }
         data.append(event_data)
     return data

--- a/ecs/states-inventory-ports/fields/custom/interface.yml
+++ b/ecs/states-inventory-ports/fields/custom/interface.yml
@@ -1,5 +1,9 @@
 ---
 - name: interface
+  reusable:
+    top_level: true
+    expected:
+      - { at: observer.egress.interface, as: observer.ingress.interface }
   title: Interface
   type: group
   group: 2


### PR DESCRIPTION
### Description
Add missing configuration on the `ecs/states-inventory-ports/fields/custom/interface.yml` to have interface at ports index top level.

### Related Issues
Resolves #580
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
