### PR TITLE
Update Vulnerability Scanner package.size ECS field to unsigned_long for 4.12.0

### DIFF
--- a/ecs/vulnerability-detector/fields/custom/package.yml
+++ b/ecs/vulnerability-detector/fields/custom/package.yml
@@ -1,10 +1,11 @@
 - name: package
   title: Package
   group: 2
-  short: Fields to describe the package relevant to an event.
+  short: These fields contain information about an installed software package.
   description: >
-    The package fields describe information about a package that is
-    relevant to an event.
+    These fields contain information about an installed software package.
+    It contains general information about a package, such as name, version or size.
+    It also contains installation details, such as time or location.
   type: group
   fields:
     - name: size

--- a/ecs/vulnerability-detector/fields/custom/package.yml
+++ b/ecs/vulnerability-detector/fields/custom/package.yml
@@ -1,0 +1,14 @@
+- name: package
+  title: Package
+  group: 2
+  short: Fields to describe the package relevant to an event.
+  description: >
+    The package fields describe information about a package that is
+    relevant to an event.
+  type: group
+  fields:
+    - name: size
+      type: unsigned_long
+      level: custom
+      description: >
+        Size of the package.

--- a/ecs/vulnerability-detector/fields/custom/package.yml
+++ b/ecs/vulnerability-detector/fields/custom/package.yml
@@ -11,4 +11,4 @@
       type: unsigned_long
       level: custom
       description: >
-        Size of the package.
+        Package size in bytes.


### PR DESCRIPTION
### Description
Change vulnerability scanner's package.size from `long` to `unsigned_long`

### Related Issues
Resolves https://github.com/wazuh/wazuh/issues/27979

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
