### PR TITLE
Allow dynamic fields on alerts mapping settings

### DIFF
--- a/ecs/alerts/fields/mapping-settings.json
+++ b/ecs/alerts/fields/mapping-settings.json
@@ -1,4 +1,4 @@
 {
-    "dynamic": "strict",
+    "dynamic": true,
     "date_detection": false
 }

--- a/ecs/docs/alerts.md
+++ b/ecs/docs/alerts.md
@@ -611,7 +611,7 @@ fields:
         fields: "*"
 ```
 
-###
+### Template settings
 
 ```json
 {
@@ -631,5 +631,14 @@ fields:
       }
     }
   }
+}
+```
+
+### Mapping settings
+
+```json
+{
+    "dynamic": true,
+    "date_detection": false
 }
 ```


### PR DESCRIPTION
### Description
Enable dynamic fields on `alerts` ECS mapping settings, and update the corresponding ECS documentation 

### Related Issues
Resolves https://github.com/wazuh/wazuh-indexer-plugins/issues/177
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
