### PR TITLE
Create /var/lib/wazuh-indexer/tmp directory before using it in `RPM` upgrades

### DIFF
--- a/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
+++ b/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
@@ -162,6 +162,7 @@ set -e
 if command -v systemctl >/dev/null && systemctl is-active %{name}.service >/dev/null; then
     echo "Stop existing %{name}.service"
     systemctl --no-reload stop %{name}.service
+    mkdir -p %{tmp_dir}
     touch %{tmp_dir}/wazuh-indexer.restart
 fi
 if command -v systemctl >/dev/null && systemctl is-active %{name}-performance-analyzer.service >/dev/null; then


### PR DESCRIPTION
### Description
This PR modifies the RPM packages `spec` to create the `/var/lib/wazuh-indexer/tmp` directory before using it on upgrades.

### Related Issues
Closes #721 

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.
