### PR TITLE
Export missing variables to the Docker container to build packages

### DIFF
--- a/docker/builder/builder.sh
+++ b/docker/builder/builder.sh
@@ -4,7 +4,7 @@
 # Requires Docker
 # Script usage: bash ./builder.sh
 
-set -ex
+set -e
 
 # ====
 # Checks that the script is run from the intended location

--- a/docker/builder/builder.sh
+++ b/docker/builder/builder.sh
@@ -4,7 +4,7 @@
 # Requires Docker
 # Script usage: bash ./builder.sh
 
-set -e
+set -ex
 
 # ====
 # Checks that the script is run from the intended location
@@ -103,6 +103,12 @@ function main() {
     VERSION=$(cat VERSION)
     export REPO_PATH
     export VERSION
+    export INDEXER_PLUGINS_BRANCH
+    export INDEXER_REPORTING_BRANCH
+    export REVISION
+    export IS_STAGE
+    export DISTRIBUTION
+    export ARCHITECTURE
 
     parse_args "${@}"
 


### PR DESCRIPTION
### Description
This PR fixes #560, as the variables set to build packages in the `builder.sh` script were not being passed to the Docker container to build the package, so it was always using the default values. 

### Related Issues
Resolves #522

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
