### PR TITLE
Fix build workflow version getter

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -158,7 +158,7 @@ jobs:
 
       - name: Get version
         id: version
-        run: echo "version=$(bash build-scripts/product_version.sh)" >> "$GITHUB_OUTPUT"
+        run: echo "version=$(jq .version VERSION.json)" >> "$GITHUB_OUTPUT"
 
       - name: Build with Gradle
         working-directory: ./plugins/${{ matrix.plugins }}
@@ -201,7 +201,7 @@ jobs:
 
       - name: Get version
         id: version
-        run: echo "version=$(bash build-scripts/product_version.sh)" >> "$GITHUB_OUTPUT"
+        run: echo "version=$(jq .version VERSION.json)" >> "$GITHUB_OUTPUT"
 
       - name: Build with Gradle
         run: ./gradlew build -Dversion=${{ steps.version.outputs.version }} -Drevision=${{ inputs.revision }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -158,7 +158,7 @@ jobs:
 
       - name: Get version
         id: version
-        run: echo "version=$(<VERSION)" >> "$GITHUB_OUTPUT"
+        run: echo "version=$(bash build-scripts/product_version.sh)" >> "$GITHUB_OUTPUT"
 
       - name: Build with Gradle
         working-directory: ./plugins/${{ matrix.plugins }}
@@ -201,7 +201,7 @@ jobs:
 
       - name: Get version
         id: version
-        run: echo "version=$(<VERSION)" >> "$GITHUB_OUTPUT"
+        run: echo "version=$(bash build-scripts/product_version.sh)" >> "$GITHUB_OUTPUT"
 
       - name: Build with Gradle
         run: ./gradlew build -Dversion=${{ steps.version.outputs.version }} -Drevision=${{ inputs.revision }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -158,7 +158,7 @@ jobs:
 
       - name: Get version
         id: version
-        run: echo "version=$(jq .version VERSION.json)" >> "$GITHUB_OUTPUT"
+        run: echo "version=$(jq .version -r VERSION.json)" >> "$GITHUB_OUTPUT"
 
       - name: Build with Gradle
         working-directory: ./plugins/${{ matrix.plugins }}
@@ -201,7 +201,7 @@ jobs:
 
       - name: Get version
         id: version
-        run: echo "version=$(jq .version VERSION.json)" >> "$GITHUB_OUTPUT"
+        run: echo "version=$(jq .version -r VERSION.json)" >> "$GITHUB_OUTPUT"
 
       - name: Build with Gradle
         run: ./gradlew build -Dversion=${{ steps.version.outputs.version }} -Drevision=${{ inputs.revision }}


### PR DESCRIPTION
### Description
The builder workflow was referencing the old format VERSION file to get the version number, where it should be calling the `product_version.sh` script. This PR fixes that issue.

### Related Issues
Closes #718 

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.
