### PR TITLE
Update opensearch.yml template and auto-generate creds directory

### DIFF
--- a/.github/workflows/4_builderpackage_indexer_onpush.yml
+++ b/.github/workflows/4_builderpackage_indexer_onpush.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
       - 4.*
+    paths-ignore:
+      - '**.md'
 
 jobs:
   call-build-workflow:

--- a/.github/workflows/5_builderpackage_docker_onpush.yml
+++ b/.github/workflows/5_builderpackage_docker_onpush.yml
@@ -5,6 +5,8 @@ name: Build and push Docker image (on push)
 
 on:
   push:
+    paths-ignore:
+      - '**.md'
 
 jobs:
   call-docker-workflow:

--- a/.github/workflows/5_builderpackage_indexer_onpush.yml
+++ b/.github/workflows/5_builderpackage_indexer_onpush.yml
@@ -5,6 +5,8 @@ name: Build packages (on push)
 
 on:
   push:
+    paths-ignore:
+      - '**.md'
 
 jobs:
   call-build-workflow:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - New quality check workflows [(#753)](https://github.com/wazuh/wazuh-indexer/pull/753)
 ### Dependencies
 
+### Changed
+- Update opensearch.yml template and auto-generate creds directory [(#755)](https://github.com/wazuh/wazuh-indexer/pull/755)
+
 ### Deprecated
 
 ### Removed
 
 ### Fixed
-- Update opensearch.yml template and auto-generate creds directory [(#755)](https://github.com/wazuh/wazuh-indexer/pull/755)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Removed
 
 ### Fixed
+- Update opensearch.yml template and auto-generate creds directory [(#755)](https://github.com/wazuh/wazuh-indexer/pull/755)
 
 ### Security
 

--- a/distribution/packages/src/common/scripts/install-demo-certificates.sh
+++ b/distribution/packages/src/common/scripts/install-demo-certificates.sh
@@ -24,9 +24,9 @@ openssl req -new -key "$TMP_DIR/admin-key.pem" -subj "/C=US/L=California/O=Wazuh
 openssl x509 -req -in "$TMP_DIR/admin.csr" -CA "$TMP_DIR/root-ca.pem" -CAkey "$TMP_DIR/root-ca-key-temp.pem" -CAcreateserial -sha256 -out "$TMP_DIR/admin.pem" -days 3650
 
 # Node cert
-openssl genrsa -out "$TMP_DIR/indexer-key-temp.pem" 2048
-openssl pkcs8 -inform PEM -outform PEM -in "$TMP_DIR/indexer-key-temp.pem" -topk8 -nocrypt -v1 PBE-SHA1-3DES -out "$TMP_DIR/indexer-key.pem"
-openssl req -new -key "$TMP_DIR/indexer-key.pem" -subj "/C=US/L=California/O=Wazuh/OU=Wazuh/CN=node-0.wazuh.indexer" -out "$TMP_DIR/indexer.csr"
+openssl genrsa -out "$TMP_DIR/indexer-1-key-temp.pem" 2048
+openssl pkcs8 -inform PEM -outform PEM -in "$TMP_DIR/indexer-1-key-temp.pem" -topk8 -nocrypt -v1 PBE-SHA1-3DES -out "$TMP_DIR/indexer-1-key.pem"
+openssl req -new -key "$TMP_DIR/indexer-1-key.pem" -subj "/C=US/L=California/O=Wazuh/OU=Wazuh/CN=node-0.wazuh.indexer" -out "$TMP_DIR/indexer.csr"
 cat <<'INDEXER_EXT' >$TMP_DIR/indexer.ext
 subjectAltName = @alt_names
 [alt_names]
@@ -37,7 +37,7 @@ IP.1 = 127.0.0.1
 IP.2 =  0:0:0:0:0:0:0:1
 INDEXER_EXT
 
-openssl x509 -req -in "$TMP_DIR/indexer.csr" -CA "$TMP_DIR/root-ca.pem" -CAkey "$TMP_DIR/root-ca-key-temp.pem" -CAcreateserial -sha256 -out "$TMP_DIR/indexer.pem" -days 3650 -extfile "$TMP_DIR/indexer.ext"
+openssl x509 -req -in "$TMP_DIR/indexer.csr" -CA "$TMP_DIR/root-ca.pem" -CAkey "$TMP_DIR/root-ca-key-temp.pem" -CAcreateserial -sha256 -out "$TMP_DIR/indexer-1.pem" -days 3650 -extfile "$TMP_DIR/indexer.ext"
 
 # Cleanup temporary files
 rm "$TMP_DIR/"*.csr "$TMP_DIR"/*.ext "$TMP_DIR"/*.srl "$TMP_DIR"/*-temp.pem

--- a/distribution/packages/src/deb/debian/postinst
+++ b/distribution/packages/src/deb/debian/postinst
@@ -15,6 +15,7 @@ echo "Running Wazuh Indexer Post-Installation Script"
 
 product_dir=/usr/share/wazuh-indexer
 config_dir=/etc/wazuh-indexer
+certs_dir=${config_dir}/certs
 data_dir=/var/lib/wazuh-indexer
 log_dir=/var/log/wazuh-indexer
 pid_dir=/run/wazuh-indexer
@@ -104,12 +105,14 @@ else
             echo " sudo /etc/init.d/wazuh-indexer start"
         fi
     fi
-    if ! [ -d "${config_dir}/certs" ] && [ -f "${product_dir}/plugins/opensearch-security/tools/install-demo-certificates.sh" ]; then
-        echo "### Installing wazuh-indexer demo certificates in ${config_dir}"
+    # Create the certs directory and if required, install demo certificates.
+    mkdir -p ${certs_dir}
+    if [ "$GENERATE_CERTS" = "true" ] && [ -f "${product_dir}/plugins/opensearch-security/tools/install-demo-certificates.sh" ]; then
+        echo "### Installing wazuh-indexer demo certificates in ${certs_dir}"
         echo " If you are using a custom certificates path, ignore this message"
         echo " See demo certs creation log in ${log_dir}/install_demo_certificates.log"
         bash "${product_dir}/plugins/opensearch-security/tools/install-demo-certificates.sh" >"${log_dir}/install_demo_certificates.log" 2>&1
-        yes | ${product_dir}/jdk/bin/keytool -trustcacerts -keystore ${product_dir}/jdk/lib/security/cacerts -importcert -alias wazuh-root-ca -file ${config_dir}/certs/root-ca.pem > /dev/null 2>&1
+        yes | ${product_dir}/jdk/bin/keytool -trustcacerts -keystore ${product_dir}/jdk/lib/security/cacerts -importcert -alias wazuh-root-ca -file ${certs_dir}/root-ca.pem > /dev/null 2>&1
     fi
 fi
 

--- a/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
+++ b/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
@@ -25,6 +25,7 @@
 # User Define Variables
 %define product_dir %{_datadir}/%{name}
 %define config_dir %{_sysconfdir}/%{name}
+%define certs_dir %{config_dir}/certs
 %define data_dir %{_sharedstatedir}/%{name}
 %define log_dir %{_localstatedir}/log/%{name}
 %define pid_dir %{_localstatedir}/run/%{name}
@@ -278,12 +279,14 @@ else
             echo " sudo /etc/init.d/%{name} start"
         fi
     fi
-    if ! [ -d %{config_dir}/certs ] && [ -f %{product_dir}/plugins/opensearch-security/tools/install-demo-certificates.sh ]; then
-        echo "### Installing %{name} demo certificates in %{config_dir}"
+    # Create the certs directory and if required, install demo certificates.
+    mkdir -p %{certs_dir}
+    if [ "$GENERATE_CERTS" = "true" ] && [ -f %{product_dir}/plugins/opensearch-security/tools/install-demo-certificates.sh ]; then
+        echo "### Installing %{name} demo certificates in %{certs_dir}"
         echo " If you are using a custom certificates path, ignore this message"
         echo " See demo certs creation log in %{log_dir}/install_demo_certificates.log"
         bash %{product_dir}/plugins/opensearch-security/tools/install-demo-certificates.sh > %{log_dir}/install_demo_certificates.log 2>&1
-        yes | /usr/share/%{name}/jdk/bin/keytool -trustcacerts -keystore /usr/share/%{name}/jdk/lib/security/cacerts -importcert -alias wazuh-root-ca -file %{config_dir}/certs/root-ca.pem > /dev/null 2>&1
+        yes | /usr/share/%{name}/jdk/bin/keytool -trustcacerts -keystore /usr/share/%{name}/jdk/lib/security/cacerts -importcert -alias wazuh-root-ca -file %{certs_dir}/root-ca.pem > /dev/null 2>&1
     fi
 fi
 exit 0

--- a/distribution/src/config/opensearch.prod.yml
+++ b/distribution/src/config/opensearch.prod.yml
@@ -1,23 +1,23 @@
-network.host: "0.0.0.0"
-node.name: "node-1"
+network.host: "127.0.0.1"
+node.name: "indexer-1"
 cluster.initial_master_nodes:
-- "node-1"
-#- "node-2"
-#- "node-3"
+- "indexer-1"
+#- "indexer-2"
+#- "indexer-3"
 cluster.name: "wazuh-cluster"
 #discovery.seed_hosts:
-#  - "node-1-ip"
-#  - "node-2-ip"
-#  - "node-3-ip"
+#  - "indexer-1-ip"
+#  - "indexer-2-ip"
+#  - "indexer-3-ip"
 node.max_local_storage_nodes: "3"
 path.data: /var/lib/wazuh-indexer
 path.logs: /var/log/wazuh-indexer
 
-plugins.security.ssl.http.pemcert_filepath: /etc/wazuh-indexer/certs/indexer.pem
-plugins.security.ssl.http.pemkey_filepath: /etc/wazuh-indexer/certs/indexer-key.pem
+plugins.security.ssl.http.pemcert_filepath: /etc/wazuh-indexer/certs/indexer-1.pem
+plugins.security.ssl.http.pemkey_filepath: /etc/wazuh-indexer/certs/indexer-1-key.pem
 plugins.security.ssl.http.pemtrustedcas_filepath: /etc/wazuh-indexer/certs/root-ca.pem
-plugins.security.ssl.transport.pemcert_filepath: /etc/wazuh-indexer/certs/indexer.pem
-plugins.security.ssl.transport.pemkey_filepath: /etc/wazuh-indexer/certs/indexer-key.pem
+plugins.security.ssl.transport.pemcert_filepath: /etc/wazuh-indexer/certs/indexer-1.pem
+plugins.security.ssl.transport.pemkey_filepath: /etc/wazuh-indexer/certs/indexer-1-key.pem
 plugins.security.ssl.transport.pemtrustedcas_filepath: /etc/wazuh-indexer/certs/root-ca.pem
 plugins.security.ssl.http.enabled: true
 plugins.security.ssl.transport.enforce_hostname_verification: false
@@ -28,9 +28,9 @@ plugins.security.authcz.admin_dn:
 plugins.security.check_snapshot_restore_write_privileges: true
 plugins.security.enable_snapshot_restore_privilege: true
 plugins.security.nodes_dn:
-- "CN=node-1,OU=Wazuh,O=Wazuh,L=California,C=US"
-#- "CN=node-2,OU=Wazuh,O=Wazuh,L=California,C=US"
-#- "CN=node-3,OU=Wazuh,O=Wazuh,L=California,C=US"
+- "CN=indexer-1,OU=Wazuh,O=Wazuh,L=California,C=US"
+#- "CN=indexer-2,OU=Wazuh,O=Wazuh,L=California,C=US"
+#- "CN=indexer-3,OU=Wazuh,O=Wazuh,L=California,C=US"
 plugins.security.restapi.roles_enabled:
 - "all_access"
 - "security_rest_api_access"


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Updates the `opensearch.yml` template with the new expected node and certificates names, and modified the DEB and RPM packaging scripts to always create the default certificates directory at installation.  

### Related Issues
Resolves #754 
<!-- List any other related issues here -->

### Validations

- RPM Package is installed with the new configuration and the certs directory is created empty
    ```shellsession
    $ sudo rpm -i wazuh-indexer_5.0.0-0_aarch64_39e79c40-f5ecffe-892e43b.rpm 
    ### NOT starting on installation, please execute the following statements to configure wazuh-indexer service to start automatically using systemd
     sudo systemctl daemon-reload
     sudo systemctl enable wazuh-indexer.service
    ### You can start wazuh-indexer service by executing
     sudo systemctl start wazuh-indexer.service
    
    $ sudo ls /etc/wazuh-indexer/
    certs		   opensearch-notifications	    opensearch-security
    jvm.options	   opensearch-notifications-core    opensearch.yml
    jvm.options.d	   opensearch-observability	    wazuh-indexer-reports-scheduler
    log4j2.properties  opensearch-performance-analyzer
    
    $ sudo ls -a /etc/wazuh-indexer/certs
    .  ..
    ```
    ```yml
    cat /etc/wazuh-indexer/opensearch.yml
    network.host: "127.0.0.1"
    node.name: "indexer-1"
    cluster.initial_master_nodes:
    - "indexer-1"
    #- "indexer-2"
    #- "indexer-3"
    cluster.name: "wazuh-cluster"
    #discovery.seed_hosts:
    #  - "indexer-1-ip"
    #  - "indexer-2-ip"
    #  - "indexer-3-ip"
    node.max_local_storage_nodes: "3"
    path.data: /var/lib/wazuh-indexer
    path.logs: /var/log/wazuh-indexer
    
    plugins.security.ssl.http.pemcert_filepath: /etc/wazuh-indexer/certs/indexer-1.pem
    plugins.security.ssl.http.pemkey_filepath: /etc/wazuh-indexer/certs/indexer-1-key.pem
    plugins.security.ssl.http.pemtrustedcas_filepath: /etc/wazuh-indexer/certs/root-ca.pem
    plugins.security.ssl.transport.pemcert_filepath: /etc/wazuh-indexer/certs/indexer-1.pem
    plugins.security.ssl.transport.pemkey_filepath: /etc/wazuh-indexer/certs/indexer-1-key.pem
    plugins.security.ssl.transport.pemtrustedcas_filepath: /etc/wazuh-indexer/certs/root-ca.pem
    plugins.security.ssl.http.enabled: true
    plugins.security.ssl.transport.enforce_hostname_verification: false
    plugins.security.ssl.transport.resolve_hostname: false
    
    plugins.security.authcz.admin_dn:
    - "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
    plugins.security.check_snapshot_restore_write_privileges: true
    plugins.security.enable_snapshot_restore_privilege: true
    plugins.security.nodes_dn:
    - "CN=indexer-1,OU=Wazuh,O=Wazuh,L=California,C=US"
    #- "CN=indexer-2,OU=Wazuh,O=Wazuh,L=California,C=US"
    #- "CN=indexer-3,OU=Wazuh,O=Wazuh,L=California,C=US"
    plugins.security.restapi.roles_enabled:
    - "all_access"
    - "security_rest_api_access"
    
    plugins.security.system_indices.enabled: true
    plugins.security.system_indices.indices: [".plugins-ml-model", ".plugins-ml-task", ".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-anomaly-results*", ".opendistro-anomaly-detector*", ".opendistro-anomaly-checkpoints", ".opendistro-anomaly-detection-state", ".opendistro-reports-*", ".opensearch-notifications-*", ".opensearch-notebooks", ".opensearch-observability", ".opendistro-asynchronous-search-response*", ".replication-metadata-store"]
    ```
- DEB Package is installed with the new configuration and the certs directory is created
    ```shellsession
    $ sudo dpkg -i wazuh-indexer_5.0.0-0_arm64_39e79c40-f5ecffe-892e43b.deb 
    Selecting previously unselected package wazuh-indexer.
    (Reading database ... 29248 files and directories currently installed.)
    Preparing to unpack wazuh-indexer_5.0.0-0_arm64_bf260dca-f5ecffe-091b8af.deb ...
    Running Wazuh Indexer Pre-Installation Script
    Unpacking wazuh-indexer (5.0.0-0) ...
    Setting up wazuh-indexer (5.0.0-0) ...
    Running Wazuh Indexer Post-Installation Script
    ### NOT starting on installation, please execute the following statements to configure wazuh-indexer service to start automatically using systemd
     sudo systemctl daemon-reload
     sudo systemctl enable wazuh-indexer.service
    ### You can start wazuh-indexer service by executing
     sudo systemctl start wazuh-indexer.service
    
    $ sudo ls /etc/wazuh-indexer/
    certs			       opensearch-observability
    jvm.options		       opensearch-performance-analyzer
    jvm.options.d		       opensearch-security
    log4j2.properties	       opensearch.yml
    opensearch-notifications       wazuh-indexer-reports-scheduler
    opensearch-notifications-core
    
    $ sudo ls -a /etc/wazuh-indexer/certs
    .  ..
    ```
    ```yml
    cat /etc/wazuh-indexer/opensearch.yml
    network.host: "127.0.0.1"
    node.name: "indexer-1"
    cluster.initial_master_nodes:
    - "indexer-1"
    #- "indexer-2"
    #- "indexer-3"
    cluster.name: "wazuh-cluster"
    #discovery.seed_hosts:
    #  - "indexer-1-ip"
    #  - "indexer-2-ip"
    #  - "indexer-3-ip"
    node.max_local_storage_nodes: "3"
    path.data: /var/lib/wazuh-indexer
    path.logs: /var/log/wazuh-indexer
    
    plugins.security.ssl.http.pemcert_filepath: /etc/wazuh-indexer/certs/indexer-1.pem
    plugins.security.ssl.http.pemkey_filepath: /etc/wazuh-indexer/certs/indexer-1-key.pem
    plugins.security.ssl.http.pemtrustedcas_filepath: /etc/wazuh-indexer/certs/root-ca.pem
    plugins.security.ssl.transport.pemcert_filepath: /etc/wazuh-indexer/certs/indexer-1.pem
    plugins.security.ssl.transport.pemkey_filepath: /etc/wazuh-indexer/certs/indexer-1-key.pem
    plugins.security.ssl.transport.pemtrustedcas_filepath: /etc/wazuh-indexer/certs/root-ca.pem
    plugins.security.ssl.http.enabled: true
    plugins.security.ssl.transport.enforce_hostname_verification: false
    plugins.security.ssl.transport.resolve_hostname: false
    
    plugins.security.authcz.admin_dn:
    - "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
    plugins.security.check_snapshot_restore_write_privileges: true
    plugins.security.enable_snapshot_restore_privilege: true
    plugins.security.nodes_dn:
    - "CN=indexer-1,OU=Wazuh,O=Wazuh,L=California,C=US"
    #- "CN=indexer-2,OU=Wazuh,O=Wazuh,L=California,C=US"
    #- "CN=indexer-3,OU=Wazuh,O=Wazuh,L=California,C=US"
    plugins.security.restapi.roles_enabled:
    - "all_access"
    - "security_rest_api_access"
    
    plugins.security.system_indices.enabled: true
    plugins.security.system_indices.indices: [".plugins-ml-model", ".plugins-ml-task", ".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-anomaly-results*", ".opendistro-anomaly-detector*", ".opendistro-anomaly-checkpoints", ".opendistro-anomaly-detection-state", ".opendistro-reports-*", ".opensearch-notifications-*", ".opensearch-notebooks", ".opensearch-observability", ".opendistro-asynchronous-search-response*", ".replication-metadata-store"]
    ```

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
