### PR TITLE
Move restart block to %preun in `rpm`

### DIFF
--- a/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
+++ b/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
@@ -206,6 +206,22 @@ if command -v systemd-tmpfiles > /dev/null; then
     systemd-tmpfiles --create %{name}.conf
 fi
 
+if [ ! -f %{tmp_dir}/wazuh-indexer.restart ]; then
+  # Messages
+  echo "###"
+  echo "### NOT starting on installation, please execute the following statements to configure wazuh-indexer service to start automatically using systemd"
+  echo " sudo systemctl daemon-reload"
+  echo " sudo systemctl enable wazuh-indexer.service"
+  echo "### You can start wazuh-indexer service by executing"
+  echo " sudo systemctl start wazuh-indexer.service"
+  echo "###"
+fi
+
+exit 0
+
+%preun
+set -e
+
 if [ -f %{tmp_dir}/wazuh-indexer.restart ]; then
     rm -f %{tmp_dir}/wazuh-indexer.restart
     if command -v systemctl > /dev/null; then
@@ -215,16 +231,6 @@ if [ -f %{tmp_dir}/wazuh-indexer.restart ]; then
     fi
 fi
 
-# Messages
-echo "### NOT starting on installation, please execute the following statements to configure wazuh-indexer service to start automatically using systemd"
-echo " sudo systemctl daemon-reload"
-echo " sudo systemctl enable wazuh-indexer.service"
-echo "### You can start wazuh-indexer service by executing"
-echo " sudo systemctl start wazuh-indexer.service"
-exit 0
-
-%preun
-set -e
 if command -v systemctl >/dev/null && systemctl is-active %{name}.service >/dev/null; then
     echo "Stop existing %{name}.service"
     systemctl --no-reload stop %{name}.service
@@ -233,6 +239,7 @@ if command -v systemctl >/dev/null && systemctl is-active %{name}-performance-an
     echo "Stop existing %{name}-performance-analyzer.service"
     systemctl --no-reload stop %{name}-performance-analyzer.service
 fi
+
 exit 0
 
 %files -f %{_topdir}/filelist.txt


### PR DESCRIPTION
### Description
This PR fixes an issue with upgrades on `rpm`, where the `wazuh-indexer` service was stopped after an upgrade.

### Related Issues
Closes #723 

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.
