### PR TITLE
Make `command.action.args` type `object` instead of `keyword` type value

### DIFF
--- a/ecs/command/event-generator/event_generator.py
+++ b/ecs/command/event-generator/event_generator.py
@@ -44,7 +44,7 @@ def generate_random_command(include_all_fields=False):
         },
         "action": {
             "name": random.choice(["restart", "update","change_group", "apply_policy"]),
-            "args": [f"/path/to/executable/arg{random.randint(1, 10)}"],
+            "args": { "arg1": f"/path/to/executable/arg{random.randint(1, 10)}"},
             "version": f"v{random.randint(1, 5)}"
         },
         "timeout": random.randint(10, 100)

--- a/ecs/command/fields/custom/command.yml
+++ b/ecs/command/fields/custom/command.yml
@@ -33,7 +33,7 @@
       description: >
         The requested action type. Examples: `restart`, `update`, `change_group`, `apply_policy`, ...
     - name: action.args
-      type: keyword
+      type: object
       level: custom
       description: >
         Array of command arguments, starting with the absolute path to the executable.

--- a/ecs/command/fields/custom/command.yml
+++ b/ecs/command/fields/custom/command.yml
@@ -36,7 +36,7 @@
       type: object
       level: custom
       description: >
-        Array of command arguments, starting with the absolute path to the executable.
+        Command arguments object.
     - name: action.version
       type: keyword
       level: custom

--- a/ecs/command/fields/mapping-settings.json
+++ b/ecs/command/fields/mapping-settings.json
@@ -1,4 +1,4 @@
 {
-    "dynamic": "strict",
+    "dynamic": "true",
     "date_detection": false
 }

--- a/ecs/docs/commands.md
+++ b/ecs/docs/commands.md
@@ -19,7 +19,7 @@ This index stores information about the commands executed by the agents. The ind
 | \*  | `command.target.id`      | keyword | Unique identifier of the destination to send the command to.                                                                        |
 | \*  | `command.target.type`    | keyword | The destination type. One of [`group`, `agent`, `server`],                                                                          |
 | \*  | `command.action.name`    | keyword | The requested action type. Examples: `restart`, `update`, `change_group`, `apply_policy`, ...                                       |
-| \*  | `command.action.args`    | Object  | Array of command arguments, starting with the absolute path to the executable.                                                      |
+| \*  | `command.action.args`    | object  | Command arguments. The Object type allows for ad-hoc format of the value.                                                           |
 | \*  | `command.action.version` | keyword | Version of the command's schema.                                                                                                    |
 | \*  | `command.timeout`        | short   | Time window in which the command has to be sent to its target.                                                                      |
 | \*  | `command.status`         | keyword | Status within the Command Manager's context. One of [`pending`, `sent`, `success`, `failure`].                                      |

--- a/ecs/docs/commands.md
+++ b/ecs/docs/commands.md
@@ -19,7 +19,7 @@ This index stores information about the commands executed by the agents. The ind
 | \*  | `command.target.id`      | keyword | Unique identifier of the destination to send the command to.                                                                        |
 | \*  | `command.target.type`    | keyword | The destination type. One of [`group`, `agent`, `server`],                                                                          |
 | \*  | `command.action.name`    | keyword | The requested action type. Examples: `restart`, `update`, `change_group`, `apply_policy`, ...                                       |
-| \*  | `command.action.args`    | keyword | Array of command arguments, starting with the absolute path to the executable.                                                      |
+| \*  | `command.action.args`    | Object  | Array of command arguments, starting with the absolute path to the executable.                                                      |
 | \*  | `command.action.version` | keyword | Version of the command's schema.                                                                                                    |
 | \*  | `command.timeout`        | short   | Time window in which the command has to be sent to its target.                                                                      |
 | \*  | `command.status`         | keyword | Status within the Command Manager's context. One of [`pending`, `sent`, `success`, `failure`].                                      |


### PR DESCRIPTION
### Description
This PR changes `command.action.args` from the `.commands` index template from keyword into `object` to accommodate for various data types, including arrays.

### Related Issues
Resolves #618 

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.
