### PR TITLE
Update `ecs/generate.sh` to remove multi-fields

### DIFF
--- a/ecs/generate.sh
+++ b/ecs/generate.sh
@@ -21,7 +21,10 @@ remove_multi_fields() {
   jq 'del(
     .mappings.properties.host.properties.os.properties.full.fields,
     .mappings.properties.host.properties.os.properties.name.fields,
-    .mappings.properties.vulnerability.properties.description.fields
+    .mappings.properties.vulnerability.properties.description.fields,
+    .mappings.properties.process.properties.command_line.fields,
+    .mappings.properties.process.properties.name.fields,
+    .mappings.properties.file.properties.path.fields
   )' "$IN_FILE" > "$OUT_FILE"
 }
 


### PR DESCRIPTION
### Description
This PR updates the `ecs/generate.sh` script to remove the identified multi-fields for Inventory.

### Related Issues
Closes #827 

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
