### PR TITLE
Fix CI Docker environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 - Fix startup errors on STIG compliant systems due to noexec filesystems [(#533)](https://github.com/wazuh/wazuh-indexer/pull/533)
+- Fix CI Docker environment to build packages locallly [(#760)](https://github.com/wazuh/wazuh-indexer/pull/760)
 
 ### Security
 - Migration to OpenSearch 2.19.0 (JDK 21 and Gradle 8.2) [(#702)](https://github.com/wazuh/wazuh-indexer/pull/702)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 - Fix startup errors on STIG compliant systems due to noexec filesystems [(#533)](https://github.com/wazuh/wazuh-indexer/pull/533)
-- Fix CI Docker environment to build packages locallly [(#760)](https://github.com/wazuh/wazuh-indexer/pull/760)
+- Fix CI Docker environment [(#760)](https://github.com/wazuh/wazuh-indexer/pull/760)
 
 ### Security
 - Migration to OpenSearch 2.19.0 (JDK 21 and Gradle 8.2) [(#702)](https://github.com/wazuh/wazuh-indexer/pull/702)

--- a/docker/dev/images/Dockerfile
+++ b/docker/dev/images/Dockerfile
@@ -1,10 +1,3 @@
-FROM gradle:8.12.1-jdk23-alpine AS builder
-USER gradle
-WORKDIR /home/wazuh-indexer
-COPY --chown=gradle:gradle . /home/wazuh-indexer
-RUN gradle clean
-
-
 FROM eclipse-temurin:23-jdk-alpine
 RUN apk add git && \
   apk add curl && \
@@ -15,7 +8,8 @@ RUN apk add git && \
   chmod 0775 /home/wazuh-indexer && \
   chown -R 1000:0 /home/wazuh-indexer
 USER wazuh-indexer
-COPY --from=builder --chown=1000:0 /home/wazuh-indexer /home/wazuh-indexer
+COPY --chown=1000:0 . /home/wazuh-indexer
 WORKDIR /home/wazuh-indexer
+RUN ./gradlew clean
 RUN git config --global --add safe.directory /home/wazuh-indexer
 EXPOSE 9200 9300


### PR DESCRIPTION
### Description
This PR fixes the CI Docker environment, used to build wazuh-indexer packages locally.

### Related Issues
Resolves #759

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
