### PR TITLE
Remove custom temporary folder for Java

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # build files
 artifacts/
+.devscripts
 *.deb
 *.rpm
 *.zip
@@ -9,6 +10,7 @@ integrations/amazon-security-lake/package
 
 .java
 .m2
+maven
 
 # intellij files
 .idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Deprecated
 
 ### Removed
-- 
+- Remove custom temporary folder for Java [(#782)](https://github.com/wazuh/wazuh-indexer/pull/782)
 
 ### Fixed
 - 

--- a/distribution/packages/src/common/systemd/wazuh-indexer.service
+++ b/distribution/packages/src/common/systemd/wazuh-indexer.service
@@ -9,7 +9,6 @@ Type=notify
 RuntimeDirectory=wazuh-indexer
 PrivateTmp=true
 Environment=OPENSEARCH_HOME=/usr/share/wazuh-indexer
-Environment=OPENSEARCH_TMPDIR=/var/lib/wazuh-indexer/tmp
 Environment=OPENSEARCH_PATH_CONF=${path.conf}
 Environment=PID_DIR=/run/wazuh-indexer
 Environment=OPENSEARCH_SD_NOTIFY=true

--- a/distribution/packages/src/deb/debian/postinst
+++ b/distribution/packages/src/deb/debian/postinst
@@ -19,7 +19,6 @@ config_dir=/etc/${name}
 data_dir=/var/lib/${name}
 log_dir=/var/log/${name}
 pid_dir=/run/${name}
-tmp_dir=${data_dir}/tmp
 state_file=${config_dir}/.was_active
 
 # Set owner
@@ -28,7 +27,6 @@ chown -R ${name}:${name} ${config_dir}
 chown -R ${name}:${name} ${log_dir}
 chown -R ${name}:${name} ${data_dir}
 chown -R ${name}:${name} ${pid_dir}
-chown -R ${name}:${name} ${tmp_dir}
 
 # Reload systemd
 command -v systemctl >/dev/null && systemctl daemon-reload

--- a/distribution/packages/src/deb/debian/preinst
+++ b/distribution/packages/src/deb/debian/preinst
@@ -14,11 +14,6 @@ set -e
 name="wazuh-indexer"
 config_dir=/etc/${name}
 state_file=${config_dir}/.was_active
-data_dir=/var/lib/${name}
-tmp_dir=${data_dir}/tmp
-
-# Create needed directories
-mkdir -p ${tmp_dir}
 
 echo "Running Wazuh Indexer Pre-Installation Script"
 

--- a/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
+++ b/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
@@ -27,7 +27,6 @@
 %define data_dir %{_sharedstatedir}/%{name}
 %define log_dir %{_localstatedir}/log/%{name}
 %define pid_dir %{_localstatedir}/run/%{name}
-%define tmp_dir %{data_dir}/tmp
 %define state_file %{config_dir}/.was_active
 %{!?_version: %define _version 0.0.0 }
 %{!?_architecture: %define _architecture x86_64 }
@@ -67,7 +66,6 @@ cd %{_topdir} && pwd
 # Create necessary directories
 mkdir -p %{buildroot}%{pid_dir}
 mkdir -p %{buildroot}%{product_dir}/plugins
-mkdir -p %{buildroot}%{tmp_dir}
 
 # Install directories/files
 cp -a etc usr var %{buildroot}

--- a/distribution/src/config/jvm.prod.options
+++ b/distribution/src/config/jvm.prod.options
@@ -81,7 +81,7 @@
 
 # JDK 20+ Incubating Vector Module for SIMD optimizations;
 # disabling may reduce performance on vector optimized lucene
-20:--add-modules=jdk.incubator.vector
+20-:--add-modules=jdk.incubator.vector
 
 # HDFS ForkJoinPool.common() support by SecurityManager
 -Djava.util.concurrent.ForkJoinPool.common.threadFactory=org.opensearch.secure_sm.SecuredForkJoinWorkerThreadFactory


### PR DESCRIPTION
### Description
This PR removes the custom temporary folder for the bundle Java process (defaults to `/var/lib/wazuh-indexer/tmp`) which was causing `needrestart` to track the shared libraries being created there, asking for a `wazuh-indexer` restart after the installation of packages unrelated to Wazuh Indexer.

The default temporary folder provided by `systemd` is used instead.

It also:

- Updates Debian maintainer scripts, following the scripts from OpenSearch 2.19.1. 
- Fixes a typo on `jvm.options` file.

To test this PR, install the package on a system that mounts the `/tmp` folder with the `noexec` flag.

### Related Issues
Resolves #769 

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
