### PR TITLE
Fix RPM upgrade when the wazuh-indexer service is still running

### DIFF
--- a/.github/workflows/build_on_push.yml
+++ b/.github/workflows/build_on_push.yml
@@ -4,9 +4,7 @@ name: Build packages (on push)
 # - On push to branches named after ci/*
 on:
   push:
-    # Sequence of patterns matched against refs/heads
-    branches:
-      - "ci/*"
+
 
 jobs:
   call-build-workflow:

--- a/distribution/packages/src/deb/debian/prerm
+++ b/distribution/packages/src/deb/debian/prerm
@@ -19,10 +19,7 @@ case "$1" in
         # Stop existing service
         if command -v systemctl >/dev/null && systemctl is-active wazuh-indexer.service >/dev/null; then
             echo "Stop existing wazuh-indexer.service"
-            if ! systemctl --no-reload stop wazuh-indexer.service; then
-                echo "Error while stopping the wazuh indexer service" >&2
-                exit 1
-    fi
+            systemctl --no-reload stop wazuh-indexer.service
         fi
         if command -v systemctl >/dev/null && systemctl is-active wazuh-indexer-performance-analyzer.service >/dev/null; then
             echo "Stop existing wazuh-indexer-performance-analyzer.service"

--- a/distribution/packages/src/deb/debian/prerm
+++ b/distribution/packages/src/deb/debian/prerm
@@ -19,7 +19,10 @@ case "$1" in
         # Stop existing service
         if command -v systemctl >/dev/null && systemctl is-active wazuh-indexer.service >/dev/null; then
             echo "Stop existing wazuh-indexer.service"
-            systemctl --no-reload stop wazuh-indexer.service
+            if ! systemctl --no-reload stop wazuh-indexer.service; then
+                echo "Error while stopping the wazuh indexer service" >&2
+                exit 1
+    fi
         fi
         if command -v systemctl >/dev/null && systemctl is-active wazuh-indexer-performance-analyzer.service >/dev/null; then
             echo "Stop existing wazuh-indexer-performance-analyzer.service"

--- a/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
+++ b/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
@@ -228,14 +228,16 @@ if [ -f %{tmp_dir}/wazuh-indexer.restart ]; then
     if command -v systemctl > /dev/null; then
         echo "Restarting wazuh-indexer service..."
         systemctl restart wazuh-indexer.service > /dev/null 2>&1
+        echo "Test 1"
         exit 0
     fi
 fi
-
+echo "Test 2"
 if command -v systemctl >/dev/null && systemctl is-active %{name}.service >/dev/null; then
     echo "Stop existing %{name}.service"
     systemctl --no-reload stop %{name}.service
 fi
+echo "Test 3"
 if command -v systemctl >/dev/null && systemctl is-active %{name}-performance-analyzer.service >/dev/null; then
     echo "Stop existing %{name}-performance-analyzer.service"
     systemctl --no-reload stop %{name}-performance-analyzer.service


### PR DESCRIPTION
### Description
This PR Fixes an error where RPM package is not working on updates where the `wazuh-indexer` is still running.

### Related Issues
Closes #787 

### Check List
- [ ] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
