### PR TITLE
Update certificates directory ownership and permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 - Update opensearch.yml template and auto-generate creds directory [(#755)](https://github.com/wazuh/wazuh-indexer/pull/755)
+- Update certificates directory ownership and permissions [(#766)](https://github.com/wazuh/wazuh-indexer/pull/766)
 
 ### Deprecated
 

--- a/distribution/packages/src/deb/debian/postinst
+++ b/distribution/packages/src/deb/debian/postinst
@@ -29,6 +29,7 @@ chown -R wazuh-indexer:wazuh-indexer ${log_dir}
 chown -R wazuh-indexer:wazuh-indexer ${data_dir}
 chown -R wazuh-indexer:wazuh-indexer ${pid_dir}
 chown -R wazuh-indexer:wazuh-indexer ${tmp_dir}
+chown -R wazuh-indexer:wazuh-indexer ${certs_dir}
 
 export OPENSEARCH_PATH_CONF=${OPENSEARCH_PATH_CONF:-${config_dir}}
 # Apply Performance Analyzer settings, as per https://github.com/opensearch-project/opensearch-build/blob/2.18.0/scripts/pkg/build_templates/current/opensearch/deb/debian/postinst#L28-L37
@@ -106,7 +107,6 @@ else
         fi
     fi
     # Create the certs directory and if required, install demo certificates.
-    mkdir -p ${certs_dir}
     if [ "$GENERATE_CERTS" = "true" ] && [ -f "${product_dir}/plugins/opensearch-security/tools/install-demo-certificates.sh" ]; then
         echo "### Installing wazuh-indexer demo certificates in ${certs_dir}"
         echo " If you are using a custom certificates path, ignore this message"

--- a/distribution/packages/src/deb/debmake_install.sh
+++ b/distribution/packages/src/deb/debmake_install.sh
@@ -24,6 +24,7 @@ product_dir="/usr/share/${name}"
 config_dir="/etc/${name}"
 pid_dir="/run/${name}"
 service_dir="/usr/lib/systemd/system"
+certs_dir=${config_dir}/certs
 
 buildroot="${curdir}/debian/${name}"
 
@@ -31,6 +32,7 @@ buildroot="${curdir}/debian/${name}"
 mkdir -p "${buildroot}"
 mkdir -p "${buildroot}${pid_dir}"
 mkdir -p "${buildroot}${product_dir}/plugins"
+mkdir -p "${buildroot}${certs_dir}"
 
 # Install directories/files
 cp -a "${curdir}"/etc "${curdir}"/usr "${curdir}"/var "${buildroot}"/
@@ -71,6 +73,7 @@ fi
 
 # Files that need other permissions
 chmod -c 440 "${buildroot}${product_dir}/VERSION.json"
+chmod -c 500 "${buildroot}${certs_dir}"
 if [ -d "${buildroot}${product_dir}/plugins/opensearch-security" ]; then
 	chmod -c 0740 "${buildroot}${product_dir}"/plugins/opensearch-security/tools/*.sh
 fi

--- a/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
+++ b/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
@@ -83,6 +83,9 @@ mkdir -p %{buildroot}%{config_dir}/opensearch-observability
 mkdir -p %{buildroot}%{config_dir}/wazuh-indexer-reports-scheduler
 mkdir -p %{buildroot}%{product_dir}/performance-analyzer-rca
 
+# Create empty certs directory
+mkdir -p %{buildroot}%{certs_dir}
+
 # Pre-populate PA configs if not present
 if [ ! -f %{buildroot}%{data_dir}/rca_enabled.conf ]; then
     echo 'true' > %{buildroot}%{data_dir}/rca_enabled.conf
@@ -279,8 +282,6 @@ else
             echo " sudo /etc/init.d/%{name} start"
         fi
     fi
-    # Create the certs directory and if required, install demo certificates.
-    mkdir -p %{certs_dir}
     if [ "$GENERATE_CERTS" = "true" ] && [ -f %{product_dir}/plugins/opensearch-security/tools/install-demo-certificates.sh ]; then
         echo "### Installing %{name} demo certificates in %{certs_dir}"
         echo " If you are using a custom certificates path, ignore this message"
@@ -358,6 +359,9 @@ fi
 %attr(750, %{name}, %{name}) %{product_dir}/jdk/lib/jspawnhelper
 %attr(750, %{name}, %{name}) %{product_dir}/jdk/lib/modules
 %attr(750, %{name}, %{name}) %{product_dir}/performance-analyzer-rca/bin/*
+
+# Certificates files permissions
+%attr(500, %{name}, %{name}) %{certs_dir}
 
 %changelog
 * Mon Jun 23 2025 support <info@wazuh.com> - 5.0.0


### PR DESCRIPTION
### Description
Change the default certificates directory ownership to `wazuh-indexer:wazuh-indexer` and set the permissions `500`

### Related Issues
Resolves #754 
<!-- List any other related issues here -->

### Validations

- RPM package is installed, and the directory has the corresponding configuration
    ```Shellsession
    $ sudo ls -ll /etc/wazuh-indexer/ 
    total 36
    dr-x------. 2 wazuh-indexer wazuh-indexer     6 Mar 18 10:57 certs
    ...
    ```
- DEB package is installed, and the directory has the corresponding configuration
    ```Shellsession
    $ sudo ls -ll /etc/wazuh-indexer/ 
    total 60
    dr-x------ 2 wazuh-indexer wazuh-indexer  4096 Mar 18 11:09 certs
    ...
    ```
### Check List
- [X] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.licencese.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
