### PR TITLE
Add script and workflow to build Docker images

### DIFF
--- a/.github/workflows/build-push-docker-image.yml
+++ b/.github/workflows/build-push-docker-image.yml
@@ -115,6 +115,6 @@ jobs:
           QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
           QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
         run: |
-          bash build-scripts/build-and-push-docker-image.sh -n ${{ needs.call-build-workflow.outputs }}
+          bash build-scripts/build-and-push-docker-image.sh -n ${{ needs.call-build-workflow.outputs.name }}
 
         # echo ${{ needs.job1.outputs.firstword }}

--- a/.github/workflows/build-push-docker-image.yml
+++ b/.github/workflows/build-push-docker-image.yml
@@ -8,7 +8,12 @@ on:
   # For testing purposes. Must be removed before merging.
   push:
     branches:
-      524-automate-generation-of-docker-images
+      - 524-automate-generation-of-docker-images
+  pull_request:
+    branches:
+      - "master" 
+    paths:
+      - ".github/workflows/build-push-docker-image.yml"
   workflow_dispatch:
     inputs:
       revision:

--- a/.github/workflows/build-push-docker-image.yml
+++ b/.github/workflows/build-push-docker-image.yml
@@ -1,0 +1,120 @@
+run-name: Build Wazuh Indexer Docker image | ${{ inputs.id }}
+name: Build and push Docker image
+
+# This workflow runs when any of the following occur:
+# - Run manually
+# - Invoked from another workflow
+on:
+  workflow_dispatch:
+    inputs:
+      revision:
+        description: "Revision number of the package."
+        type: string
+        default: "0"
+        required: false
+      is_stage:
+        description: "Enable to use the release naming nomenclature."
+        type: boolean
+        default: false
+      id:
+        description: "ID used to identify the workflow uniquely."
+        type: string
+        required: false
+      wazuh_plugins_ref:
+        description: "Branch, commit or tag for the wazuh-indexer-plugins repository."
+        type: string
+        default: "master"
+        required: false
+      reporting_plugin_ref:
+        description: "Branch, commit or tag for the wazuh-indexer-reporting repository."
+        type: string
+        default: "master"
+        required: false
+  workflow_call:
+    inputs:
+      revision:
+        description: "Revision number of the package."
+        type: string
+        default: "0"
+        required: false
+      is_stage:
+        description: "Enable to use the release naming nomenclature."
+        type: boolean
+        default: false
+      id:
+        description: "ID used to identify the workflow uniquely."
+        type: string
+        required: false
+      wazuh_plugins_ref:
+        description: "Branch, commit or tag for the wazuh-indexer-plugins repository."
+        type: string
+        default: "master"
+        required: false
+      reporting_plugin_ref:
+        description: "Branch, commit or tag for the wazuh-indexer-reporting repository."
+        type: string
+        default: "master"
+        required: false
+    secrets:
+      QUAY_USERNAME:
+        required: true
+        description: "Quay.io username"
+      QUAY_TOKEN:
+        required: true
+        description: "Quay.io token"
+
+# ==========================
+# Bibliography
+# ==========================
+#
+# * Reusable workflows: limitations
+#   | https://docs.github.com/en/actions/using-workflows/reusing-workflows#limitations
+# * Using matrix in reusable workflows:
+#   | https://docs.github.com/en/actions/using-workflows/reusing-workflows#using-a-matrix-strategy-with-a-reusable-workflow
+# * Reading input from the called workflow
+#   | https://docs.github.com/en/enterprise-cloud@latest/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_callinputs
+# * Ternary operator
+#   | https://docs.github.com/en/actions/learn-github-actions/expressions#example
+
+jobs:
+  call-build-workflow:
+    uses: ./.github/workflows/build.yml
+    with:
+      revision: ${{ inputs.revision }}
+      is_stage: ${{ inputs.is_stage }}
+      distribution: '[ "tar" ]'
+      architecture: '[ "x64" ]'
+      id: ${{ inputs.id }}
+      wazuh_plugins_ref: ${{ inputs.wazuh_plugins_ref }}
+      reporting_plugin_ref: ${{ inputs.reporting_plugin_ref }}
+    secrets: inherit
+
+  build-and-push-docker-image:
+    needs: [call-build-workflow]
+    runs-on: ubuntu-24.04
+    env:
+      docker_path: ./docker/prod
+    steps:
+      - uses: actions/checkout@v4
+
+      # Download tarball
+      - name: Download tarball
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{env.docker_path }}
+          merge-multiple: true
+      
+      - name: Display structure of downloaded files
+        run: ls -lR ${{env.docker_path }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        env:
+          QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+          QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
+        run: |
+          bash build-scripts/build-and-push-docker-image.sh -n ${{ needs.call-build-workflow.outputs }}
+
+        # echo ${{ needs.job1.outputs.firstword }}

--- a/.github/workflows/build-push-docker-image.yml
+++ b/.github/workflows/build-push-docker-image.yml
@@ -5,15 +5,6 @@ name: Build and push Docker image
 # - Run manually
 # - Invoked from another workflow
 on:
-  # For testing purposes. Must be removed before merging.
-  push:
-    branches:
-      - '524-automate-generation-of-docker-images'
-  pull_request:
-    branches:
-      - 'master' 
-    paths:
-      - '.github/workflows/build-push-docker-image.yml'
   workflow_dispatch:
     inputs:
       revision:

--- a/.github/workflows/build-push-docker-image.yml
+++ b/.github/workflows/build-push-docker-image.yml
@@ -8,12 +8,12 @@ on:
   # For testing purposes. Must be removed before merging.
   push:
     branches:
-      - 524-automate-generation-of-docker-images
+      - '524-automate-generation-of-docker-images'
   pull_request:
     branches:
-      - "master" 
+      - 'master' 
     paths:
-      - ".github/workflows/build-push-docker-image.yml"
+      - '.github/workflows/build-push-docker-image.yml'
   workflow_dispatch:
     inputs:
       revision:

--- a/.github/workflows/build-push-docker-image.yml
+++ b/.github/workflows/build-push-docker-image.yml
@@ -103,7 +103,7 @@ jobs:
         with:
           path: ${{env.docker_path }}
           merge-multiple: true
-      
+
       - name: Display structure of downloaded files
         run: ls -lR ${{env.docker_path }}
 
@@ -116,5 +116,3 @@ jobs:
           QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
         run: |
           bash build-scripts/build-and-push-docker-image.sh -n ${{ needs.call-build-workflow.outputs.name }}
-
-        # echo ${{ needs.job1.outputs.firstword }}

--- a/.github/workflows/build-push-docker-image.yml
+++ b/.github/workflows/build-push-docker-image.yml
@@ -5,6 +5,10 @@ name: Build and push Docker image
 # - Run manually
 # - Invoked from another workflow
 on:
+  # For testing purposes. Must be removed before merging.
+  push:
+    branches:
+      524-automate-generation-of-docker-images
   workflow_dispatch:
     inputs:
       revision:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -222,7 +222,7 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.matrix.outputs.matrix) }}
     outputs:
-      package_name: ${{ steps.package.outputs.name }}
+      name: ${{ steps.package.outputs.name }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,6 +97,10 @@ on:
       CI_INTERNAL_DEVELOPMENT_BUCKET_USER_SECRET_KEY:
         required: true
         description: "AWS user secret key"
+    outputs:
+      name:
+        description: Name of the package built.
+        value: ${{ jobs.build.outputs.name }}
 
 # ==========================
 # Bibliography

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -221,6 +221,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.matrix.outputs.matrix) }}
+    outputs:
+      package_name: ${{ steps.package.outputs.name }}
     steps:
       - uses: actions/checkout@v4
 

--- a/build-scripts/README.md
+++ b/build-scripts/README.md
@@ -39,6 +39,28 @@ The resulting package will be stored at `wazuh-indexer/artifacts/dist`.
 
 > The `STAGE` option defines the naming of the package. When set to `false`, the package will be unequivocally named with the commits' SHA of the `wazuh-indexer`, `wazuh-indexer-plugins` and `wazuh-indexer-reporting` repositories, in that order. For example: `wazuh-indexer_5.0.0-0_x86_64_aff30960363-846f143-494d125.rpm`.
 
-## Building wazuh-indexer docker images
+## Building wazuh-indexer Docker images
 
-> TBD. For manual building refer to [our Docker containers guide](../docker/README.md).
+The `build-and-push-docker-image.sh` script automates the process to build and push Wazuh Indexer Docker images to our repository in quay.io. The script takes serveral parameters. Use the `-h` option to display them.
+
+The Docker image is built from a wazuh-indexer tarball (tar.gz), which must be present in the same folder as the Dockerfile in `wazuh-indexer/docker/prod`.
+
+To push images, credentials must be set at environment level:
+
+- QUAY_USERNAME
+- QUAY_TOKEN
+
+```bash
+Usage: build-scripts/build-and-push-docker-image.sh [args]
+
+Arguments:
+-n NAME         [required] Tarball name.
+-r REVISION     [Optional] Revision qualifier, default is 0.
+-h help
+```
+
+The script will stop if the credentials are not set, or if any of the required parameters are not provided.
+
+This script is used in the `build-push-docker-image.yml` **GitHub Workflow**, which is used to automate the process even more. When possible, **prefer this method**.
+
+For manual building refer to [our Docker containers guide](../docker/README.md).

--- a/build-scripts/build-and-push-docker-image.sh
+++ b/build-scripts/build-and-push-docker-image.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+
+# This script builds and pushes wazuh-indexer docker images to the quay.io registry.
+# The Docker image is built from a wazuh-indexer tarball (tar.gz), which must be 
+# present in the same folder as the Dockerfile in wazuh-indexer/docker/prod.
+# For addtional information, read these documents:
+#   - wazuh-indexer/docker/README.md
+#   - wazuh-indexer/build-scripts/README.md
+#
+# To push images, credentials must be set at environment level:
+#  - QUAY_USERNAME
+#  - QUAY_TOKEN
+# 
+# Usage: build-scripts/build-and-push-docker-image.sh [args]
+# 
+# Arguments:
+# -n NAME         [required] Tarball name.
+# -r REVISION     [Optional] Revision qualifier, default is 0.
+# -h help
+
+set -e
+
+DOCKER_REGISTRY="quay.io"
+DOCKER_REPOSITORY="$DOCKER_REGISTRY/wazuh/wazuh-indexer"
+
+# ====
+# Usage.
+# ====
+function usage() {
+    echo "Usage: $0 [args]"
+    echo ""
+    echo "Arguments:"
+    echo -e "-n NAME    \t[required] Tarball name."
+    echo -e "-r REVISION\t[Optional] Revision qualifier, default is 0."
+    echo -e "-h help"
+}
+
+# ====
+# Exit with failure function.
+# ====
+function fail() {
+    echo "Required environment variable is not set: $1"
+    exit 1
+}
+
+# ====
+# Parse arguments
+# ====
+function parse_args() {
+
+    while getopts ":n:r:h" arg; do
+        case $arg in
+        h)
+            usage
+            exit 1
+            ;;
+        n)
+            TARBALL=$OPTARG
+            ;;
+        r)
+            REVISION=$OPTARG
+            ;;
+        :)
+            echo "Error: -${OPTARG} requires an argument"
+            usage
+            exit 1
+            ;;
+        ?)
+            echo "Invalid option: -${arg}"
+            exit 1
+            ;;
+        esac
+    done
+
+    if [ -z "$TARBALL" ]; then
+        echo "Missing required argument 'TARBALL'"
+        echo ""
+        usage
+        exit 1
+    fi
+
+    REVISION="${REVISION:-0}"
+    VERSION=$(<VERSION)
+}
+
+# ====
+# Main function
+# ====
+function main() {
+    # Check required environment variables are set. Exit otherwise.
+    [[ -z "${QUAY_USERNAME}" ]] && fail "QUAY_USERNAME"
+    [[ -z "${QUAY_TOKEN}" ]] && fail "QUAY_TOKEN"
+
+    # Parse args
+    parse_args "${@}"
+
+    # Login to the registry.
+    docker login -u="${QUAY_USERNAME}" -p="${QUAY_TOKEN}" "${DOCKER_REGISTRY}"
+
+    # Build the Docker image.
+    local dockerfile_path="docker/prod"
+    cd ${dockerfile_path}
+    docker build \
+        --build-arg="VERSION=${VERSION}" \
+        --build-arg="INDEXER_TAR_NAME=${TARBALL}" \
+        --tag="${DOCKER_REPOSITORY}:${VERSION}-${REVISION}" \
+        --progress=plain --no-cache .
+
+    # Push the Docker image.
+    docker push "${DOCKER_REPOSITORY}:${VERSION}-${REVISION}"
+}
+
+main "${@}"

--- a/build-scripts/build-and-push-docker-image.sh
+++ b/build-scripts/build-and-push-docker-image.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # This script builds and pushes wazuh-indexer docker images to the quay.io registry.
-# The Docker image is built from a wazuh-indexer tarball (tar.gz), which must be 
+# The Docker image is built from a wazuh-indexer tarball (tar.gz), which must be
 # present in the same folder as the Dockerfile in wazuh-indexer/docker/prod.
 # For addtional information, read these documents:
 #   - wazuh-indexer/docker/README.md
@@ -10,9 +10,9 @@
 # To push images, credentials must be set at environment level:
 #  - QUAY_USERNAME
 #  - QUAY_TOKEN
-# 
+#
 # Usage: build-scripts/build-and-push-docker-image.sh [args]
-# 
+
 # Arguments:
 # -n NAME         [required] Tarball name.
 # -r REVISION     [Optional] Revision qualifier, default is 0.

--- a/docker/README.md
+++ b/docker/README.md
@@ -45,14 +45,16 @@ Refer to [build-scripts/README.md](../build-scripts/README.md) for details about
 The [prod](./prod) folder contains the code to build Docker images. A tarball of `wazuh-indexer` needs to be located at the same level that the Dockerfile. Below there is an example of the command needed to build the image. Set the build arguments and the image tag accordingly.
 
 ```bash
-docker build --build-arg="VERSION=5.0.0" --build-arg="INDEXER_TAR_NAME=wazuh-indexer-5.0.0-1_linux-x64_cfca84f.tar.gz" --tag=wazuh-indexer:5.0.0 --progress=plain --no-cache .
+docker build --build-arg="VERSION=5.0.0" --build-arg="INDEXER_TAR_NAME=wazuh-indexer_5.0.0-0_linux-x64.tar.gz" --tag=wazuh-indexer:5.0.0-0 --progress=plain --no-cache .
 ```
 
 Then, start a container with:
 
 ```bash
-docker run -it --rm wazuh-indexer:5.0.0
+docker run -p 9200:9200 -it --rm quay.io/wazuh/wazuh-indexer:5.0.0-latest
 ```
+
+Refer to [build-scripts/README.md](../build-scripts/README.md) for details about how to build and push Wazuh Indexer Docker images.
 
 <!-- Links -->
 

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -1,5 +1,5 @@
 # Wazuh Docker Copyright (C) 2017, Wazuh Inc. (License GPLv2)
-FROM amazonlinux:2023.3.20240219.0 AS builder
+FROM amazonlinux:2023.6.20241212.0 AS builder
 
 ARG VERSION
 ARG INDEXER_TAR_NAME
@@ -23,7 +23,7 @@ RUN bash config.sh
 # Add entrypoint
 
 ################################################################################
-FROM amazonlinux:2023.3.20240219.0
+FROM amazonlinux:2023.6.20241212.0
 
 ENV USER="wazuh-indexer" \
     GROUP="wazuh-indexer" \


### PR DESCRIPTION
### Description
This PR adds a script and a GitHub Workflow to build `wazuh-indexer` Docker images.

The script takes a tarball as input to build the Docker image, which must be present at same level as the Dockerfile. A custom revision / label can be set ("latest", "0", ...), appended to the wazuh-indexer version, which is read from the VERSION file on the repository.

The GH Workflow reuses the existing workflow to build packages to generate the tar.gz package. Then, on another job, downloads the package to the expected location and invokes the script.

**Build and push the image**
```bash
bash build-scripts/build-and-push-docker-image.sh -n wazuh-indexer_5.0.0-0_linux-x64.tar.gz -r latest
```

**Run the container**
```bash
docker run -p 9200:9200 -it --rm quay.io/wazuh/wazuh-indexer:5.0.0-latest
```

**Result**
![image](https://github.com/user-attachments/assets/b2fb731b-1534-4546-af2f-f3cb22bcec76)

### Related Issues
Resolves #524

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
