### PR TITLE
Change `registry.mtime` to `date`

### DIFF
--- a/ecs/states-fim-registries/fields/custom/registry.yml
+++ b/ecs/states-fim-registries/fields/custom/registry.yml
@@ -35,7 +35,7 @@
       description: >
         SHA-256 hash of the file or registry value content
     - name: mtime
-      type: long
+      type: date
       level: custom
       description: >
         Last modified timestamp of the entity


### PR DESCRIPTION
### Description
This PR changes the type of the `registry.mtime` field to `date`. It was previously set to `long`, but `date` can accommodate both for a unix timestamp style as well as a formatted string type input.

### Related Issues
Resolves #779 

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.