### PR TITLE
Update generate.sh to replace wildcard and match_only_text with keyword

### DIFF
--- a/ecs/generate.sh
+++ b/ecs/generate.sh
@@ -54,6 +54,10 @@ generate_mappings() {
   # Replace "wildcard" type (showing as "unknown" on dashboard) with "keyword"
   echo "Replacing \"wildcard\" type with \"keyword\""
   find "$OUT_DIR" -type f -exec sed -i 's/wildcard/keyword/g' {} \;
+  
+  # Replace "match_only_text" type (showing as "unknown" on dashboard) with "keyword"
+  echo "Replacing \"match_only_text\" type with \"keyword\""
+  find "$OUT_DIR" -type f -exec sed -i 's/match_only_text/keyword/g' {} \;
 
   # Replace "flattened" type (not supported by OpenSearch) with "flat_object"
   echo "Replacing \"flattened\" type with \"flat_object\""


### PR DESCRIPTION
### Description
This PR updates the mappings generator script to swap `wildcard` and `match_only_text` mappings with `keyword` ones in order to work around a known OpenSearch dashboards bug.

### Related Issues
Resolves #590 

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.