### PR TITLE
Create a `needrestart` conf file on `deb` postinst phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Removed
 
 ### Fixed
-- Fixed interactive prompt by needrestart [(#770)](https://github.com/wazuh/wazuh-indexer/pull/770)
+- Fix interactive prompt by needrestart [(#770)](https://github.com/wazuh/wazuh-indexer/pull/770)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Removed
 
 ### Fixed
+- Fixed interactive prompt by needrestart [(#770)](https://github.com/wazuh/wazuh-indexer/pull/770)
 
 ### Security
 

--- a/distribution/packages/src/deb/debian/postinst
+++ b/distribution/packages/src/deb/debian/postinst
@@ -59,6 +59,20 @@ if command -v systemd-tmpfiles > /dev/null 2>&1 && systemctl > /dev/null 2>&1; t
     systemd-tmpfiles --create wazuh-indexer.conf > /dev/null 2>&1
 fi
 
+# Avoid needrestart restarts on libraries installs and upgrades
+NEEDRESTART_CONF_DIR="/etc/needrestart/conf.d"
+NEEDRESTART_CONF_FILE="${NEEDRESTART_CONF_DIR}/wazuh-indexer.conf"
+if [ -d "${NEEDRESTART_CONF_DIR}" ]
+then
+	if [ ! -f "${NEEDRESTART_CONF_FILE}" ]
+	then
+		echo "Creating needrestart config file"
+		echo '$nrconf{blacklist_rc} = [ qr(^wazuh-indexer) ];' > "${NEEDRESTART_CONF_FILE}"
+	fi
+fi
+
+
+
 # Check if the script is executed on upgrade
 if [ -n "$2" ]; then
     if [ -f $restart_service ]; then

--- a/distribution/packages/src/deb/debian/prerm
+++ b/distribution/packages/src/deb/debian/prerm
@@ -11,6 +11,20 @@
 
 set -e
 
+# Remove needrestart's configuration file
+# under all prerm actions
+NEEDRESTART_CONF_DIR="/etc/needrestart/conf.d"
+NEEDRESTART_CONF_FILE="${NEEDRESTART_CONF_DIR}/wazuh-indexer.conf"
+if [ -d "${NEEDRESTART_CONF_DIR}" ]
+then
+	if [ -f "${NEEDRESTART_CONF_FILE}" ]
+	then
+		echo "Deleting needrestart config file"
+    rm "${NEEDRESTART_CONF_FILE}"
+	fi
+fi
+
+
 case "$1" in
     upgrade|deconfigure)
     ;;


### PR DESCRIPTION
### Description
This PR updates the debian postinst script to create a `needrestart` file that avoids the service being restarted when a system library is updated.

### Related Issues
Resolves #769 

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.
