### PR TITLE
Improve DEB and RPM packaging scripts 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 - Update opensearch.yml template and auto-generate creds directory [(#755)](https://github.com/wazuh/wazuh-indexer/pull/755)
 - Update certificates directory ownership and permissions [(#766)](https://github.com/wazuh/wazuh-indexer/pull/766)
-- Remove custom Java temporary folder [(#805)](https://github.com/wazuh/wazuh-indexer/pull/805)
+- Improve DEB and RPM packaging scripts [(#805)](https://github.com/wazuh/wazuh-indexer/pull/805)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 - Update opensearch.yml template and auto-generate creds directory [(#755)](https://github.com/wazuh/wazuh-indexer/pull/755)
 - Update certificates directory ownership and permissions [(#766)](https://github.com/wazuh/wazuh-indexer/pull/766)
+- Remove custom Java temporary folder [(#805)](https://github.com/wazuh/wazuh-indexer/pull/805)
 
 ### Deprecated
 

--- a/distribution/packages/src/common/systemd/wazuh-indexer.service
+++ b/distribution/packages/src/common/systemd/wazuh-indexer.service
@@ -9,7 +9,6 @@ Type=notify
 RuntimeDirectory=wazuh-indexer
 PrivateTmp=true
 Environment=OPENSEARCH_HOME=/usr/share/wazuh-indexer
-Environment=OPENSEARCH_TMPDIR=/var/lib/wazuh-indexer/tmp
 Environment=OPENSEARCH_PATH_CONF=${path.conf}
 Environment=PID_DIR=/run/wazuh-indexer
 Environment=OPENSEARCH_SD_NOTIFY=true

--- a/distribution/packages/src/deb/debian/postinst
+++ b/distribution/packages/src/deb/debian/postinst
@@ -20,7 +20,6 @@ certs_dir=${config_dir}/certs
 data_dir=/var/lib/${name}
 log_dir=/var/log/${name}
 pid_dir=/run/${name}
-tmp_dir=${data_dir}/tmp
 state_file=${config_dir}/${name}.was_active
 
 # Set owner
@@ -29,7 +28,6 @@ chown -R ${name}:${name} ${config_dir}
 chown -R ${name}:${name} ${log_dir}
 chown -R ${name}:${name} ${data_dir}
 chown -R ${name}:${name} ${pid_dir}
-chown -R ${name}:${name} ${tmp_dir}
 chown -R ${name}:${name} ${certs_dir}
 
 export OPENSEARCH_PATH_CONF=${OPENSEARCH_PATH_CONF:-${config_dir}}

--- a/distribution/packages/src/deb/debian/postinst
+++ b/distribution/packages/src/deb/debian/postinst
@@ -63,7 +63,7 @@ fi
 # Check if the script is executed on upgrade
 if [ -n "$2" ]; then
     if [ -f $state_file ]; then
-        echo "Restarting ${name} service after upgrade"
+        echo "Restoring ${name}.service to its previous active state."
         rm -f $state_file
         if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1; then
             systemctl restart ${name}.service > /dev/null 2>&1
@@ -73,7 +73,7 @@ if [ -n "$2" ]; then
             /etc/init.d/${name} restart > /dev/null 2>&1
         fi
     else
-        echo "### NOT restarting ${name} service after upgrade"
+        echo "### Service will remain stopped after the upgrade (previous state preserved)."
         echo "### You can start ${name} service by executing"
         if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1; then
             echo " sudo systemctl start ${name}.service"

--- a/distribution/packages/src/deb/debian/postinst
+++ b/distribution/packages/src/deb/debian/postinst
@@ -62,7 +62,7 @@ fi
 
 # Check if the script is executed on upgrade
 if [ -n "$2" ]; then
-    if [ -f $state_file ]; then
+    if [ -f ${state_file} ]; then
         echo "Restoring ${name}.service to its previous active state."
         rm -f $state_file
         if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1; then

--- a/distribution/packages/src/deb/debian/postinst
+++ b/distribution/packages/src/deb/debian/postinst
@@ -13,23 +13,24 @@ set -e
 
 echo "Running Wazuh Indexer Post-Installation Script"
 
-product_dir=/usr/share/wazuh-indexer
-config_dir=/etc/wazuh-indexer
+name="wazuh-indexer"
+product_dir=/usr/share/${name}
+config_dir=/etc/${name}
 certs_dir=${config_dir}/certs
-data_dir=/var/lib/wazuh-indexer
-log_dir=/var/log/wazuh-indexer
-pid_dir=/run/wazuh-indexer
+data_dir=/var/lib/${name}
+log_dir=/var/log/${name}
+pid_dir=/run/${name}
 tmp_dir=${data_dir}/tmp
-restart_service=${tmp_dir}/wazuh-indexer.restart
+state_file=${config_dir}/${name}.was_active
 
 # Set owner
-chown -R wazuh-indexer:wazuh-indexer ${product_dir}
-chown -R wazuh-indexer:wazuh-indexer ${config_dir}
-chown -R wazuh-indexer:wazuh-indexer ${log_dir}
-chown -R wazuh-indexer:wazuh-indexer ${data_dir}
-chown -R wazuh-indexer:wazuh-indexer ${pid_dir}
-chown -R wazuh-indexer:wazuh-indexer ${tmp_dir}
-chown -R wazuh-indexer:wazuh-indexer ${certs_dir}
+chown -R ${name}:${name} ${product_dir}
+chown -R ${name}:${name} ${config_dir}
+chown -R ${name}:${name} ${log_dir}
+chown -R ${name}:${name} ${data_dir}
+chown -R ${name}:${name} ${pid_dir}
+chown -R ${name}:${name} ${tmp_dir}
+chown -R ${name}:${name} ${certs_dir}
 
 export OPENSEARCH_PATH_CONF=${OPENSEARCH_PATH_CONF:-${config_dir}}
 # Apply Performance Analyzer settings, as per https://github.com/opensearch-project/opensearch-build/blob/2.18.0/scripts/pkg/build_templates/current/opensearch/deb/debian/postinst#L28-L37
@@ -56,59 +57,59 @@ if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1; then
 fi
 
 if command -v systemd-tmpfiles > /dev/null 2>&1 && systemctl > /dev/null 2>&1; then
-    systemd-tmpfiles --create wazuh-indexer.conf > /dev/null 2>&1
+    systemd-tmpfiles --create ${name}.conf > /dev/null 2>&1
 fi
 
 # Check if the script is executed on upgrade
 if [ -n "$2" ]; then
-    if [ -f $restart_service ]; then
-        echo "Restarting wazuh-indexer service after upgrade"
-        rm -f $restart_service
+    if [ -f $state_file ]; then
+        echo "Restarting ${name} service after upgrade"
+        rm -f $state_file
         if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1; then
-            systemctl restart wazuh-indexer.service > /dev/null 2>&1
+            systemctl restart ${name}.service > /dev/null 2>&1
         elif command -v service > /dev/null 2>&1; then
-            service wazuh-indexer restart > /dev/null 2>&1
-        elif command -v /etc/init.d/wazuh-indexer > /dev/null 2>&1; then
-            /etc/init.d/wazuh-indexer restart > /dev/null 2>&1
+            service ${name} restart > /dev/null 2>&1
+        elif command -v /etc/init.d/${name} > /dev/null 2>&1; then
+            /etc/init.d/${name} restart > /dev/null 2>&1
         fi
     else
-        echo "### NOT restarting wazuh-indexer service after upgrade"
-        echo "### You can start wazuh-indexer service by executing"
+        echo "### NOT restarting ${name} service after upgrade"
+        echo "### You can start ${name} service by executing"
         if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1; then
-            echo " sudo systemctl start wazuh-indexer.service"
+            echo " sudo systemctl start ${name}.service"
         elif command -v service > /dev/null 2>&1; then
-            echo " sudo service wazuh-indexer start"
-        elif command -v /etc/init.d/wazuh-indexer > /dev/null 2>&1; then
-            echo " sudo /etc/init.d/wazuh-indexer start"
+            echo " sudo service ${name} start"
+        elif command -v /etc/init.d/${name} > /dev/null 2>&1; then
+            echo " sudo /etc/init.d/${name} start"
         fi
     fi
 else
     # Messages
     if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1; then
-        echo "### NOT starting on installation, please execute the following statements to configure wazuh-indexer service to start automatically using systemd"
+        echo "### NOT starting on installation, please execute the following statements to configure ${name} service to start automatically using systemd"
         echo " sudo systemctl daemon-reload"
-        echo " sudo systemctl enable wazuh-indexer.service"
-        echo "### You can start wazuh-indexer service by executing"
-        echo " sudo systemctl start wazuh-indexer.service"
+        echo " sudo systemctl enable ${name}.service"
+        echo "### You can start ${name} service by executing"
+        echo " sudo systemctl start ${name}.service"
     else
         if command -v chkconfig > /dev/null 2>&1; then
-            echo "### NOT starting on installation, please execute the following statements to configure wazuh-indexer service to start automatically using chkconfig"
-            echo " sudo chkconfig --add wazuh-indexer"
+            echo "### NOT starting on installation, please execute the following statements to configure ${name} service to start automatically using chkconfig"
+            echo " sudo chkconfig --add ${name}"
         elif command -v update-rc.d > /dev/null 2>&1; then
-            echo "### NOT starting on installation, please execute the following statements to configure wazuh-indexer service to start automatically using update-rc.d"
-            echo " sudo update-rc.d wazuh-indexer defaults 95 10"
+            echo "### NOT starting on installation, please execute the following statements to configure ${name} service to start automatically using update-rc.d"
+            echo " sudo update-rc.d ${name} defaults 95 10"
         fi
         if command -v service > /dev/null 2>&1; then
-            echo "### You can start wazuh-indexer service by executing"
-            echo " sudo service wazuh-indexer start"
-        elif command -v /etc/init.d/wazuh-indexer > /dev/null 2>&1; then
-            echo "### You can start wazuh-indexer service by executing"
-            echo " sudo /etc/init.d/wazuh-indexer start"
+            echo "### You can start ${name} service by executing"
+            echo " sudo service ${name} start"
+        elif command -v /etc/init.d/${name} > /dev/null 2>&1; then
+            echo "### You can start ${name} service by executing"
+            echo " sudo /etc/init.d/${name} start"
         fi
     fi
     # Create the certs directory and if required, install demo certificates.
     if [ "$GENERATE_CERTS" = "true" ] && [ -f "${product_dir}/plugins/opensearch-security/tools/install-demo-certificates.sh" ]; then
-        echo "### Installing wazuh-indexer demo certificates in ${certs_dir}"
+        echo "### Installing ${name} demo certificates in ${certs_dir}"
         echo " If you are using a custom certificates path, ignore this message"
         echo " See demo certs creation log in ${log_dir}/install_demo_certificates.log"
         bash "${product_dir}/plugins/opensearch-security/tools/install-demo-certificates.sh" >"${log_dir}/install_demo_certificates.log" 2>&1

--- a/distribution/packages/src/deb/debian/preinst
+++ b/distribution/packages/src/deb/debian/preinst
@@ -18,7 +18,7 @@ data_dir=/var/lib/${name}
 log_dir=/var/log/${name}
 pid_dir=/run/${name}
 tmp_dir=${data_dir}/tmp
-state_file=${config_dir}/.was_active
+state_file=${config_dir}/${name}.was_active
 
 # Create needed directories
 mkdir -p ${tmp_dir}

--- a/distribution/packages/src/deb/debian/preinst
+++ b/distribution/packages/src/deb/debian/preinst
@@ -12,10 +12,13 @@
 set -e
 
 name="wazuh-indexer"
+product_dir=/usr/share/${name}
 config_dir=/etc/${name}
-state_file=${config_dir}/.was_active
 data_dir=/var/lib/${name}
+log_dir=/var/log/${name}
+pid_dir=/run/${name}
 tmp_dir=${data_dir}/tmp
+state_file=${config_dir}/.was_active
 
 # Cleanup temp directory
 if [ -d ${tmp_dir} ]; then
@@ -24,21 +27,32 @@ fi
 # Create needed directories
 mkdir -p ${tmp_dir}
 
+# Set owner
+ chown -R ${name}:${name} ${product_dir}
+ chown -R ${name}:${name} ${config_dir}
+ chown -R ${name}:${name} ${log_dir}
+ chown -R ${name}:${name} ${data_dir}
+ chown -R ${name}:${name} ${pid_dir}
+ chown -R ${name}:${name} ${tmp_dir}
+
 echo "Running Wazuh Indexer Pre-Installation Script"
 
 case "$1" in
     upgrade)
         # Stop existing wazuh-indexer.service
-        echo "Stop existing ${name}.service"
+        echo "Verifying ${name}.service is stopped to proceed with the upgrade..."
         if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1 && systemctl is-active ${name}.service > /dev/null 2>&1; then
             systemctl --no-reload stop ${name}.service > /dev/null 2>&1
-            touch $state_file
+            echo "${name}.service is currently active; scheduling restart after the upgrade."
+            touch ${state_file}
         elif command -v service > /dev/null 2>&1 && service ${name} status > /dev/null 2>&1; then
             service ${name} stop > /dev/null 2>&1
-            touch $state_file
+            echo "${name}.service is currently active; scheduling restart after the upgrade."
+            touch ${state_file}
         elif command -v /etc/init.d/${name} > /dev/null 2>&1 && /etc/init.d/${name} status > /dev/null 2>&1; then
             /etc/init.d/${name} stop > /dev/null 2>&1
-            touch $state_file
+            echo "${name}.service is currently active; scheduling restart after the upgrade."
+            touch ${state_file}
         fi
 
         echo "Stop existing ${name}-performance-analyzer.service"

--- a/distribution/packages/src/deb/debian/preinst
+++ b/distribution/packages/src/deb/debian/preinst
@@ -20,20 +20,8 @@ pid_dir=/run/${name}
 tmp_dir=${data_dir}/tmp
 state_file=${config_dir}/.was_active
 
-# Cleanup temp directory
-if [ -d ${tmp_dir} ]; then
-    rm -r ${tmp_dir}
-fi
 # Create needed directories
 mkdir -p ${tmp_dir}
-
-# Set owner
- chown -R ${name}:${name} ${product_dir}
- chown -R ${name}:${name} ${config_dir}
- chown -R ${name}:${name} ${log_dir}
- chown -R ${name}:${name} ${data_dir}
- chown -R ${name}:${name} ${pid_dir}
- chown -R ${name}:${name} ${tmp_dir}
 
 echo "Running Wazuh Indexer Pre-Installation Script"
 
@@ -54,7 +42,6 @@ case "$1" in
             echo "${name}.service is currently active; scheduling restart after the upgrade."
             touch ${state_file}
         fi
-
         echo "Stop existing ${name}-performance-analyzer.service"
         if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1 && systemctl is-active ${name}-performance-analyzer.service > /dev/null 2>&1; then
             systemctl --no-reload stop ${name}-performance-analyzer.service > /dev/null 2>&1

--- a/distribution/packages/src/deb/debian/preinst
+++ b/distribution/packages/src/deb/debian/preinst
@@ -11,14 +11,17 @@
 
 set -e
 
-# Reference to temp directory
-tmp_dir=/var/lib/wazuh-indexer/tmp
-restart_service=${tmp_dir}/wazuh-indexer.restart
+name="wazuh-indexer"
+config_dir=/etc/${name}
+state_file=${config_dir}/.was_active
+data_dir=/var/lib/${name}
+tmp_dir=${data_dir}/tmp
 
-# Create needed directories
+# Cleanup temp directory
 if [ -d ${tmp_dir} ]; then
     rm -r ${tmp_dir}
 fi
+# Create needed directories
 mkdir -p ${tmp_dir}
 
 echo "Running Wazuh Indexer Pre-Installation Script"
@@ -26,25 +29,25 @@ echo "Running Wazuh Indexer Pre-Installation Script"
 case "$1" in
     upgrade)
         # Stop existing wazuh-indexer.service
-        echo "Stop existing wazuh-indexer.service"
-        if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1 && systemctl is-active wazuh-indexer.service > /dev/null 2>&1; then
-            systemctl --no-reload stop wazuh-indexer.service > /dev/null 2>&1
-            touch $restart_service
-        elif command -v service > /dev/null 2>&1 && service wazuh-indexer status > /dev/null 2>&1; then
-            service wazuh-indexer stop > /dev/null 2>&1
-            touch $restart_service
-        elif command -v /etc/init.d/wazuh-indexer > /dev/null 2>&1 && /etc/init.d/wazuh-indexer status > /dev/null 2>&1; then
-            /etc/init.d/wazuh-indexer stop > /dev/null 2>&1
-            touch $restart_service
+        echo "Stop existing ${name}.service"
+        if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1 && systemctl is-active ${name}.service > /dev/null 2>&1; then
+            systemctl --no-reload stop ${name}.service > /dev/null 2>&1
+            touch $state_file
+        elif command -v service > /dev/null 2>&1 && service ${name} status > /dev/null 2>&1; then
+            service ${name} stop > /dev/null 2>&1
+            touch $state_file
+        elif command -v /etc/init.d/${name} > /dev/null 2>&1 && /etc/init.d/${name} status > /dev/null 2>&1; then
+            /etc/init.d/${name} stop > /dev/null 2>&1
+            touch $state_file
         fi
 
-        echo "Stop existing wazuh-indexer-performance-analyzer.service"
-        if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1 && systemctl is-active wazuh-indexer-performance-analyzer.service > /dev/null 2>&1; then
-            systemctl --no-reload stop wazuh-indexer-performance-analyzer.service > /dev/null 2>&1
-        elif command -v service > /dev/null 2>&1 && service wazuh-indexer-performance-analyzer status > /dev/null 2>&1; then
-            service wazuh-indexer-performance-analyzer stop > /dev/null 2>&1
-        elif command -v /etc/init.d/wazuh-indexer-performance-analyzer > /dev/null 2>&1 && /etc/init.d/wazuh-indexer-performance-analyzer status > /dev/null 2>&1; then
-            /etc/init.d/wazuh-indexer-performance-analyzer stop > /dev/null 2>&1
+        echo "Stop existing ${name}-performance-analyzer.service"
+        if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1 && systemctl is-active ${name}-performance-analyzer.service > /dev/null 2>&1; then
+            systemctl --no-reload stop ${name}-performance-analyzer.service > /dev/null 2>&1
+        elif command -v service > /dev/null 2>&1 && service ${name}-performance-analyzer status > /dev/null 2>&1; then
+            service ${name}-performance-analyzer stop > /dev/null 2>&1
+        elif command -v /etc/init.d/${name}-performance-analyzer > /dev/null 2>&1 && /etc/init.d/${name}-performance-analyzer status > /dev/null 2>&1; then
+            /etc/init.d/${name}-performance-analyzer stop > /dev/null 2>&1
         fi
         ;;
     *)
@@ -52,8 +55,8 @@ case "$1" in
 esac
 
 # Create user and group if they do not already exist.
-getent group wazuh-indexer > /dev/null 2>&1 || groupadd -r wazuh-indexer
-getent passwd wazuh-indexer > /dev/null 2>&1 || \
-    useradd -r -g wazuh-indexer -M -s /sbin/nologin \
-        -c "wazuh-indexer user/group" wazuh-indexer
+getent group ${name} > /dev/null 2>&1 || groupadd -r ${name}
+getent passwd ${name} > /dev/null 2>&1 || \
+    useradd -r -g ${name} -M -s /sbin/nologin \
+        -c "${name} user/group" ${name}
 exit 0

--- a/distribution/packages/src/deb/debian/preinst
+++ b/distribution/packages/src/deb/debian/preinst
@@ -12,16 +12,9 @@
 set -e
 
 name="wazuh-indexer"
-product_dir=/usr/share/${name}
 config_dir=/etc/${name}
-data_dir=/var/lib/${name}
-log_dir=/var/log/${name}
-pid_dir=/run/${name}
-tmp_dir=${data_dir}/tmp
 state_file=${config_dir}/${name}.was_active
 
-# Create needed directories
-mkdir -p ${tmp_dir}
 
 echo "Running Wazuh Indexer Pre-Installation Script"
 

--- a/distribution/packages/src/deb/debian/prerm
+++ b/distribution/packages/src/deb/debian/prerm
@@ -11,28 +11,30 @@
 
 set -e
 
+name="wazuh-indexer"
+
 case "$1" in
     upgrade|deconfigure)
     ;;
     remove)
         echo "Running Wazuh Indexer Pre-Removal Script"
         # Stop existing wazuh-indexer.service
-        if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1 && systemctl is-active wazuh-indexer.service > /dev/null 2>&1; then
-            echo "Stop existing wazuh-indexer.service"
-            systemctl --no-reload stop wazuh-indexer.service > /dev/null 2>&1
-        elif command -v service > /dev/null 2>&1 && service wazuh-indexer status > /dev/null 2>&1; then
-            service wazuh-indexer stop > /dev/null 2>&1
-        elif command -v /etc/init.d/wazuh-indexer > /dev/null 2>&1 && /etc/init.d/wazuh-indexer status > /dev/null 2>&1; then
-            /etc/init.d/wazuh-indexer stop > /dev/null 2>&1
+        if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1 && systemctl is-active ${name}.service > /dev/null 2>&1; then
+            echo "Stop existing ${name}}.service"
+            systemctl --no-reload stop ${name}.service > /dev/null 2>&1
+        elif command -v service > /dev/null 2>&1 && service ${name} status > /dev/null 2>&1; then
+            service ${name} stop > /dev/null 2>&1
+        elif command -v /etc/init.d/${name} > /dev/null 2>&1 && /etc/init.d/${name} status > /dev/null 2>&1; then
+            /etc/init.d/${name} stop > /dev/null 2>&1
         fi
         # Stop existing wazuh-indexer-performance-analyzer.service
-        if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1 && systemctl is-active wazuh-indexer-performance-analyzer.service > /dev/null 2>&1; then
-            echo "Stop existing wazuh-indexer-performance-analyzer.service"
-            systemctl --no-reload stop wazuh-indexer-performance-analyzer.service > /dev/null 2>&1
-        elif command -v service > /dev/null 2>&1 && service wazuh-indexer-performance-analyzer status > /dev/null 2>&1; then
-            service wazuh-indexer-performance-analyzer stop > /dev/null 2>&1
-        elif command -v /etc/init.d/wazuh-indexer-performance-analyzer > /dev/null 2>&1 && /etc/init.d/wazuh-indexer-performance-analyzer status > /dev/null 2>&1; then
-            /etc/init.d/wazuh-indexer-performance-analyzer stop > /dev/null 2>&1
+        if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1 && systemctl is-active ${name}-performance-analyzer.service > /dev/null 2>&1; then
+            echo "Stop existing ${name}}-performance-analyzer.service"
+            systemctl --no-reload stop ${name}-performance-analyzer.service > /dev/null 2>&1
+        elif command -v service > /dev/null 2>&1 && service ${name}-performance-analyzer status > /dev/null 2>&1; then
+            service ${name}-performance-analyzer stop > /dev/null 2>&1
+        elif command -v /etc/init.d/${name}-performance-analyzer > /dev/null 2>&1 && /etc/init.d/${name}-performance-analyzer status > /dev/null 2>&1; then
+            /etc/init.d/${name}-performance-analyzer stop > /dev/null 2>&1
         fi
     ;;
     failed-upgrade)

--- a/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
+++ b/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
@@ -222,11 +222,6 @@ if ! grep -q '## OpenSearch Performance Analyzer' "$OPENSEARCH_PATH_CONF/jvm.opt
     } >> "$OPENSEARCH_PATH_CONF/jvm.options"
 fi
 
-exit 0
-
-%posttrans
-set -e
-
 # Reload systemctl daemon
 if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1; then
     systemctl daemon-reload > /dev/null 2>&1

--- a/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
+++ b/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
@@ -29,7 +29,6 @@
 %define data_dir %{_sharedstatedir}/%{name}
 %define log_dir %{_localstatedir}/log/%{name}
 %define pid_dir %{_localstatedir}/run/%{name}
-%define tmp_dir %{data_dir}/tmp
 %define state_file %{config_dir}/.was_active
 %{!?_version: %define _version 0.0.0 }
 %{!?_architecture: %define _architecture x86_64 }
@@ -69,7 +68,6 @@ cd %{_topdir} && pwd
 # Create necessary directories
 mkdir -p %{buildroot}%{pid_dir}
 mkdir -p %{buildroot}%{product_dir}/plugins
-mkdir -p %{buildroot}%{tmp_dir}
 
 # Install directories/files
 cp -a etc usr var %{buildroot}
@@ -152,7 +150,7 @@ if [ %observability_plugin -eq 1 ]; then
 fi
 
 if [ %reportsscheduler_plugin -eq 1 ]; then
-    set -- "$@" "%{config_dir}/%{name}%-reports-scheduler/reports-scheduler.yml"
+    set -- "$@" "%{config_dir}/%{name}-reports-scheduler/reports-scheduler.yml"
 fi
 
 for i in "$@"

--- a/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
+++ b/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
@@ -169,18 +169,17 @@ set -e
 
 # Stop the services to upgrade the package
 if [ $1 = 2 ]; then
-    mkdir -p %{tmp_dir}
     # Stop wazuh-indexer service
     if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1 && systemctl is-active %{name}.service > /dev/null 2>&1; then
-        echo "Stop existing %{name}.service"
         systemctl --no-reload stop %{name}.service > /dev/null 2>&1
+        echo "%{name}.service is currently active; scheduling restart after the upgrade."
         touch %{state_file}
     elif command -v service > /dev/null 2>&1 && service %{name} status > /dev/null 2>&1; then
-        echo "Stop existing %{name} service"
+        echo "%{name}.service is currently active; scheduling restart after the upgrade."
         service %{name} stop > /dev/null 2>&1
         touch %{state_file}
     elif command -v /etc/init.d/%{name} > /dev/null 2>&1 && /etc/init.d/%{name} status > /dev/null 2>&1; then
-        echo "Stop existing %{name} service"
+        echo "%{name}.service is currently active; scheduling restart after the upgrade."
         /etc/init.d/%{name} stop > /dev/null 2>&1
         touch %{state_file}
     fi
@@ -243,7 +242,7 @@ fi
 
 if [ $1 = 2 ]; then
     if [ -f %{state_file} ]; then
-        echo "Restarting %{name} service after upgrade"
+        echo "Restoring %{name}.service to its previous active state."
         rm -f %{state_file}
         if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1; then
             systemctl restart %{name}.service > /dev/null 2>&1
@@ -253,7 +252,7 @@ if [ $1 = 2 ]; then
             /etc/init.d/%{name} restart > /dev/null 2>&1
         fi
     else
-        echo "### NOT restarting %{name} service after upgrade"
+        echo "### Service will remain stopped after the upgrade (previous state preserved)."
         echo "### You can start the %{name} service by executing"
         if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1; then
             echo " sudo systemctl start %{name}.service"


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Update the RPM and DEB packaging scripts improving the service status preservation after the upgrade process, and remove the custom Java temporary folder

### Validations

<details><summary>DEB packages</summary>

- Initial installation
    ```Shellsession
    # dpkg -i wazuh-indexer_5.0.0-0_arm64_59a5a2f6-3b0c4dd-892e43b.deb
    Selecting previously unselected package wazuh-indexer.
    (Reading database ... 29263 files and directories currently installed.)
    Preparing to unpack wazuh-indexer_5.0.0-0_arm64_59a5a2f6-3b0c4dd-892e43b.deb ...
    Running Wazuh Indexer Pre-Installation Script
    Unpacking wazuh-indexer (5.0.0-0) ...
    Setting up wazuh-indexer (5.0.0-0) ...
    Running Wazuh Indexer Post-Installation Script
    ### NOT starting on installation, please execute the following statements to configure wazuh-indexer service to start automatically using systemd
     sudo systemctl daemon-reload
     sudo systemctl enable wazuh-indexer.service
    ### You can start wazuh-indexer service by executing
     sudo systemctl start wazuh-indexer.service
    ```
- Upgrade with service already running
    ```shellsession
    # dpkg -i wazuh-indexer_5.0.0-0_arm64_59a5a2f6-3b0c4dd-892e43b.deb 
    (Reading database ... 30486 files and directories currently installed.)
    Preparing to unpack wazuh-indexer_5.0.0-0_arm64_59a5a2f6-3b0c4dd-892e43b.deb ...
    Running Wazuh Indexer Pre-Installation Script
    Verifying wazuh-indexer.service is stopped to proceed with the upgrade...
    wazuh-indexer.service is currently active; scheduling restart after the upgrade.
    Stop existing wazuh-indexer-performance-analyzer.service
    Unpacking wazuh-indexer (5.0.0-0) over (5.0.0-0) ...
    Setting up wazuh-indexer (5.0.0-0) ...
    Running Wazuh Indexer Post-Installation Script
    Restoring wazuh-indexer.service to its previous active state.
    
    # sudo systemctl status wazuh-indexer.service
    ● wazuh-indexer.service - wazuh-indexer
         Loaded: loaded (/lib/systemd/system/wazuh-indexer.service; disabled; vendor p>
         Active: active (running) since Mon 2025-04-28 16:39:59 UTC; 3min 54s ago
           Docs: https://documentation.wazuh.com
       Main PID: 13322 (java)
          Tasks: 113 (limit: 9413)
         Memory: 1.5G
            CPU: 40.150s
         CGroup: /system.slice/wazuh-indexer.service
                 └─13322 /usr/share/wazuh-indexer/jdk/bin/java -Xshare:auto -Dopensear>
    ```
- Upgrade with service stopped
    ```shellsession
    # dpkg -i wazuh-indexer_5.0.0-0_arm64_59a5a2f6-3b0c4dd-892e43b.deb 
    (Reading database ... 30486 files and directories currently installed.)
    Preparing to unpack wazuh-indexer_5.0.0-0_arm64_59a5a2f6-3b0c4dd-892e43b.deb ...
    Running Wazuh Indexer Pre-Installation Script
    Verifying wazuh-indexer.service is stopped to proceed with the upgrade...
    Stop existing wazuh-indexer-performance-analyzer.service
    Unpacking wazuh-indexer (5.0.0-0) over (5.0.0-0) ...
    Setting up wazuh-indexer (5.0.0-0) ...
    Running Wazuh Indexer Post-Installation Script
    ### Service will remain stopped after the upgrade (previous state preserved).
    ### You can start wazuh-indexer service by executing
     sudo systemctl start wazuh-indexer.service
    
    # sudo systemctl status wazuh-indexer.service
    ● wazuh-indexer.service - wazuh-indexer
         Loaded: loaded (/lib/systemd/system/wazuh-indexer.service; disabled; vendor p>
         Active: inactive (dead)
           Docs: https://documentation.wazuh.com
    ```
</details>

<details><summary>RPM packages</summary>

- Initial installation
    ```Shellsession
    # rpm -i wazuh-indexer_5.0.0-0_aarch64_59a5a2f6-3b0c4dd-892e43b.rpm 
    ### NOT starting on installation, please execute the following statements to configure wazuh-indexer service to start automatically using systemd
     sudo systemctl daemon-reload
     sudo systemctl enable wazuh-indexer.service
    ### You can start the wazuh-indexer service by executing
     sudo systemctl start wazuh-indexer.service
    ```
- Upgrade with service already running
    ```shellsession
    # # rpm -i --force wazuh-indexer_5.0.0-0_aarch64_59a5a2f6-3b0c4dd-892e43b.rpm 
    wazuh-indexer.service is currently active; scheduling restart after the upgrade.
    Restoring wazuh-indexer.service to its previous active state.
    
    # sudo systemctl status wazuh-indexer.service
    ● wazuh-indexer.service - wazuh-indexer
         Loaded: loaded (/usr/lib/systemd/system/wazuh-indexer.service; enabled; prese>
         Active: active (running) since Mon 2025-04-28 17:05:54 UTC; 14s ago
           Docs: https://documentation.wazuh.com
       Main PID: 5934 (java)
          Tasks: 77 (limit: 50368)
         Memory: 1.3G
            CPU: 12.566s
         CGroup: /system.slice/wazuh-indexer.service
                 └─5934 /usr/share/wazuh-indexer/jdk/bin/java -Xshare:auto -Dopensearc>
    ```
- Upgrade with service stopped
    ```shellsession
    # rpm -i --force wazuh-indexer_5.0.0-0_aarch64_59a5a2f6-3b0c4dd-892e43b.rpm 
    ### Service will remain stopped after the upgrade (previous state preserved).
    ### You can start the wazuh-indexer service by executing
     sudo systemctl start wazuh-indexer.service

    # sudo systemctl status wazuh-indexer.service
    ○ wazuh-indexer.service - wazuh-indexer
         Loaded: loaded (/usr/lib/systemd/system/wazuh-indexer.service; enabled; prese>
         Active: inactive (dead) since Mon 2025-04-28 17:06:22 UTC; 38s ago
       Duration: 28.038s
           Docs: https://documentation.wazuh.com
       Main PID: 5934 (code=exited, status=143)
            CPU: 13.418s
    ```
</details>

### Related Issues

Closes #804 


### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
