### PR TITLE
Redesign the mechanism to preserve the status of the service on upgrades

### DIFF
--- a/distribution/packages/src/deb/debian/postinst
+++ b/distribution/packages/src/deb/debian/postinst
@@ -30,40 +30,27 @@ chown -R ${name}:${name} ${data_dir}
 chown -R ${name}:${name} ${pid_dir}
 chown -R ${name}:${name} ${tmp_dir}
 
-# Reload systemctl daemon
-if command -v systemctl > /dev/null; then
-    systemctl daemon-reload
-fi
-
-# Reload other configs
-if command -v systemctl > /dev/null; then
-    systemctl restart systemd-sysctl.service || true
-fi
-
-if command -v systemd-tmpfiles > /dev/null; then
-    systemd-tmpfiles --create ${name}.conf
-fi
+# Reload systemd
+command -v systemctl >/dev/null && systemctl daemon-reload
+command -v systemctl >/dev/null && systemctl restart systemd-sysctl.service
+command -v systemd-tmpfiles >/dev/null && systemd-tmpfiles --create ${name}.conf
 
 # Preserve service state flag across upgrade
 if [ -f ${state_file} ]; then
+    echo "Restarting ${name}.service because it was active before upgrade"
     rm -f ${state_file}
-    echo "Restarting ${name} service..."
-    if command -v systemctl > /dev/null; then
-        systemctl restart ${name}.service > /dev/null 2>&1
-    fi
-    exit 0
+    command -v systemctl >/dev/null && systemctl restart ${name}.service
+else
+    echo "### NOT starting on installation, please execute the following statements to configure ${name} service to start automatically using systemd"
+    echo " sudo systemctl daemon-reload"
+    echo " sudo systemctl enable ${name}.service"
+    echo "### You can start ${name} service by executing"
+    echo " sudo systemctl start ${name}.service"
 fi
 
 # Remove legacy VERSION file on upgrade
 if [ -f "${product_dir}"/VERSION ]; then
     rm -f "${product_dir}"/VERSION
 fi
-
-# Messages
-echo "### NOT starting on installation, please execute the following statements to configure ${name} service to start automatically using systemd"
-echo " sudo systemctl daemon-reload"
-echo " sudo systemctl enable ${name}.service"
-echo "### You can start ${name} service by executing"
-echo " sudo systemctl start ${name}.service"
 
 exit 0

--- a/distribution/packages/src/deb/debian/postinst
+++ b/distribution/packages/src/deb/debian/postinst
@@ -7,7 +7,7 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
-# deb ${name} postinst script
+# deb wazuh-indexer postinst script
 
 set -e
 

--- a/distribution/packages/src/deb/debian/postinst
+++ b/distribution/packages/src/deb/debian/postinst
@@ -7,27 +7,28 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
-# deb wazuh-indexer postinst script
+# deb ${name} postinst script
 
 set -e
 
 echo "Running Wazuh Indexer Post-Installation Script"
 
-product_dir=/usr/share/wazuh-indexer
-config_dir=/etc/wazuh-indexer
-data_dir=/var/lib/wazuh-indexer
-log_dir=/var/log/wazuh-indexer
-pid_dir=/run/wazuh-indexer
+name="wazuh-indexer"
+product_dir=/usr/share/${name}
+config_dir=/etc/${name}
+data_dir=/var/lib/${name}
+log_dir=/var/log/${name}
+pid_dir=/run/${name}
 tmp_dir=${data_dir}/tmp
-restart_service=${tmp_dir}/wazuh-indexer.restart
+state_file=${config_dir}/.was_active
 
 # Set owner
-chown -R wazuh-indexer:wazuh-indexer ${product_dir}
-chown -R wazuh-indexer:wazuh-indexer ${config_dir}
-chown -R wazuh-indexer:wazuh-indexer ${log_dir}
-chown -R wazuh-indexer:wazuh-indexer ${data_dir}
-chown -R wazuh-indexer:wazuh-indexer ${pid_dir}
-chown -R wazuh-indexer:wazuh-indexer ${tmp_dir}
+chown -R ${name}:${name} ${product_dir}
+chown -R ${name}:${name} ${config_dir}
+chown -R ${name}:${name} ${log_dir}
+chown -R ${name}:${name} ${data_dir}
+chown -R ${name}:${name} ${pid_dir}
+chown -R ${name}:${name} ${tmp_dir}
 
 # Reload systemctl daemon
 if command -v systemctl > /dev/null; then
@@ -40,14 +41,15 @@ if command -v systemctl > /dev/null; then
 fi
 
 if command -v systemd-tmpfiles > /dev/null; then
-    systemd-tmpfiles --create wazuh-indexer.conf
+    systemd-tmpfiles --create ${name}.conf
 fi
 
-if [ -f $restart_service ]; then
-    rm -f $restart_service
-    echo "Restarting wazuh-indexer service..."
+# Preserve service state flag across upgrade
+if [ -f ${state_file} ]; then
+    rm -f ${state_file}
+    echo "Restarting ${name} service..."
     if command -v systemctl > /dev/null; then
-        systemctl restart wazuh-indexer.service > /dev/null 2>&1
+        systemctl restart ${name}.service > /dev/null 2>&1
     fi
     exit 0
 fi
@@ -58,10 +60,10 @@ if [ -f "${product_dir}"/VERSION ]; then
 fi
 
 # Messages
-echo "### NOT starting on installation, please execute the following statements to configure wazuh-indexer service to start automatically using systemd"
+echo "### NOT starting on installation, please execute the following statements to configure ${name} service to start automatically using systemd"
 echo " sudo systemctl daemon-reload"
-echo " sudo systemctl enable wazuh-indexer.service"
-echo "### You can start wazuh-indexer service by executing"
-echo " sudo systemctl start wazuh-indexer.service"
+echo " sudo systemctl enable ${name}.service"
+echo "### You can start ${name} service by executing"
+echo " sudo systemctl start ${name}.service"
 
 exit 0

--- a/distribution/packages/src/deb/debian/preinst
+++ b/distribution/packages/src/deb/debian/preinst
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-# Copyright OpenSearch Contributors
+# Copyright Wazuh Indexer Contributors
 # SPDX-License-Identifier: Apache-2.0
 #
-# The OpenSearch Contributors require contributions made to
+# The Wazuh Indexer Contributors require contributions made to
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
-# deb ${name} preinst script
+# deb wazuh-indexer preinst script
 
 set -e
 

--- a/distribution/packages/src/deb/debian/preinst
+++ b/distribution/packages/src/deb/debian/preinst
@@ -7,36 +7,30 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
-# deb wazuh-indexer preinst script
+# deb ${name} preinst script
 
 set -e
 
-# Reference to temp directory
-tmp_dir=/var/lib/wazuh-indexer/tmp
-restart_service=${tmp_dir}/wazuh-indexer.restart
-
-# Create needed directories
-if [ -d ${tmp_dir} ]; then
-    rm -r ${tmp_dir}
-fi
-mkdir -p ${tmp_dir}
+name="wazuh-indexer"
+config_dir=/etc/${name}
+state_file=${config_dir}/.was_active
 
 echo "Running Wazuh Indexer Pre-Installation Script"
 
 # Stop existing service
-if command -v systemctl >/dev/null && systemctl is-active wazuh-indexer.service >/dev/null; then
-    echo "Stop existing wazuh-indexer.service"
-    systemctl --no-reload stop wazuh-indexer.service
-    touch $restart_service
+if command -v systemctl >/dev/null && systemctl is-active ${name}.service >/dev/null; then
+    echo "Stop existing ${name}.service"
+    systemctl --no-reload stop ${name}.service
+    touch ${state_file}
 fi
-if command -v systemctl >/dev/null && systemctl is-active wazuh-indexer-performance-analyzer.service >/dev/null; then
-    echo "Stop existing wazuh-indexer-performance-analyzer.service"
-    systemctl --no-reload stop wazuh-indexer-performance-analyzer.service
+if command -v systemctl >/dev/null && systemctl is-active ${name}-performance-analyzer.service >/dev/null; then
+    echo "Stop existing ${name}-performance-analyzer.service"
+    systemctl --no-reload stop ${name}-performance-analyzer.service
 fi
 
 # Create user and group if they do not already exist.
-getent group wazuh-indexer > /dev/null 2>&1 || groupadd -r wazuh-indexer
-getent passwd wazuh-indexer > /dev/null 2>&1 || \
-    useradd -r -g wazuh-indexer -M -s /sbin/nologin \
-        -c "wazuh-indexer user/group" wazuh-indexer
+getent group ${name} > /dev/null 2>&1 || groupadd -r ${name}
+getent passwd ${name} > /dev/null 2>&1 || \
+    useradd -r -g ${name} -M -s /sbin/nologin \
+        -c "${name} user/group" ${name}
 exit 0

--- a/distribution/packages/src/deb/debian/preinst
+++ b/distribution/packages/src/deb/debian/preinst
@@ -14,6 +14,11 @@ set -e
 name="wazuh-indexer"
 config_dir=/etc/${name}
 state_file=${config_dir}/.was_active
+data_dir=/var/lib/${name}
+tmp_dir=${data_dir}/tmp
+
+# Create needed directories
+mkdir -p ${tmp_dir}
 
 echo "Running Wazuh Indexer Pre-Installation Script"
 

--- a/distribution/packages/src/deb/debian/prerm
+++ b/distribution/packages/src/deb/debian/prerm
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-# Copyright OpenSearch Contributors
+# Copyright Wazuh Indexer Contributors
 # SPDX-License-Identifier: Apache-2.0
 #
-# The OpenSearch Contributors require contributions made to
+# The Wazuh Indexer Contributors require contributions made to
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
-# deb ${name} prerm script
+# deb wazuh-indexer prerm script
 
 set -e
 

--- a/distribution/packages/src/deb/debian/prerm
+++ b/distribution/packages/src/deb/debian/prerm
@@ -7,9 +7,11 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
-# deb wazuh-indexer prerm script
+# deb ${name} prerm script
 
 set -e
+
+name="wazuh-indexer"
 
 case "$1" in
     upgrade|deconfigure)
@@ -17,13 +19,13 @@ case "$1" in
     remove)
         echo "Running Wazuh Indexer Pre-Removal Script"
         # Stop existing service
-        if command -v systemctl >/dev/null && systemctl is-active wazuh-indexer.service >/dev/null; then
-            echo "Stop existing wazuh-indexer.service"
-            systemctl --no-reload stop wazuh-indexer.service
+        if command -v systemctl >/dev/null && systemctl is-active ${name}.service >/dev/null; then
+            echo "Stop existing ${name}.service"
+            systemctl --no-reload stop ${name}.service
         fi
-        if command -v systemctl >/dev/null && systemctl is-active wazuh-indexer-performance-analyzer.service >/dev/null; then
-            echo "Stop existing wazuh-indexer-performance-analyzer.service"
-            systemctl --no-reload stop wazuh-indexer-performance-analyzer.service
+        if command -v systemctl >/dev/null && systemctl is-active ${name}-performance-analyzer.service >/dev/null; then
+            echo "Stop existing ${name}-performance-analyzer.service"
+            systemctl --no-reload stop ${name}-performance-analyzer.service
         fi
     ;;
     failed-upgrade)

--- a/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
+++ b/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
@@ -162,13 +162,6 @@ exit 0
 # Remove -x once solution is approved
 set -ex 
 
-# Stop existing service
-# if command -v systemctl >/dev/null && systemctl is-active %{name}.service >/dev/null; then
-#     echo "Stop existing %{name}.service"
-#     systemctl --no-reload stop %{name}.service
-#     mkdir -p %{tmp_dir}
-#     touch %{tmp_dir}/wazuh-indexer.restart
-# fi
 # Only during upgrade
 if [ "$1" -gt 1 ]; then
     echo "Running upgrade pre-script"
@@ -204,7 +197,6 @@ set -ex
 # Fix ownership and permissions
 chown -R %{name}:%{name} %{config_dir}
 chown -R %{name}:%{name} %{log_dir}
-# chmod a+rw /tmp
 
 # Apply PerformanceAnalyzer Settings
 if ! grep -q '## OpenSearch Performance Analyzer' %{config_dir}/jvm.options; then
@@ -217,6 +209,10 @@ if ! grep -q '## OpenSearch Performance Analyzer' %{config_dir}/jvm.options; the
    echo "-Djava.security.policy=file://%{config_dir}/opensearch-performance-analyzer/opensearch_security.policy" >> %{config_dir}/jvm.options
    echo "--add-opens=jdk.attach/sun.tools.attach=ALL-UNNAMED" >> %{config_dir}/jvm.options
 fi
+
+exit 0
+
+%posttrans
 
 # System setup
 command -v systemctl && systemctl daemon-reload
@@ -301,6 +297,9 @@ exit 0
 %attr(750, %{name}, %{name}) %{product_dir}/jdk/lib/jspawnhelper
 %attr(750, %{name}, %{name}) %{product_dir}/jdk/lib/modules
 %attr(750, %{name}, %{name}) %{product_dir}/performance-analyzer-rca/bin/*
+
+# Preserve service state flag across upgrade
+%ghost %attr(440, %{name}, %{name}) %{config_dir}/.was_active
 
 %changelog
 * Wed Apr 30 2025 support <info@wazuh.com> - 4.12.0

--- a/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
+++ b/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
@@ -225,14 +225,11 @@ if [ -f %{state_file} ]; then
     rm -f %{state_file}
     systemctl restart %{name}.service
 else
-    echo "###"
-    echo "### NOT starting %{name}.service (was not active before upgrade)"
-    echo "### Please execute the following statements to configure the %{name} service to start automatically using systemd"
+    echo "### NOT starting on installation, please execute the following statements to configure %{name} service to start automatically using systemd"
     echo " sudo systemctl daemon-reload"
     echo " sudo systemctl enable %{name}.service"
     echo "### You can start the %{name} service by executing"
     echo " sudo systemctl start %{name}.service"
-    echo "###"
 fi
 
 # Remove legacy VERSION file on upgrade

--- a/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
+++ b/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
@@ -159,8 +159,7 @@ chmod -Rf a+rX,u+w,g-w,o-w %{buildroot}/*
 exit 0
 
 %pre
-# Remove -x once solution is approved
-set -ex 
+set -e
 
 # Only during upgrade
 if [ "$1" -gt 1 ]; then
@@ -191,8 +190,7 @@ getent passwd %{name} > /dev/null 2>&1 || \
 exit 0
 
 %post
-# Remove -x once solution is approved
-set -ex
+set -e
 
 # Fix ownership and permissions
 chown -R %{name}:%{name} %{config_dir}
@@ -213,8 +211,7 @@ fi
 exit 0
 
 %posttrans
-
-set -ex
+set -e
 
 # Reload systemd
 command -v systemctl > /dev/null && systemctl daemon-reload
@@ -242,8 +239,7 @@ fi
 exit 0
 
 %preun
-# Remove -x once solution is approved
-set -ex
+set -e
 
 if command -v systemctl >/dev/null && systemctl is-active %{name}.service >/dev/null; then
     echo "Stop existing %{name}.service"

--- a/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
+++ b/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
@@ -214,16 +214,18 @@ exit 0
 
 %posttrans
 
-# System setup
-command -v systemctl && systemctl daemon-reload
-command -v systemctl && systemctl restart systemd-sysctl.service
-command -v systemd-tmpfiles && systemd-tmpfiles --create %{name}.conf
+set -ex
+
+# Reload systemd
+command -v systemctl > /dev/null && systemctl daemon-reload
+command -v systemctl > /dev/null && systemctl restart systemd-sysctl.service
+command -v systemd-tmpfiles > /dev/null && systemd-tmpfiles --create %{name}.conf
 
 # Restart if previously active
 if [ -f %{state_file} ]; then
     echo "Restarting %{name}.service because it was active before upgrade"
     rm -f %{state_file}
-    systemctl restart %{name}.service
+    command -v systemctl > /dev/null && systemctl restart %{name}.service
 else
     echo "### NOT starting on installation, please execute the following statements to configure %{name} service to start automatically using systemd"
     echo " sudo systemctl daemon-reload"

--- a/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
+++ b/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
@@ -28,6 +28,7 @@
 %define log_dir %{_localstatedir}/log/%{name}
 %define pid_dir %{_localstatedir}/run/%{name}
 %define tmp_dir %{data_dir}/tmp
+%define state_file %{config_dir}/.was_active
 %{!?_version: %define _version 0.0.0 }
 %{!?_architecture: %define _architecture x86_64 }
 
@@ -158,20 +159,36 @@ chmod -Rf a+rX,u+w,g-w,o-w %{buildroot}/*
 exit 0
 
 %pre
-set -e
+# Remove -x once solution is approved
+set -ex 
+
 # Stop existing service
-if command -v systemctl >/dev/null && systemctl is-active %{name}.service >/dev/null; then
-    echo "Stop existing %{name}.service"
-    systemctl --no-reload stop %{name}.service
-    mkdir -p %{tmp_dir}
-    touch %{tmp_dir}/wazuh-indexer.restart
+# if command -v systemctl >/dev/null && systemctl is-active %{name}.service >/dev/null; then
+#     echo "Stop existing %{name}.service"
+#     systemctl --no-reload stop %{name}.service
+#     mkdir -p %{tmp_dir}
+#     touch %{tmp_dir}/wazuh-indexer.restart
+# fi
+# Only during upgrade
+if [ "$1" -gt 1 ]; then
+    echo "Running upgrade pre-script"
+
+    # Mark if service is running
+    if command -v systemctl >/dev/null && systemctl is-active --quiet %{name}.service; then
+        echo "Service is active, marking it for restart"
+        touch %{state_file}
+
+        echo "Stopping service before upgrade"
+        systemctl stop %{name}.service
+    else
+        echo "Service is inactive; nothing to mark"
+    fi
 fi
+
 if command -v systemctl >/dev/null && systemctl is-active %{name}-performance-analyzer.service >/dev/null; then
     echo "Stop existing %{name}-performance-analyzer.service"
     systemctl --no-reload stop %{name}-performance-analyzer.service
 fi
-
-rm -rf %{product_dir}/lib/*
 
 # Create user and group if they do not already exist.
 getent group %{name} > /dev/null 2>&1 || groupadd -r %{name}
@@ -181,12 +198,15 @@ getent passwd %{name} > /dev/null 2>&1 || \
 exit 0
 
 %post
-set -e
+# Remove -x once solution is approved
+set -ex
+
+# Fix ownership and permissions
 chown -R %{name}:%{name} %{config_dir}
 chown -R %{name}:%{name} %{log_dir}
+# chmod a+rw /tmp
 
 # Apply PerformanceAnalyzer Settings
-chmod a+rw /tmp
 if ! grep -q '## OpenSearch Performance Analyzer' %{config_dir}/jvm.options; then
    # Add Performance Analyzer settings in %{config_dir}/jvm.options
    CLK_TCK=`/usr/bin/getconf CLK_TCK`
@@ -197,28 +217,26 @@ if ! grep -q '## OpenSearch Performance Analyzer' %{config_dir}/jvm.options; the
    echo "-Djava.security.policy=file://%{config_dir}/opensearch-performance-analyzer/opensearch_security.policy" >> %{config_dir}/jvm.options
    echo "--add-opens=jdk.attach/sun.tools.attach=ALL-UNNAMED" >> %{config_dir}/jvm.options
 fi
-# Reload systemctl daemon
-if command -v systemctl > /dev/null; then
-    systemctl daemon-reload
-fi
-# Reload other configs
-if command -v systemctl > /dev/null; then
-    systemctl restart systemd-sysctl.service || true
-fi
 
-if command -v systemd-tmpfiles > /dev/null; then
-    systemd-tmpfiles --create %{name}.conf
-fi
+# System setup
+command -v systemctl && systemctl daemon-reload
+command -v systemctl && systemctl restart systemd-sysctl.service
+command -v systemd-tmpfiles && systemd-tmpfiles --create %{name}.conf
 
-if [ ! -f %{tmp_dir}/wazuh-indexer.restart ]; then
-  # Messages
-  echo "###"
-  echo "### NOT starting on installation, please execute the following statements to configure wazuh-indexer service to start automatically using systemd"
-  echo " sudo systemctl daemon-reload"
-  echo " sudo systemctl enable wazuh-indexer.service"
-  echo "### You can start wazuh-indexer service by executing"
-  echo " sudo systemctl start wazuh-indexer.service"
-  echo "###"
+# Restart if previously active
+if [ -f %{state_file} ]; then
+    echo "Restarting %{name}.service because it was active before upgrade"
+    rm -f %{state_file}
+    systemctl restart %{name}.service
+else
+    echo "###"
+    echo "### NOT starting %{name}.service (was not active before upgrade)"
+    echo "### Please execute the following statements to configure the %{name} service to start automatically using systemd"
+    echo " sudo systemctl daemon-reload"
+    echo " sudo systemctl enable %{name}.service"
+    echo "### You can start the %{name} service by executing"
+    echo " sudo systemctl start %{name}.service"
+    echo "###"
 fi
 
 # Remove legacy VERSION file on upgrade
@@ -229,16 +247,8 @@ fi
 exit 0
 
 %preun
+# Remove -x once solution is approved
 set -ex
-
-if [ -f %{tmp_dir}/wazuh-indexer.restart ]; then
-    rm -f %{tmp_dir}/wazuh-indexer.restart
-    if command -v systemctl > /dev/null; then
-        echo "Restarting wazuh-indexer service..."
-        systemctl restart wazuh-indexer.service > /dev/null 2>&1
-        exit 0
-    fi
-fi
 
 if command -v systemctl >/dev/null && systemctl is-active %{name}.service >/dev/null; then
     echo "Stop existing %{name}.service"

--- a/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
+++ b/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
@@ -170,6 +170,9 @@ if command -v systemctl >/dev/null && systemctl is-active %{name}-performance-an
     echo "Stop existing %{name}-performance-analyzer.service"
     systemctl --no-reload stop %{name}-performance-analyzer.service
 fi
+
+rm -rf %{product_dir}/lib/*
+
 # Create user and group if they do not already exist.
 getent group %{name} > /dev/null 2>&1 || groupadd -r %{name}
 getent passwd %{name} > /dev/null 2>&1 || \

--- a/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
+++ b/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
@@ -221,7 +221,7 @@ fi
 exit 0
 
 %preun
-set -e
+set -ex
 
 if [ -f %{tmp_dir}/wazuh-indexer.restart ]; then
     rm -f %{tmp_dir}/wazuh-indexer.restart


### PR DESCRIPTION
### Description
This PR Fixes an error where RPM package is not working on updates where the `wazuh-indexer` is still running.

Testing steps on the issue's comments.

### Related Issues
Closes #787 

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
