### PR TITLE
Update repository bumper script to modify package changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased 4.13.x]
 ### Added
-- Implement version bumper script [(#802)](https://github.com/wazuh/wazuh-indexer/pull/802)
-- Update repository bumper script to modify package changelog [(#803)](https://github.com/wazuh/wazuh-indexer/pull/803)
+- Implement version bumper script [(#802)](https://github.com/wazuh/wazuh-indexer/pull/802) [(#803)](https://github.com/wazuh/wazuh-indexer/pull/803)
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased 4.13.x]
 ### Added
-- Implement version bumper script [(#802)](https://github.com/wazuh/wazuh-indexer/pull/802/files)
+- Implement version bumper script [(#802)](https://github.com/wazuh/wazuh-indexer/pull/802)
+- Update repository bumper script to modify package changelog [(#803)](https://github.com/wazuh/wazuh-indexer/pull/803)
 
 ### Dependencies
 

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -14,7 +14,7 @@
 # The changelog entry will be added to the %changelog section of the RPM spec file,
 # and will be formatted as follows:
 #   * [DATE] support <info@wazuh.com> - [VERSION]
-#   * More info: https://documentation.wazuh.com/current/release-notes/release-[VERSION].html
+#   - More info: https://documentation.wazuh.com/current/release-notes/release-[VERSION].html
 
 set -euo pipefail
 

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -163,7 +163,6 @@ function update_rpm_changelog() {
             if (!inserted && /^%changelog/) {
                 print line1
                 print line2
-                print ""
                 inserted=1
             }
         }

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -5,8 +5,8 @@ set -euo pipefail
 # Print usage instructions
 # ====
 function usage() {
-    echo "Usage: $0 <version> <stage>"
-    echo "  version:  The new version to set in VERSION.json"
+    echo "Usage: $0 <version> <stage> <date>"
+    echo "  version:  The new version to set in VERSION.json (e.g., 4.5.0)"
     echo "  stage:    The new stage to set in VERSION.json (alpha, beta, rc, stable)"
     echo "  date:     The date to set in the changelog (e.g., 'Mon Jan 02 2025')"
     exit 1
@@ -177,7 +177,7 @@ function update_rpm_changelog() {
 # Main logic
 # ====
 function main() {
-    if [ "$#" -ne 2 ]; then
+    if [ "$#" -ne 3 ]; then
         usage
     fi
 

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -1,4 +1,21 @@
 #!/bin/bash
+
+# =========================
+# Repository Bumper Script
+# =========================
+# This script updates the VERSION.json file and the changelog section of the
+# RPM spec file for a new version release.
+#
+# It takes three arguments:
+# 1. The new version to set (e.g., 4.5.0)
+# 2. The new stage to set (alpha, beta, rc, stable)
+# 3. The date to set in the changelog (e.g., 'Mon Jan 02 2025')
+#
+# The changelog entry will be added to the %changelog section of the RPM spec file,
+# and will be formatted as follows:
+#   * [DATE] support <info@wazuh.com> - [VERSION]
+#   * More info: https://documentation.wazuh.com/current/release-notes/release-[VERSION].html
+
 set -euo pipefail
 
 # ====

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -8,6 +8,7 @@ function usage() {
     echo "Usage: $0 <version> <stage>"
     echo "  version:  The new version to set in VERSION.json"
     echo "  stage:    The new stage to set in VERSION.json (alpha, beta, rc, stable)"
+    echo "  date:     The date to set in the changelog (e.g., 'Mon Jan 02 2025')"
     exit 1
 }
 
@@ -63,10 +64,12 @@ function navigate_to_project_root() {
 # Arguments:
 #   $1 - version
 #   $2 - stage
+#   $3 - date
 # ====
 function validate_inputs() {
     local version="$1"
     local stage="$2"
+    local date_str="$3"
 
     if ! [[ $version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
         log "Error: Invalid version format '$version'."
@@ -77,6 +80,11 @@ function validate_inputs() {
     normalized_stage=$(echo "$stage" | tr '[:upper:]' '[:lower:]')
     if ! [[ $normalized_stage =~ ^(alpha[0-9]*|beta[0-9]*|rc[0-9]*|stable)$ ]]; then
         log "Error: Invalid stage format '$stage'."
+        exit 1
+    fi
+
+    if ! [[ $date_str =~ ^[A-Za-z]{3}\ [A-Za-z]{3}\ [0-9]{1,2}\ [0-9]{4}$ ]]; then
+        log "Error: Invalid date format '$date_str'."
         exit 1
     fi
 }
@@ -114,6 +122,58 @@ function update_version_file() {
 }
 
 # ====
+# Update the changelog section of the RPM spec file, if needed
+# Arguments:
+#   $1 - version
+#   $2 - date
+# ====
+function update_rpm_changelog() {
+    local version="$1"
+    local date_str="$2"
+    local spec_file="distribution/packages/src/rpm/wazuh-indexer.rpm.spec"
+    local changelog_entry="* $date_str support <info@wazuh.com> - $version"
+
+    if grep -q "^- More info: .*release-$version\.html" "$spec_file"; then
+        # Update existing changelog date
+        awk -v version="$version" -v new_date="$date_str" '
+            BEGIN { updated = 0 }
+            {
+                if ($0 ~ "^- More info: .*release-"version"\\.html") {
+                    prev = NR - 1
+                    lines[prev] = "* " new_date " support <info@wazuh.com> - " version
+                    lines[NR] = $0
+                    updated = 1
+                } else {
+                    lines[NR] = $0
+                }
+            }
+            END {
+                for (i = 1; i <= NR; i++) print lines[i]
+                if (updated) print ""
+            }
+        ' "$spec_file" >"${spec_file}.tmp" && mv "${spec_file}.tmp" "$spec_file"
+
+        log "Updated existing changelog entry for version=$version with date=$date_str"
+    else
+        log "Inserting changelog entry for version=$version"
+        awk -v line1="$changelog_entry" -v line2="- More info: https://documentation.wazuh.com/current/release-notes/release-$version.html" '
+        BEGIN { inserted=0 }
+        {
+            print
+            if (!inserted && /^%changelog/) {
+                print line1
+                print line2
+                print ""
+                inserted=1
+            }
+        }
+        ' "$spec_file" >"${spec_file}.tmp" && mv "${spec_file}.tmp" "$spec_file"
+
+        log "Inserted new changelog entry for version=$version with date=$date_str"
+    fi
+}
+
+# ====
 # Main logic
 # ====
 function main() {
@@ -123,14 +183,16 @@ function main() {
 
     local version="$1"
     local stage="$2"
+    local date_str="$3"
 
     init_logging
     log "Starting update for VERSION.json with version=$version, stage=$stage"
 
     navigate_to_project_root
     check_jq_installed
-    validate_inputs "$version" "$stage"
+    validate_inputs "$version" "$stage" "$date_str"
     update_version_file "$version" "$stage"
+    update_rpm_changelog "$version" "$date_str"
 
     log "Update complete."
 }

--- a/tools/version_initializer.sh
+++ b/tools/version_initializer.sh
@@ -5,7 +5,10 @@ set -euo pipefail
 # Usage info
 # ====
 function usage() {
-    echo "Usage: $0 <version> <previous_version>"
+    echo "Usage: $0 <version> <previous_version> <date>"
+    echo "  version:            The new version to set (e.g., 4.5.0)"
+    echo "  previous_version:   The previous version to compare against (e.g., 4.4.0)"
+    echo "  date:               The date to set in the changelog (e.g., '2025-01-01')"
     exit 1
 }
 
@@ -37,6 +40,11 @@ function validate_inputs() {
         log "Error: Invalid previous version format '$PREVIOUS_VERSION'."
         exit 1
     fi
+
+    if ! [[ $DATE =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+        log "Error: Invalid date format '$DATE'."
+        exit 1
+    fi
 }
 
 # ====
@@ -62,34 +70,6 @@ function navigate_to_project_root() {
 }
 
 # ====
-# Updates RPM spec file changelog
-# Globals:
-#   VERSION
-#   DISTRIBUTION_FILE
-# ====
-function update_rpm_spec() {
-    local current_date
-    current_date=$(date +"%a %b %d %Y")
-    local entry_line1="* $current_date support <info@wazuh.com> - $VERSION"
-    local entry_line2="- More info: https://documentation.wazuh.com/current/release-notes/release-$VERSION.html"
-
-    awk -v l1="$entry_line1" -v l2="$entry_line2" '
-        BEGIN { inserted=0 }
-        {
-            print
-            if (!inserted && /^%changelog/) {
-                print l1
-                print l2
-                inserted=1
-            }
-        }
-    ' "$DISTRIBUTION_FILE" > "${DISTRIBUTION_FILE}.tmp"
-
-    mv "${DISTRIBUTION_FILE}.tmp" "$DISTRIBUTION_FILE"
-    log "Updated RPM spec file: $DISTRIBUTION_FILE"
-}
-
-# ====
 # Initializes CHANGELOG.md for new version
 # Globals:
 #   CHANGELOG_FILE
@@ -111,10 +91,8 @@ function update_changelog() {
 #   VERSION
 # ====
 function update_release_notes() {
-    local today
-    today=$(date +%Y-%m-%d)
     local content
-    content=$(echo "$RELEASE_NOTES_TEMPLATE_CONTENT" | sed "s|<VERSION>|$VERSION|g" | sed "s|<DATE>|$today|g")
+    content=$(echo "$RELEASE_NOTES_TEMPLATE_CONTENT" | sed "s|<VERSION>|$VERSION|g" | sed "s|<DATE>|$DATE|g")
 
     echo "$content" > "$RELEASE_NOTES_FILE"
     log "Created release notes: $RELEASE_NOTES_FILE"
@@ -124,23 +102,23 @@ function update_release_notes() {
 # Main function
 # ====
 function main() {
-    if [ "$#" -ne 2 ]; then
+    if [ "$#" -ne 3 ]; then
         usage
     fi
 
     VERSION="$1"
     PREVIOUS_VERSION="$2"
+    DATE="$3"
 
     # Paths and files
-    DISTRIBUTION_FILE="distribution/packages/src/rpm/wazuh-indexer.rpm.spec"
     CHANGELOG_FILE="CHANGELOG.md"
     RELEASE_NOTES_FILE="release-notes/wazuh.release-notes-${VERSION}.md"
-    FILES_TO_UPDATE=("$DISTRIBUTION_FILE" "$CHANGELOG_FILE" "$RELEASE_NOTES_FILE")
+    FILES_TO_UPDATE=("$CHANGELOG_FILE" "$RELEASE_NOTES_FILE")
 
     # Log file
     local script_dir
-    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
     local timestamp
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
     timestamp=$(date +"%Y-%m-%d_%H-%M-%S-%3N")
     LOG_FILE="$script_dir/version_initializer_${timestamp}.log"
     exec > >(tee -a "$LOG_FILE") 2>&1
@@ -150,7 +128,6 @@ function main() {
 
     navigate_to_project_root
     validate_inputs
-    update_rpm_spec
     update_changelog
     update_release_notes
 
@@ -195,7 +172,7 @@ EOF
 )
 
 RELEASE_NOTES_TEMPLATE_CONTENT=$(cat <<'EOF'
-<DATE> Version <VERSION> Release Notes
+## <DATE> Version <VERSION> Release Notes
 
 ## [<VERSION>]
 ### Added

--- a/tools/version_initializer.sh
+++ b/tools/version_initializer.sh
@@ -1,4 +1,21 @@
 #!/bin/bash
+
+# =========================
+# Version Initializer Script
+# =========================
+# This script initializes the changelog and release notes for a new version.
+# It should be used alongside the repository_bumper.sh script in order to
+# ensure that all the necessary files are updated correctly.
+#
+# The script takes three arguments:
+# 1. The new version to set (e.g., 4.5.0)
+# 2. The previous version to compare against (e.g., 4.4.0)
+# 3. The date to set in the release notes (e.g., '2025-01-01')
+#
+# It will create or update the CHANGELOG.md and release-notes files with the
+# new version information. Both files will be formatted according to the
+# [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) standard.
+
 set -euo pipefail
 
 # ====
@@ -8,7 +25,7 @@ function usage() {
     echo "Usage: $0 <version> <previous_version> <date>"
     echo "  version:            The new version to set (e.g., 4.5.0)"
     echo "  previous_version:   The previous version to compare against (e.g., 4.4.0)"
-    echo "  date:               The date to set in the changelog (e.g., '2025-01-01')"
+    echo "  date:               The date to set in the release notes (e.g., '2025-01-01')"
     exit 1
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
The repository bumper script updates the package RPM spec to set a giving date on the corresponding changelog entry, if such entry does not exists it adds the new entry to the file.

### Validations

- New changelog entry
    ```shellsession
    % bash tools/repository_bumper.sh 4.14.1 alpha3 'Mon Jan 01 2025'
    [2025-04-22 09:02:24] Logging initialized. Log file: /Users/quebim_wz/IdeaProjects/wazuh-indexer/tools/repository_bumper_2025-04-22_09-02-24-3N.log
    [2025-04-22 09:02:24] Starting update for VERSION.json with version=4.14.1, stage=alpha3
    [2025-04-22 09:02:24] Moved to repository root: /Users/quebim_wz/IdeaProjects/wazuh-indexer
    [2025-04-22 09:02:24] Updated VERSION.json with version=4.14.1 and stage=alpha3
    [2025-04-22 09:02:24] Inserting changelog entry for version=4.14.1
    [2025-04-22 09:02:24] Inserted new changelog entry for version=4.14.1 with date=Mon Jan 01 2025
    [2025-04-22 09:02:24] Update complete.
    ```
    ```bash
    ...
    %changelog
    * Mon Jan 01 2025 support <info@wazuh.com> - 4.14.1
    - More info: https://documentation.wazuh.com/current/release-notes/release-4.14.1.html
    ...
    ```
- Update existing changelog entry
    ```shellsession
    % bash tools/repository_bumper.sh 4.14.1 alpha3 'Mon Jan 02 2025'
    [2025-04-22 09:16:45] Logging initialized. Log file: /Users/quebim_wz/IdeaProjects/wazuh-indexer/tools/repository_bumper_2025-04-22_09-16-45-3N.log
    [2025-04-22 09:16:45] Starting update for VERSION.json with version=4.14.1, stage=alpha3
    [2025-04-22 09:16:45] Moved to repository root: /Users/quebim_wz/IdeaProjects/wazuh-indexer
    [2025-04-22 09:16:45] Updated VERSION.json with version=4.14.1 and stage=alpha3
    [2025-04-22 09:16:45] Updated existing changelog entry for version=4.14.1 with date=Mon Jan 02 2025
    [2025-04-22 09:16:45] Update complete.
    ```
    ```bash
    ...
    %changelog
    * Mon Jan 02 2025 support <info@wazuh.com> - 4.14.1
    - More info: https://documentation.wazuh.com/current/release-notes/release-4.14.1.html
    ...
    ```

### Related Issues
Closes #79 
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
