### PR TITLE
Remove @timestamp from inventory index templates

### DIFF
--- a/ecs/generate.sh
+++ b/ecs/generate.sh
@@ -78,6 +78,11 @@ generate_mappings() {
   jq 'del(.mappings.properties.tags)' "$IN_FILE" > "$OUT_FILE"
   mv "$OUT_FILE" "$IN_FILE"
 
+  # Delete the "@timestamp" field from the index template
+  echo "Deleting the \"@timestamp\" field from the index template"
+  jq 'del(.mappings.properties.["@timestamp"])' "$IN_FILE" > "$OUT_FILE"
+  mv "$OUT_FILE" "$IN_FILE"
+
   # Remove multi-fields from the generated index template
   echo "Removing multi-fields from the index template"
   remove_multi_fields "$IN_FILE" "$OUT_FILE"


### PR DESCRIPTION
### Description
This PR removes the `@timestamp` field from the Inventory index templates.

### Related Issues
Resolves #838 

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
