### PR TITLE
Update setup-gradle version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,7 +133,7 @@ jobs:
           java-version: 21
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Provision
         if: ${{ matrix.distribution == 'deb' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased 4.13.x]
 ### Added
 - Implement version bumper script [(#802)](https://github.com/wazuh/wazuh-indexer/pull/802) [(#803)](https://github.com/wazuh/wazuh-indexer/pull/803)
-- Update setup-gradle version [(#831)](https://github.com/wazuh/wazuh-indexer/pull/831)
 
 ### Dependencies
 - 
 
 ### Changed
-- 
+- Update setup-gradle version [(#831)](https://github.com/wazuh/wazuh-indexer/pull/831)
 
 ### Deprecated
 - 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased 4.13.x]
 ### Added
 - Implement version bumper script [(#802)](https://github.com/wazuh/wazuh-indexer/pull/802) [(#803)](https://github.com/wazuh/wazuh-indexer/pull/803)
+- Update setup-gradle version [(#831)](https://github.com/wazuh/wazuh-indexer/pull/831)
 
 ### Dependencies
 - 


### PR DESCRIPTION
### Description
This PR updates the version of the action `gradle/actions/setup-gradle` to avoid the error: 
```
[call-build-workflow / build (deb, x64)](https://github.com/wazuh/wazuh-indexer/actions/runs/14861601552/job/41727678207#step:4:30)
Failed to restore gradle-home-v1|Linux|build[77a359827a47dad18812db08e6f2de33]-8a228b7cd58a22f0742490845f690f39c2dcca05: Error: Cache service responded with 422
```
### Related Issues
Closes #828 

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
