### PR TITLE
Update packages builder to allow the use of "latest" suffix

### DIFF
--- a/.github/workflows/5_builderpackage_indexer.yml
+++ b/.github/workflows/5_builderpackage_indexer.yml
@@ -359,12 +359,9 @@ jobs:
           echo "name=$name" >> $GITHUB_OUTPUT
         id: package_latest
   
-      - name: Upload package to S3 as latest
-        if: ${{ inputs.upload }}
-        run: |
-            mv "artifacts/dist/${{ steps.package.outputs.name }}" "artifacts/dist/${{ steps.package_latest.outputs.name }}"
-            src="artifacts/dist/${{ steps.package_latest.outputs.name }}"
-            dest="s3://packages-dev.internal.wazuh.com/development/wazuh/5.x/main/packages/"
-            aws s3 cp "$src" "$dest"
-            s3uri="${dest}${{ steps.package_latest.outputs.name }}"
-            echo "::notice::S3 URI: ${s3uri}"
+      - name: Upload artifacts as latest
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.package_latest.outputs.name }}
+          path: artifacts/dist/${{ steps.package.outputs.name }}
+          if-no-files-found: error

--- a/.github/workflows/5_builderpackage_indexer.yml
+++ b/.github/workflows/5_builderpackage_indexer.yml
@@ -344,3 +344,27 @@ jobs:
           aws s3 cp "$src" "$dest"
           s3uri="${dest}${{ steps.package.outputs.name }}.sha512"
           echo "::notice::S3 sha512 URI: ${s3uri}"
+
+      - name: Run `baptizer.sh` (latest)
+        run: |
+          name=$(bash build-scripts/baptizer.sh \
+            -a ${{ matrix.architecture }} \
+            -d ${{ matrix.distribution }}  \
+            -r ${{ inputs.revision }} \
+            -l ${{ needs.build-wazuh-plugins.outputs.hash }} \
+            -e ${{ needs.build-reporting-plugin.outputs.hash }} \
+            ${{ inputs.is_stage && '-x' || '' }} \
+            -t
+          )
+          echo "name=$name" >> $GITHUB_OUTPUT
+        id: package_latest
+  
+      - name: Upload package to S3 as latest
+        if: ${{ inputs.upload }}
+        run: |
+            mv "artifacts/dist/${{ steps.package.outputs.name }}" "artifacts/dist/${{ steps.package_latest.outputs.name }}"
+            src="artifacts/dist/${{ steps.package_latest.outputs.name }}"
+            dest="s3://packages-dev.internal.wazuh.com/development/wazuh/5.x/main/packages/"
+            aws s3 cp "$src" "$dest"
+            s3uri="${dest}${{ steps.package_latest.outputs.name }}"
+            echo "::notice::S3 URI: ${s3uri}"

--- a/.github/workflows/5_builderpackage_indexer.yml
+++ b/.github/workflows/5_builderpackage_indexer.yml
@@ -358,10 +358,13 @@ jobs:
           )
           echo "name=$name" >> $GITHUB_OUTPUT
         id: package_latest
-  
-      - name: Upload artifacts as latest
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ steps.package_latest.outputs.name }}
-          path: artifacts/dist/${{ steps.package.outputs.name }}
-          if-no-files-found: error
+
+      - name: Upload package to S3 as latest
+        if: ${{ inputs.upload }}
+        run: |
+            mv "artifacts/dist/${{ steps.package.outputs.name }}" "artifacts/dist/${{ steps.package_latest.outputs.name }}"
+            src="artifacts/dist/${{ steps.package_latest.outputs.name }}"
+            dest="s3://packages-dev.internal.wazuh.com/development/wazuh/5.x/main/packages/"
+            aws s3 cp "$src" "$dest"
+            s3uri="${dest}${{ steps.package_latest.outputs.name }}"
+            echo "::notice::S3 URI: ${s3uri}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased 5.0.x]
 ### Added
-- "latest" sufix option for package building
+- Add "latest" suffix option to name packages. [(#732)](https://github.com/wazuh/wazuh-indexer/pull/732)
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased 5.0.x]
 ### Added
+- "latest" sufix option for package building
 
 ### Dependencies
 

--- a/build-scripts/REFERENCE.md
+++ b/build-scripts/REFERENCE.md
@@ -52,6 +52,7 @@ scripts:
       reporting_hash: Commit hash of the `wazuh-indexer-reporting` repository.
       is_release: if set, uses release naming convention.
       is_min: if set, the package name will start by `wazuh-indexer-min`. Used on the build stage.
+      is_latest: if set, the package commit hash will be replaced by `latest`.
     outputs:
       package: the name of the wazuh-indexer package.
 ```

--- a/build-scripts/baptizer.sh
+++ b/build-scripts/baptizer.sh
@@ -15,7 +15,7 @@ function usage() {
     echo -e "-m MIN\t[Optional] Use naming convention for minimal packages, default is 'false'."
     echo -e "-x RELEASE\t[Optional] Use release naming convention, default is 'false'."
     echo -e "-h help"
-    echo -e "-t LATEST\t[Optional] Use latest naming convention, default is 'false'."
+    echo -e "-t LATEST\t[Optional] Add 'latest' suffix to the package name, default is 'false'."
 }
 
 # ====

--- a/build-scripts/baptizer.sh
+++ b/build-scripts/baptizer.sh
@@ -144,12 +144,12 @@ function get_devel_name() {
     # Add -latest to the prefix if corresponds
     if "$IS_LATEST"; then
         COMMIT_HASH=latest
-    fi
     # Generate composed commit hash
-    if [ -n "$PLUGINS_HASH" ] && [ -n "$REPORTING_HASH" ]; then
+    elif [ -n "$PLUGINS_HASH" ] && [ -n "$REPORTING_HASH" ]; then
         COMMIT_HASH="$GIT_COMMIT"-"$PLUGINS_HASH"-"$REPORTING_HASH"
     fi
     PACKAGE_NAME="$PREFIX"_"$VERSION"-"$REVISION"_"$SUFFIX"_"$COMMIT_HASH"."$EXT"
+    echo $PACKAGE_NAME
 }
 
 # ====

--- a/build-scripts/baptizer.sh
+++ b/build-scripts/baptizer.sh
@@ -15,6 +15,7 @@ function usage() {
     echo -e "-m MIN\t[Optional] Use naming convention for minimal packages, default is 'false'."
     echo -e "-x RELEASE\t[Optional] Use release naming convention, default is 'false'."
     echo -e "-h help"
+    echo -e "-t LATEST\t[Optional] Use latest naming convention, default is 'false'."
 }
 
 # ====
@@ -22,7 +23,7 @@ function usage() {
 # ====
 function parse_args() {
 
-    while getopts ":h:p:a:d:r:l:e:mx" arg; do
+    while getopts ":h:p:a:d:r:l:e:mxt" arg; do
         case $arg in
         h)
             usage
@@ -52,6 +53,9 @@ function parse_args() {
         x)
             IS_RELEASE=true
             ;;
+        t)
+            IS_LATEST=true
+            ;;
         :)
             echo "Error: -${OPTARG} requires an argument"
             usage
@@ -70,6 +74,7 @@ function parse_args() {
     [ -z "$REVISION" ] && REVISION="0"
     [ -z "$IS_MIN" ] && IS_MIN=false
     [ -z "$IS_RELEASE" ] && IS_RELEASE=false
+    [ -z "$IS_LATEST" ] && IS_LATEST=false
 
     case $PLATFORM-$DISTRIBUTION-$ARCHITECTURE in
     linux-tar-x64 | darwin-tar-x64)
@@ -136,11 +141,15 @@ function get_devel_name() {
     if "$IS_MIN"; then
         PREFIX="$PREFIX"-min
     fi
+    # Add -latest to the prefix if corresponds
+    if "$IS_LATEST"; then
+        COMMIT_HASH=latest
+    fi
     # Generate composed commit hash
     if [ -n "$PLUGINS_HASH" ] && [ -n "$REPORTING_HASH" ]; then
         COMMIT_HASH="$GIT_COMMIT"-"$PLUGINS_HASH"-"$REPORTING_HASH"
     fi
-    PACKAGE_NAME="$PREFIX"_"$VERSION"-"$REVISION"_"$SUFFIX"_latest."$EXT"
+    PACKAGE_NAME="$PREFIX"_"$VERSION"-"$REVISION"_"$SUFFIX"_"$COMMIT_HASH"."$EXT"
 }
 
 # ====

--- a/build-scripts/baptizer.sh
+++ b/build-scripts/baptizer.sh
@@ -149,7 +149,6 @@ function get_devel_name() {
         COMMIT_HASH="$GIT_COMMIT"-"$PLUGINS_HASH"-"$REPORTING_HASH"
     fi
     PACKAGE_NAME="$PREFIX"_"$VERSION"-"$REVISION"_"$SUFFIX"_"$COMMIT_HASH"."$EXT"
-    echo $PACKAGE_NAME
 }
 
 # ====

--- a/build-scripts/baptizer.sh
+++ b/build-scripts/baptizer.sh
@@ -140,7 +140,7 @@ function get_devel_name() {
     if [ -n "$PLUGINS_HASH" ] && [ -n "$REPORTING_HASH" ]; then
         COMMIT_HASH="$GIT_COMMIT"-"$PLUGINS_HASH"-"$REPORTING_HASH"
     fi
-    PACKAGE_NAME="$PREFIX"_"$VERSION"-"$REVISION"_"$SUFFIX"_"$COMMIT_HASH"."$EXT"
+    PACKAGE_NAME="$PREFIX"_"$VERSION"-"$REVISION"_"$SUFFIX"_latest."$EXT"
 }
 
 # ====

--- a/build-scripts/builder/builder.sh
+++ b/build-scripts/builder/builder.sh
@@ -26,7 +26,7 @@ function check_project_root_folder() {
 # ====
 function parse_args() {
 
-    while getopts ":p:r:R:s:d:a:Dh" arg; do
+    while getopts ":p:r:R:s:d:a:Dht" arg; do
         case $arg in
         h)
             usage
@@ -53,6 +53,8 @@ function parse_args() {
         D)
             DESTROY=true
             ;;
+        t)
+            IS_LATEST=true
         :)
             echo "Error: -${OPTARG} requires an argument"
             usage
@@ -73,6 +75,7 @@ function parse_args() {
     [ -z "$DISTRIBUTION" ] && DISTRIBUTION="rpm"
     [ -z "$ARCHITECTURE" ] && ARCHITECTURE="x64"
     [ -z "$DESTROY" ] && DESTROY=false
+    [ -z "$IS_LATEST" ] && IS_LATEST="false"
 }
 
 # ====
@@ -89,6 +92,7 @@ function usage() {
     echo -e "-d DISTRIBUTION\t[Optional] Distribution, default is 'rpm'."
     echo -e "-a ARCHITECTURE\t[Optional] Architecture, default is 'x64'."
     echo -e "-D\tDestroy the docker environment"
+    echo -e "-t\tUse latest naming convention, default is 'false'."
     echo -e "-h\tPrint help"
 }
 
@@ -109,6 +113,7 @@ function main() {
     export IS_STAGE
     export DISTRIBUTION
     export ARCHITECTURE
+    export IS_LATEST
 
     parse_args "${@}"
 

--- a/build-scripts/builder/builder.sh
+++ b/build-scripts/builder/builder.sh
@@ -92,7 +92,7 @@ function usage() {
     echo -e "-d DISTRIBUTION\t[Optional] Distribution, default is 'rpm'."
     echo -e "-a ARCHITECTURE\t[Optional] Architecture, default is 'x64'."
     echo -e "-D\tDestroy the docker environment"
-    echo -e "-t\tUse latest naming convention, default is 'false'."
+    echo -e "-t\tAdd 'latest' suffix to the package name, default is 'false'."
     echo -e "-h\tPrint help"
 }
 

--- a/build-scripts/builder/compose.yml
+++ b/build-scripts/builder/compose.yml
@@ -10,6 +10,7 @@ services:
       - INDEXER_REPORTING_BRANCH=${INDEXER_REPORTING_BRANCH:-main}
       - REVISION=${REVISION:-0}
       - IS_STAGE=${IS_STAGE:-false}
+      - IS_LATEST=${IS_LATEST:-false}
       - DISTRIBUTION=${DISTRIBUTION:-rpm}
       - ARCHITECTURE=${ARCHITECTURE:-x64}
     volumes:

--- a/build-scripts/builder/entrypoint.sh
+++ b/build-scripts/builder/entrypoint.sh
@@ -8,6 +8,7 @@ INDEXER_PLUGINS_BRANCH=${INDEXER_PLUGINS_BRANCH:-main}
 INDEXER_REPORTING_BRANCH=${INDEXER_REPORTING_BRANCH:-main}
 REVISION=${REVISION:-0}
 IS_STAGE=${IS_STAGE:-false}
+IS_LATEST=${IS_LATEST:-false}
 DISTRIBUTION=${DISTRIBUTION:-rpm}
 ARCHITECTURE=${ARCHITECTURE:-x64}
 
@@ -90,6 +91,7 @@ package_artifacts() {
     local distribution="$2"
     local revision="$3"
     local is_stage="$4"
+    local is_latest="$5"
 
     local plugins_hash
     local reporting_hash
@@ -108,7 +110,8 @@ package_artifacts() {
         -r "$revision" \
         -l "$plugins_hash" \
         -e "$reporting_hash" \
-        "$(if [ "$is_stage" = "true" ]; then echo "-x"; fi)")
+        "$(if [ "$is_stage" = "true" ]; then echo "-x"; fi)" \
+        "$(if [ "$is_latest" = "true" ]; then echo "-t"; fi)")
 
     echo "Creating package name..."
     package_name=$(bash build-scripts/baptizer.sh \
@@ -117,7 +120,8 @@ package_artifacts() {
         -r "$revision" \
         -l "$plugins_hash" \
         -e "$reporting_hash" \
-        "$(if [ "$is_stage" = "true" ]; then echo "-x"; fi)")
+        "$(if [ "$is_stage" = "true" ]; then echo "-x"; fi)" \
+        "$(if [ "$is_latest" = "true" ]; then echo "-t"; fi)")
 
     echo "Building package..."
     bash build-scripts/build.sh -a "$architecture" -d "$distribution" -n "$package_min_name"
@@ -141,7 +145,7 @@ main() {
     build_plugins "$VERSION" "$REVISION"
     build_reporting "$VERSION" "$REVISION"
     copy_builds "$VERSION" "$REVISION"
-    package_artifacts "$ARCHITECTURE" "$DISTRIBUTION" "$REVISION" "$IS_STAGE"
+    package_artifacts "$ARCHITECTURE" "$DISTRIBUTION" "$REVISION" "$IS_STAGE" "$IS_LATEST"
 
     # Clean the environment
     echo "----------------------------------------"


### PR DESCRIPTION
### Description
The modified workflow duplicates the built packages, now obtaining both "...-<COMMIT_HASH>.<EXT>" and "...latest.<EXT>" artifacts as needed. For doing so, baptizer.sh had to be modified too.

### Related Issues
Resolves #715 

### Check List
- [x] Builds correctly all the packages after executing workflow
- [x] Modifies docker builder accordingly
- [x] Documents changes as needed