### PR TITLE
Fix upgrade backported to 4.11.0

### DIFF
--- a/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
+++ b/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
@@ -162,6 +162,7 @@ set -e
 if command -v systemctl >/dev/null && systemctl is-active %{name}.service >/dev/null; then
     echo "Stop existing %{name}.service"
     systemctl --no-reload stop %{name}.service
+    mkdir -p %{tmp_dir}
     touch %{tmp_dir}/wazuh-indexer.restart
 fi
 if command -v systemctl >/dev/null && systemctl is-active %{name}-performance-analyzer.service >/dev/null; then


### PR DESCRIPTION
### Description
This PR backports the fix to the indexer upgrades breaking due to the missing `/var/lib/wazuh-indexer/tmp` directory to `4.11.0`.

### Related Issues
Resolves #721 

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.
