### PR TITLE
Move to ubuntu-24.04 runners

### DIFF
--- a/.github/workflows/assemble.yml
+++ b/.github/workflows/assemble.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11, 17, 21 ]
-        os: [ubuntu-latest, windows-latest, macos-13]
+        os: [ubuntu-24.04, windows-latest, macos-13]
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     steps:

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   backport:
     name: Backport
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     # Only react to merged PRs for security reasons.
     # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
     if: >

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,7 +133,7 @@ jobs:
       fail-fast: false
       matrix:
         plugins: ["setup", "command-manager"]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       plugin_name: wazuh-indexer-${{ matrix.plugins }}
     outputs:
@@ -176,7 +176,7 @@ jobs:
 
   build-reporting-plugin:
     if: ${{ inputs.reporting_plugin_ref != '' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       hash: ${{ steps.save-hash.outputs.hash }}
     env:

--- a/.github/workflows/changelog_verifier.yml
+++ b/.github/workflows/changelog_verifier.yml
@@ -7,7 +7,7 @@ jobs:
   # Enforces the update of a changelog file on every pull request
   verify-changelog:
     if: github.repository == 'opensearch-project/OpenSearch'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
     #   - https://gh.io/supported-runners-and-hardware-resources
     #   - https://gh.io/using-larger-runners
     # Consider using larger runners for possible analysis time improvements.
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-24.04' }}
     timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 360 }}
     permissions:
       actions: read

--- a/.github/workflows/copy-linked-issue-labels.yml
+++ b/.github/workflows/copy-linked-issue-labels.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   copy-issue-labels:
     if: github.repository == 'opensearch-project/OpenSearch'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       issues: read
       contents: read

--- a/.github/workflows/create-documentation-issue.yml
+++ b/.github/workflows/create-documentation-issue.yml
@@ -9,7 +9,7 @@ env:
 jobs:
   create-issue:
     if: ${{ github.event.label.name == 'needs-documentation' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: Create Documentation Issue
     steps:
       - name: GitHub App token

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   dco-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Get PR Commits

--- a/.github/workflows/delete_backport_branch.yml
+++ b/.github/workflows/delete_backport_branch.yml
@@ -6,7 +6,7 @@ on:
   
 jobs:
   delete-branch:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     if: github.repository == 'opensearch-project/OpenSearch' && startsWith(github.event.pull_request.head.ref,'backport/')

--- a/.github/workflows/dependabot_pr.yml
+++ b/.github/workflows/dependabot_pr.yml
@@ -3,7 +3,7 @@ on: pull_request
 
 jobs:
   dependabot:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       pull-requests: write
       contents: write

--- a/.github/workflows/detect-breaking-change.yml
+++ b/.github/workflows/detect-breaking-change.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   detect-breaking-change:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-java@v4

--- a/.github/workflows/gradle-check.yml
+++ b/.github/workflows/gradle-check.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   check-files:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       RUN_GRADLE_CHECK: ${{ steps.changed-files-specific.outputs.any_changed }}
     steps:
@@ -38,7 +38,7 @@ jobs:
       contents: read # to fetch code (actions/checkout)
       pull-requests: write # to create or update comment (peter-evans/create-or-update-comment)
       issues: write # To create an issue if check fails on push.
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 130
     steps:
       - name: Checkout OpenSearch repo
@@ -166,7 +166,7 @@ jobs:
   check-result:
     needs: [check-files, gradle-check]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Fail if gradle-check fails
         if: ${{ needs.check-files.outputs.RUN_GRADLE_CHECK && needs.gradle-check.result == 'failure' }}

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -7,7 +7,7 @@ permissions:
 jobs:
   linkchecker:
     if: github.repository == 'opensearch-project/OpenSearch'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/lucene-snapshots.yml
+++ b/.github/workflows/lucene-snapshots.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   publish-snapshots:
     if: github.repository == 'opensearch-project/OpenSearch'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:
       id-token: write

--- a/.github/workflows/poc-checklist.yml
+++ b/.github/workflows/poc-checklist.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   add-comment:
     if: github.event.label.name == 'poc'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       issues: write
     steps:

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11, 17, 21, 23 ]
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
+        os: [ubuntu-24.04, windows-latest, macos-latest, macos-13]
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}

--- a/.github/workflows/publish-maven-snapshots.yml
+++ b/.github/workflows/publish-maven-snapshots.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build-and-publish-snapshots:
     if: github.repository == 'opensearch-project/OpenSearch'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     permissions:
       id-token: write

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -9,7 +9,7 @@ permissions: {}
 jobs:
   build:
     if: github.repository == 'opensearch-project/OpenSearch'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: GitHub App token
         id: github_app_token

--- a/.github/workflows/version_check.yml
+++ b/.github/workflows/version_check.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   check-version:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/wrapper.yml
+++ b/.github/workflows/wrapper.yml
@@ -5,7 +5,7 @@ jobs:
   validate:
     name: Validate
     if: github.repository == 'opensearch-project/OpenSearch'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: gradle/wrapper-validation-action@v3


### PR DESCRIPTION
### Description
This PR modifies all references to the GHA `ubuntu-latest` runner to `ubuntu-24.04`.

### Related Issues
Resolves #578 

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.
