### PR TITLE
Implement tty.char_device.major field to processes mapping

### DIFF
--- a/ecs/docs/inventory-processes.md
+++ b/ecs/docs/inventory-processes.md
@@ -8,24 +8,24 @@ Based on ECS:
 
 - [Process Fields](https://www.elastic.co/guide/en/ecs/current/ecs-process.html).
 
-|     | Field name               | Data type | Description                                                                                          | Examples                                           | Comments                                                   |
-| --- | ------------------------ | --------- | ---------------------------------------------------------------------------------------------------- | -------------------------------------------------- | ---------------------------------------------------------- |
-|     | `agent.*`                | object    | All the agent fields.                                                                                | `                                                  |
-|     | `@timestamp`             | date      | Date/time when the event originated.                                                                 | `2016-05-23T08:05:34.853Z`                         |                                                            |
-|     | `process.args`           | keyword   | Array of process arguments.                                                                          | `["/usr/bin/ssh", "-l", "user", "10.0.0.16"]`      |                                                            |
-|     | `process.command_line`   | wildcard  | process.command_line.                                                                                | `/usr/bin/ssh -l user 10.0.0.16`                   |                                                            |
-|     | `process.name`           | keyword   | Process name.                                                                                        | `ssh`                                              |                                                            |
-|     | `process.parent.pid`     | long      | Parent process ID.                                                                                   | `4242`                                             |                                                            |
-|     | `process.pid`            | long      | Process ID.                                                                                          | `4242`                                             |                                                            |
-|     | `process.real_group.id`  | keyword   | Unique identifier for the group on the system/platform.                                              |                                                    |                                                            |
-|     | `process.real_user.id`   | keyword   | Unique identifier of the user.                                                                       | `S-1-5-21-202424912787-2692429404-2351956786-1000` |                                                            |
-|     | `process.saved_group.id` | keyword   | Unique identifier for the group on the system/platform.                                              |                                                    |                                                            |
-|     | `process.saved_user.id`  | keyword   | Unique identifier of the user.                                                                       | `S-1-5-21-202424912787-2692429404-2351956786-1000` |                                                            |
-|     | `process.start`          | date      | The time the process started.                                                                        | `2016-05-23T08:05:34.853Z`                         |                                                            |
-|     | `process.user.id`        | keyword   | Unique identifier of the user.                                                                       | `S-1-5-21-202424912787-2692429404-2351956786-1000` |                                                            |
-| !   | `process.thread.id`      | long      | Thread ID.                                                                                           |                                                    | `thread.group` is **not part of ECS;** but `thread.id` is. |
-| !   | `process.tty`            | object    | Information about the controlling TTY device. If set, the process belongs to an interactive session. |                                                    | Needs clarification                                        |
-| \*  | `process.group.id`       | keyword   | Unique identifier for the effective group on the system/platform.                                    |                                                    |                                                            |
+|    | Field name                      | Data type | Description                                                                                          | Examples                                           | Comments                                                   |
+|----|---------------------------------| --------- | ---------------------------------------------------------------------------------------------------- | -------------------------------------------------- | ---------------------------------------------------------- |
+|    | `agent.*`                       | object    | All the agent fields.                                                                                | `                                                  |
+|    | `@timestamp`                    | date      | Date/time when the event originated.                                                                 | `2016-05-23T08:05:34.853Z`                         |                                                            |
+|    | `process.args`                  | keyword   | Array of process arguments.                                                                          | `["/usr/bin/ssh", "-l", "user", "10.0.0.16"]`      |                                                            |
+|    | `process.command_line`          | wildcard  | process.command_line.                                                                                | `/usr/bin/ssh -l user 10.0.0.16`                   |                                                            |
+|    | `process.name`                  | keyword   | Process name.                                                                                        | `ssh`                                              |                                                            |
+|    | `process.parent.pid`            | long      | Parent process ID.                                                                                   | `4242`                                             |                                                            |
+|    | `process.pid`                   | long      | Process ID.                                                                                          | `4242`                                             |                                                            |
+|    | `process.real_group.id`         | keyword   | Unique identifier for the group on the system/platform.                                              |                                                    |                                                            |
+|    | `process.real_user.id`          | keyword   | Unique identifier of the user.                                                                       | `S-1-5-21-202424912787-2692429404-2351956786-1000` |                                                            |
+|    | `process.saved_group.id`        | keyword   | Unique identifier for the group on the system/platform.                                              |                                                    |                                                            |
+|    | `process.saved_user.id`         | keyword   | Unique identifier of the user.                                                                       | `S-1-5-21-202424912787-2692429404-2351956786-1000` |                                                            |
+|    | `process.start`                 | date      | The time the process started.                                                                        | `2016-05-23T08:05:34.853Z`                         |                                                            |
+|    | `process.user.id`               | keyword   | Unique identifier of the user.                                                                       | `S-1-5-21-202424912787-2692429404-2351956786-1000` |                                                            |
+| !  | `process.thread.id`             | long      | Thread ID.                                                                                           |                                                    | `thread.group` is **not part of ECS;** but `thread.id` is. |
+|    | `process.tty.char_device.major` | object    | Information about the controlling TTY device. If set, the process belongs to an interactive session. |                                                    | Needs clarification                                        |
+| \* | `process.group.id`              | keyword   | Unique identifier for the effective group on the system/platform.                                    |                                                    |                                                            |
 
 \* Custom field
 
@@ -50,7 +50,6 @@ Based on ECS:
 | x   | session    | `process.session`         | **No ECS mapping** | Session ID                                                                                           |         | **Not part of ECS;** Needs clarification.                  |
 | x   | nlwp       | `process.nlwp`            | **No ECS mapping** | Number of light-weight processes                                                                     |         | **Not part of ECS;** Needs clarification.                  |
 | !   | tgid       | `process.thread.id`       | **No ECS mapping** | Thread ID ID                                                                                         |         | `thread.group` is **not part of ECS;** but `thread.id` is. |
-| !   | tty        | `process.tty`             | object             | Information about the controlling TTY device. If set, the process belongs to an interactive session. |         | Needs clarification                                        |
 | x   | processor  | `host.cpu.processor`      | **No ECS mapping** | Processor number                                                                                     |         | No ECS field refers to the core number of the CPU.         |
 
 </p>
@@ -106,6 +105,11 @@ fields:
       thread:
         fields:
           id: ""
+      tty:
+        fields:
+          char_device:
+            fields:
+              major: ""
 ```
 
 ### Index settings

--- a/ecs/states-inventory-processes/event-generator/event_generator.py
+++ b/ecs/states-inventory-processes/event-generator/event_generator.py
@@ -152,6 +152,11 @@ def generate_random_process():
         },
         'user': {
             'id': f'userid{random.randint(0, 9999)}'
+        },
+        'tty': {
+            'char_device': {
+                'major': random.randint(0, 5)
+            }
         }
     }
     return process

--- a/ecs/states-inventory-processes/fields/subset.yml
+++ b/ecs/states-inventory-processes/fields/subset.yml
@@ -45,3 +45,8 @@ fields:
       thread:
         fields:
           id: ""
+      tty:
+        fields:
+          char_device:
+            fields:
+              major: ""


### PR DESCRIPTION
### Description
Add ECS field `tty.char_device.major` to state-inventory-processes mapping, and update the corresponding  event generator.

### Related Issues
Resolves #582 
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
