### PR TITLE
Apply the fix to Remove custom temporary folder for Java in 5.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # build files
 artifacts/
+.devscripts
 *.deb
 *.rpm
 *.zip
@@ -9,6 +10,7 @@ integrations/amazon-security-lake/package
 
 .java
 .m2
+maven
 
 # intellij files
 .idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Deprecated
 
 ### Removed
-
+- Apply the fix to Remove custom temporary folder for Java in 5.0.0 [(#806)](https://github.com/wazuh/wazuh-indexer/pull/806)
 ### Fixed
 
 ### Security

--- a/distribution/packages/src/common/systemd/wazuh-indexer.service
+++ b/distribution/packages/src/common/systemd/wazuh-indexer.service
@@ -9,7 +9,6 @@ Type=notify
 RuntimeDirectory=wazuh-indexer
 PrivateTmp=true
 Environment=OPENSEARCH_HOME=/usr/share/wazuh-indexer
-Environment=OPENSEARCH_TMPDIR=/var/lib/wazuh-indexer/tmp
 Environment=OPENSEARCH_PATH_CONF=${path.conf}
 Environment=PID_DIR=/run/wazuh-indexer
 Environment=OPENSEARCH_SD_NOTIFY=true

--- a/distribution/packages/src/deb/debian/postinst
+++ b/distribution/packages/src/deb/debian/postinst
@@ -13,23 +13,20 @@ set -e
 
 echo "Running Wazuh Indexer Post-Installation Script"
 
-product_dir=/usr/share/wazuh-indexer
-config_dir=/etc/wazuh-indexer
-certs_dir=${config_dir}/certs
-data_dir=/var/lib/wazuh-indexer
-log_dir=/var/log/wazuh-indexer
-pid_dir=/run/wazuh-indexer
-tmp_dir=${data_dir}/tmp
-restart_service=${tmp_dir}/wazuh-indexer.restart
+name="wazuh-indexer"
+product_dir=/usr/share/${name}
+config_dir=/etc/${name}
+data_dir=/var/lib/${name}
+log_dir=/var/log/${name}
+pid_dir=/run/${name}
+state_file=${config_dir}/.was_active
 
 # Set owner
-chown -R wazuh-indexer:wazuh-indexer ${product_dir}
-chown -R wazuh-indexer:wazuh-indexer ${config_dir}
-chown -R wazuh-indexer:wazuh-indexer ${log_dir}
-chown -R wazuh-indexer:wazuh-indexer ${data_dir}
-chown -R wazuh-indexer:wazuh-indexer ${pid_dir}
-chown -R wazuh-indexer:wazuh-indexer ${tmp_dir}
-chown -R wazuh-indexer:wazuh-indexer ${certs_dir}
+chown -R ${name}:${name} ${product_dir}
+chown -R ${name}:${name} ${config_dir}
+chown -R ${name}:${name} ${log_dir}
+chown -R ${name}:${name} ${data_dir}
+chown -R ${name}:${name} ${pid_dir}
 
 export OPENSEARCH_PATH_CONF=${OPENSEARCH_PATH_CONF:-${config_dir}}
 # Apply Performance Analyzer settings, as per https://github.com/opensearch-project/opensearch-build/blob/2.18.0/scripts/pkg/build_templates/current/opensearch/deb/debian/postinst#L28-L37

--- a/distribution/packages/src/deb/debian/preinst
+++ b/distribution/packages/src/deb/debian/preinst
@@ -11,15 +11,9 @@
 
 set -e
 
-# Reference to temp directory
-tmp_dir=/var/lib/wazuh-indexer/tmp
-restart_service=${tmp_dir}/wazuh-indexer.restart
-
-# Create needed directories
-if [ -d ${tmp_dir} ]; then
-    rm -r ${tmp_dir}
-fi
-mkdir -p ${tmp_dir}
+name="wazuh-indexer"
+config_dir=/etc/${name}
+state_file=${config_dir}/.was_active
 
 echo "Running Wazuh Indexer Pre-Installation Script"
 

--- a/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
+++ b/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
@@ -29,8 +29,7 @@
 %define data_dir %{_sharedstatedir}/%{name}
 %define log_dir %{_localstatedir}/log/%{name}
 %define pid_dir %{_localstatedir}/run/%{name}
-%define tmp_dir %{data_dir}/tmp
-%define restart_service %{tmp_dir}/%{name}.restart
+%define state_file %{config_dir}/.was_active
 %{!?_version: %define _version 0.0.0 }
 %{!?_architecture: %define _architecture x86_64 }
 
@@ -69,7 +68,6 @@ cd %{_topdir} && pwd
 # Create necessary directories
 mkdir -p %{buildroot}%{pid_dir}
 mkdir -p %{buildroot}%{product_dir}/plugins
-mkdir -p %{buildroot}%{tmp_dir}
 
 # Install directories/files
 cp -a etc usr var %{buildroot}

--- a/distribution/src/config/jvm.prod.options
+++ b/distribution/src/config/jvm.prod.options
@@ -1,0 +1,93 @@
+## JVM configuration
+
+################################################################
+## IMPORTANT: JVM heap size
+################################################################
+##
+## You should always set the min and max JVM heap
+## size to the same value. For example, to set
+## the heap to 4 GB, set:
+##
+## -Xms4g
+## -Xmx4g
+##
+## See https://opensearch.org/docs/opensearch/install/important-settings/
+## for more information
+##
+################################################################
+
+# Xms represents the initial size of total heap space
+# Xmx represents the maximum size of total heap space
+
+-Xms1g
+-Xmx1g
+
+################################################################
+## Expert settings
+################################################################
+##
+## All settings below this section are considered
+## expert settings. Don't tamper with them unless
+## you understand what you are doing
+##
+################################################################
+
+## GC configuration
+8-10:-XX:+UseConcMarkSweepGC
+8-10:-XX:CMSInitiatingOccupancyFraction=75
+8-10:-XX:+UseCMSInitiatingOccupancyOnly
+
+## G1GC Configuration
+# NOTE: G1 GC is only supported on JDK version 10 or later
+# to use G1GC, uncomment the next two lines and update the version on the
+# following three lines to your version of the JDK
+# 10:-XX:-UseConcMarkSweepGC
+# 10:-XX:-UseCMSInitiatingOccupancyOnly
+11-:-XX:+UseG1GC
+11-:-XX:G1ReservePercent=25
+11-:-XX:InitiatingHeapOccupancyPercent=30
+
+## JVM temporary directory
+-Djava.io.tmpdir=${OPENSEARCH_TMPDIR}
+
+## heap dumps
+
+# generate a heap dump when an allocation from the Java heap fails
+# heap dumps are created in the working directory of the JVM
+-XX:+HeapDumpOnOutOfMemoryError
+
+# specify an alternative path for heap dumps; ensure the directory exists and
+# has sufficient space
+-XX:HeapDumpPath=/var/lib/wazuh-indexer
+
+# specify an alternative path for JVM fatal error logs
+-XX:ErrorFile=/var/log/wazuh-indexer/hs_err_pid%p.log
+
+## JDK 8 GC logging
+8:-XX:+PrintGCDetails
+8:-XX:+PrintGCDateStamps
+8:-XX:+PrintTenuringDistribution
+8:-XX:+PrintGCApplicationStoppedTime
+8:-Xloggc:/var/log/wazuh-indexer/gc.log
+8:-XX:+UseGCLogFileRotation
+8:-XX:NumberOfGCLogFiles=32
+8:-XX:GCLogFileSize=64m
+
+# JDK 9+ GC logging
+9-:-Xlog:gc*,gc+age=trace,safepoint:file=/var/log/wazuh-indexer/gc.log:utctime,pid,tags:filecount=32,filesize=64m
+
+# Explicitly allow security manager (https://bugs.openjdk.java.net/browse/JDK-8270380)
+18-:-Djava.security.manager=allow
+
+# JDK 20+ Incubating Vector Module for SIMD optimizations;
+# disabling may reduce performance on vector optimized lucene
+20-:--add-modules=jdk.incubator.vector
+
+# HDFS ForkJoinPool.common() support by SecurityManager
+-Djava.util.concurrent.ForkJoinPool.common.threadFactory=org.opensearch.secure_sm.SecuredForkJoinWorkerThreadFactory
+
+## OpenSearch Performance Analyzer
+-Dclk.tck=100
+-Djdk.attach.allowAttachSelf=true
+-Djava.security.policy=file:///etc/wazuh-indexer/opensearch-performance-analyzer/opensearch_security.policy
+--add-opens=jdk.attach/sun.tools.attach=ALL-UNNAMED


### PR DESCRIPTION
### Description
This PR applies the fix to 5.0.0 which removes the custom temporary folder for the bundle Java process (defaults to `/var/lib/wazuh-indexer/tmp`) which was causing `needrestart` to track the shared libraries being created there, asking for a `wazuh-indexer` restart after the installation of packages unrelated to Wazuh Indexer.

The default temporary folder provided by `systemd` is used instead.

It also:

- Updates Debian maintainer scripts, following the scripts from OpenSearch 2.19.1. 
- Fixes a typo on `jvm.options` file.

To test this PR, install the package on a system that mounts the `/tmp` folder with the `noexec` flag.

### Related Issues
 #769 

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
