### PR TITLE
Third-party integrations maintenance

### DIFF
--- a/integrations/README.md
+++ b/integrations/README.md
@@ -27,7 +27,7 @@ We host development environments to support the following integrations:
 
 **Compatibility matrix**
 
-|                | Wazuh | Logstash | OpenSearch | Elastic | Splunk |
-| -------------- | ----- | -------- | ---------- |---------|--------|
-| v1.0           | 4.8.1 | 8.9.0    | 2.14.0     | 8.14.3  | 9.1.4  |
-| Latest version | 4.9.2 | 8.9.0    | 2.18.0     | 8.17.0  | 9.4.0  |
+|                | Wazuh  | Logstash | OpenSearch | Elastic | Splunk |
+| -------------- | ------ | -------- | ---------- | ------- | ------ |
+| v1.0           | 4.8.1  | 8.9.0    | 2.14.0     | 8.14.3  | 9.1.4  |
+| Latest version | 4.10.1 | 8.9.0    | 2.18.0     | 8.17.1  | 9.4.0  |

--- a/integrations/docker/.env
+++ b/integrations/docker/.env
@@ -20,7 +20,7 @@ KIBANA_PORT=5602
 MEM_LIMIT=1073741824
 
 # Wazuh version
-WAZUH_VERSION=4.9.2
+WAZUH_VERSION=4.10.1
 
 # Wazuh Indexer version (Provisionally using OpenSearch)
 WAZUH_INDEXER_VERSION=2.18.0
@@ -41,4 +41,4 @@ LOGSTASH_OSS_VERSION=8.9.0
 SPLUNK_VERSION=9.4.0
 
 # Version of Elastic products
-STACK_VERSION=8.17.0
+STACK_VERSION=8.17.1

--- a/integrations/elastic/README.md
+++ b/integrations/elastic/README.md
@@ -13,10 +13,6 @@ This document describes how to prepare a Docker Compose environment to test the 
    ```bash
    docker compose -f ./docker/compose.indexer-elastic.yml up -d
    ```
-3. If you prefer, you can start the integration with the Wazuh Manager as data source:
-   ```bash
-   docker compose -f ./docker/compose.manager-elastic.yml up -d
-   ```
 
 The Docker Compose project will bring up the following services:
 
@@ -25,18 +21,12 @@ The Docker Compose project will bring up the following services:
 - 1x Logstash
 - 1x Elastic
 - 1x Kibana
-- 1x Wazuh Manager (optional).
 
 For custom configurations, you may need to modify these files:
 
 - [docker/compose.indexer-elastic.yml](../docker/compose.indexer-elastic.yml): Docker Compose file.
 - [docker/.env](../docker/.env): Environment variables file.
 - [elastic/logstash/pipeline/indexer-to-elastic.conf](./logstash/pipeline/indexer-to-elastic.conf): Logstash Pipeline configuration file.
-
-If you opted to start the integration with the Wazuh Manager, you can modify the following files:
-
-- [docker/compose.manager-elastic.yml](../docker/compose.manager-elastic.yml): Docker Compose file.
-- [elastic/logstash/pipeline/manager-to-elastic.conf](./logstash/pipeline/manager-to-elastic.conf): Logstash Pipeline configuration file.
 
 Check the files above for **credentials**, ports, and other configurations.
 

--- a/integrations/opensearch/README.md
+++ b/integrations/opensearch/README.md
@@ -13,10 +13,6 @@ This document describes how to prepare a Docker Compose environment to test the 
    ```bash
    docker compose -f ./docker/compose.indexer-opensearch.yml up -d
    ```
-3. If you prefer, you can start the integration with the Wazuh Manager as data source:
-   ```bash
-   docker compose -f ./docker/compose.manager-opensearch.yml up -d
-   ```
 
 The Docker Compose project will bring up the following services:
 
@@ -25,18 +21,12 @@ The Docker Compose project will bring up the following services:
 - 1x Logstash
 - 1x OpenSearch
 - 1x OpenSearch Dashboards
-- 1x Wazuh Manager (optional).
 
 For custom configurations, you may need to modify these files:
 
 - [docker/compose.indexer-opensearch.yml](../docker/compose.indexer-opensearch.yml): Docker Compose file.
 - [docker/.env](../docker/.env): Environment variables file.
 - [opensearch/logstash/pipeline/indexer-to-opensearch.conf](./logstash/pipeline/indexer-to-opensearch.conf): Logstash Pipeline configuration file.
-
-If you opted to start the integration with the Wazuh Manager, you can modify the following files:
-
-- [docker/compose.manager-opensearch.yml](../docker/compose.manager-opensearch.yml): Docker Compose file.
-- [opensearch/logstash/pipeline/manager-to-opensearch.conf](./logstash/pipeline/manager-to-opensearch.conf): Logstash Pipeline configuration file.
 
 Check the files above for **credentials**, ports, and other configurations.
 

--- a/integrations/splunk/README.md
+++ b/integrations/splunk/README.md
@@ -13,10 +13,6 @@ This document describes how to prepare a Docker Compose environment to test the 
    ```bash
    docker compose -f ./docker/compose.indexer-splunk.yml up -d
    ```
-3. If you prefer, you can start the integration with the Wazuh Manager as data source:
-   ```bash
-   docker compose -f ./docker/compose.manager-splunk.yml up -d
-   ```
 
 The Docker Compose project will bring up the following services:
 
@@ -24,18 +20,12 @@ The Docker Compose project will bring up the following services:
 - 1x Wazuh Indexer (OpenSearch).
 - 1x Logstash
 - 1x Splunk
-- 1x Wazuh Manager (optional).
 
 For custom configurations, you may need to modify these files:
 
 - [docker/compose.indexer-splunk.yml](../docker/compose.indexer-splunk.yml): Docker Compose file.
 - [docker/.env](../docker/.env): Environment variables file.
 - [splunk/logstash/pipeline/indexer-to-splunk.conf](./logstash/pipeline/indexer-to-splunk.conf): Logstash Pipeline configuration file.
-
-If you opted to start the integration with the Wazuh Manager, you can modify the following files:
-
-- [docker/compose.manager-splunk.yml](../docker/compose.manager-splunk.yml): Docker Compose file.
-- [splunk/logstash/pipeline/manager-to-splunk.conf](./logstash/pipeline/manager-to-splunk.conf): Logstash Pipeline configuration file.
 
 Check the files above for **credentials**, ports, and other configurations.
 


### PR DESCRIPTION
### Description
This PR add maintenance operations to the third party integrations with the Indexer, including:

- Bump Wazuh version to 4.10.1.
- Bump Elastic version to 8.17.1.
- Remove documentation about integrations with the manager (no longer maintained).

### Related Issues
Resolves #674 

### Check List

- [x] The Docker Compose project starts without errors.
- [x] The data arrives to the destination.
- [x] All the dashboards can be imported successfully.
- [x] All the dashboards are populated with data.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
