### PR TITLE
Add noninteractive option for DEB packages testing

### DIFF
--- a/.github/workflows/5_builderpackage_indexer.yml
+++ b/.github/workflows/5_builderpackage_indexer.yml
@@ -364,7 +364,7 @@ jobs:
         run: |
           sudo bash build-scripts/indexer_node_install.sh ${{ needs.setup.outputs.previous_version }}
           sudo systemctl stop wazuh-indexer
-          sudo dpkg -i "artifacts/dist/${{ steps.package.outputs.name }}"
+          sudo DEBIAN_FRONTEND=noninteractive dpkg -i "artifacts/dist/${{ steps.package.outputs.name }}"
 
           sudo apt-get remove --purge wazuh-indexer -y
 
@@ -373,7 +373,7 @@ jobs:
         run: |
 
           sudo bash build-scripts/indexer_node_install.sh ${{ needs.setup.outputs.previous_version }}
-          sudo dpkg -i "artifacts/dist/${{ steps.package.outputs.name }}"
+          sudo DEBIAN_FRONTEND=noninteractive dpkg -i "artifacts/dist/${{ steps.package.outputs.name }}"
 
 
       - name: Upload artifact


### PR DESCRIPTION
### Description
This PR adds a noninteractive option to the tests of the `wazuh-indexer` DEB pcakages to fix the bug where it was getting stuck while the update process to ask for an input value.

### Related Issues
Resolves #913 

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
