### PR TITLE
Support new version 4.12.2-alpha0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,19 +8,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - 
 
 ### Dependencies
+- 
 
 ### Changed
 - 
 
 ### Deprecated
+- 
 
 ### Removed
-- Remove custom temporary folder for Java [(#782)](https://github.com/wazuh/wazuh-indexer/pull/782)
+- 
 
 ### Fixed
 - 
 
 ### Security
--
+- 
 
-[Unreleased 4.12.x]: https://github.com/wazuh/wazuh-indexer/compare/4.12.0...4.12.1
+[Unreleased 4.12.x]: https://github.com/wazuh/wazuh-indexer/compare/4.12.1...4.12.2

--- a/VERSION.json
+++ b/VERSION.json
@@ -1,4 +1,4 @@
 {
-    "version": "4.12.1",
+    "version": "4.12.2",
     "stage": "alpha0"
 }

--- a/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
+++ b/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
@@ -290,6 +290,8 @@ exit 0
 %ghost %attr(440, %{name}, %{name}) %{config_dir}/.was_active
 
 %changelog
+* Wed May 14 2025 support <info@wazuh.com> - 4.12.2
+- More info: https://documentation.wazuh.com/current/release-notes/release-4-12-2.html
 * Wed May 14 2025 support <info@wazuh.com> - 4.12.1
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-12-1.html
 * Wed Apr 30 2025 support <info@wazuh.com> - 4.12.0

--- a/docker/README.md
+++ b/docker/README.md
@@ -45,11 +45,11 @@ Refer to [packaging_scripts/README.md](../packaging_scripts/README.md) for detai
 The [prod](./prod) folder contains the code to build Docker images. A tarball of `wazuh-indexer` needs to be located at the same level that the Dockerfile. Below there is an example of the command needed to build the image. Set the build arguments and the image tag accordingly.
 
 ```console
-docker build --build-arg="VERSION=4.12.1" --build-arg="INDEXER_TAR_NAME=wazuh-indexer-4.12.1-1_linux-x64_cfca84f.tar.gz" --tag=wazuh-indexer:4.12.1--progress=plain --no-cache .
+docker build --build-arg="VERSION=4.12.2" --build-arg="INDEXER_TAR_NAME=wazuh-indexer-4.12.2-1_linux-x64_cfca84f.tar.gz" --tag=wazuh-indexer:4.12.2--progress=plain --no-cache .
 ```
 
 Then, start a container with:
 
 ```console
-docker run -it --rm wazuh-indexer:4.12.1
+docker run -it --rm wazuh-indexer:4.12.2
 ```

--- a/packaging_scripts/README.md
+++ b/packaging_scripts/README.md
@@ -77,7 +77,7 @@ For DEB packages, the `assemble.sh` script will perform the following operations
     ```
     artifacts/
     |-- dist
-    |   |-- wazuh-indexer-min_4.12.1_amd64.deb
+    |   |-- wazuh-indexer-min_4.12.2_amd64.deb
     `-- tmp
         `-- deb
             |-- Makefile
@@ -86,7 +86,7 @@ For DEB packages, the `assemble.sh` script will perform the following operations
             |-- etc
             |-- usr
             |-- var
-            `-- wazuh-indexer-min_4.12.1_amd64.deb
+            `-- wazuh-indexer-min_4.12.2_amd64.deb
     ```
 
     `usr`, `etc` and `var` folders contain `wazuh-indexer` files, extracted from `wazuh-indexer-min-*.deb`.
@@ -109,8 +109,8 @@ For DEB packages, the `assemble.sh` script will perform the following operations
     artifacts/
     |-- artifact_name.txt
     |-- dist
-    |   |-- wazuh-indexer-min_4.12.1_amd64.deb
-    |   `-- wazuh-indexer_4.12.1_amd64.deb
+    |   |-- wazuh-indexer-min_4.12.2_amd64.deb
+    |   `-- wazuh-indexer_4.12.2_amd64.deb
     `-- tmp
         `-- deb
             |-- Makefile
@@ -119,7 +119,7 @@ For DEB packages, the `assemble.sh` script will perform the following operations
             |-- etc
             |-- usr
             |-- var
-            |-- wazuh-indexer-min_4.12.1_amd64.deb
+            |-- wazuh-indexer-min_4.12.2_amd64.deb
             `-- debian/
                 | -- control
                 | -- copyright

--- a/release-notes/wazuh.release-notes-4.12.2.md
+++ b/release-notes/wazuh.release-notes-4.12.2.md
@@ -1,0 +1,23 @@
+## 2025-05-14 Version 4.12.2 Release Notes
+
+## [4.12.2]
+### Added
+- 
+
+### Dependencies
+- 
+
+### Changed
+- 
+
+### Deprecated
+- 
+
+### Removed
+- 
+
+### Fixed
+- 
+
+### Security
+- 


### PR DESCRIPTION
### Description
This PR adds support for a new version of Wazuh, 4.12.2.

### Related Issues
Resolves #816 

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
