### PR TITLE
Apply lintian overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Migrate smoke tests to 5.0.0 [(#863)](https://github.com/wazuh/wazuh-indexer/pull/863)
 - Replace and remove deprecated settings [(#894)](https://github.com/wazuh/wazuh-indexer/pull/894)
 - Backport packaging improvements [(#906)](https://github.com/wazuh/wazuh-indexer/pull/906)
+- Apply Lintian overrides [(#908)](https://github.com/wazuh/wazuh-indexer/pull/908)
 
 ### Deprecated
 -

--- a/distribution/packages/build.gradle
+++ b/distribution/packages/build.gradle
@@ -374,6 +374,12 @@ Closure commonDebConfig(boolean jdk, String architecture) {
     requires 'libc6'
     requires 'adduser'
 
+    into('/usr/share/lintian/overrides') {
+      from('src/deb/lintian/wazuh-indexer')
+      filePermissions {
+        unix 0644
+      }
+    }
   }
 }
 


### PR DESCRIPTION
### Description
This PR applies the wazuh-indexer lintian overrides file to be used during the generation of wazuh-indexer packages.

### Related Issues
Resolves #907 

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
