### PR TITLE
Fix process.command_line mapping

### DIFF
--- a/ecs/generate.sh
+++ b/ecs/generate.sh
@@ -24,8 +24,8 @@ remove_multi_fields() {
     .mappings.properties.host.properties.os.properties.full.fields,
     .mappings.properties.host.properties.os.properties.name.fields,
     .mappings.properties.process.properties.command_line.fields,
-    .mappings.properties.process.properties.name.fields
-    .mappings.properties.vulnerability.properties.description.fields,
+    .mappings.properties.process.properties.name.fields,
+    .mappings.properties.vulnerability.properties.description.fields
   )' "$IN_FILE" > "$OUT_FILE"
 }
 

--- a/ecs/generate.sh
+++ b/ecs/generate.sh
@@ -50,6 +50,10 @@ generate_mappings() {
   # Replace "constant_keyword" type (not supported by OpenSearch) with "keyword"
   echo "Replacing \"constant_keyword\" type with \"keyword\""
   find "$OUT_DIR" -type f -exec sed -i 's/constant_keyword/keyword/g' {} \;
+  
+  # Replace "wildcard" type (showing as "unknown" on dashboard) with "keyword"
+  echo "Replacing \"wildcard\" type with \"keyword\""
+  find "$OUT_DIR" -type f -exec sed -i 's/wildcard/keyword/g' {} \;
 
   # Replace "flattened" type (not supported by OpenSearch) with "flat_object"
   echo "Replacing \"flattened\" type with \"flat_object\""

--- a/ecs/generate.sh
+++ b/ecs/generate.sh
@@ -21,7 +21,8 @@ remove_multi_fields() {
   jq 'del(
     .mappings.properties.host.properties.os.properties.full.fields,
     .mappings.properties.host.properties.os.properties.name.fields,
-    .mappings.properties.vulnerability.properties.description.fields
+    .mappings.properties.vulnerability.properties.description.fields,
+    .mappings.properties.process.properties.command_line.fields
   )' "$IN_FILE" > "$OUT_FILE"
 }
 

--- a/ecs/generate.sh
+++ b/ecs/generate.sh
@@ -19,10 +19,13 @@ remove_multi_fields() {
   local OUT_FILE="$2"
 
   jq 'del(
+    .mappings.properties.agent.properties.host.properties.os.properties.full.fields,
+    .mappings.properties.agent.properties.host.properties.os.properties.name.fields,
     .mappings.properties.host.properties.os.properties.full.fields,
     .mappings.properties.host.properties.os.properties.name.fields,
+    .mappings.properties.process.properties.command_line.fields,
+    .mappings.properties.process.properties.name.fields
     .mappings.properties.vulnerability.properties.description.fields,
-    .mappings.properties.process.properties.command_line.fields
   )' "$IN_FILE" > "$OUT_FILE"
 }
 


### PR DESCRIPTION
### Description
This PR fixes the `process.command_line` field showing up as `unknown` in the dashboard.

### Related Issues
Resolves #585 

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
