### PR TITLE
Migrate smoke tests from Allocator to docker

### DIFF
--- a/.github/workflows/5_builderpackage_indexer.yml
+++ b/.github/workflows/5_builderpackage_indexer.yml
@@ -91,17 +91,12 @@ on:
       CI_INTERNAL_DEVELOPMENT_BUCKET_USER_SECRET_KEY:
         required: true
         description: "AWS user secret key"
-      AWS_IAM_OVA_ROLE:
-        required: true
-        description: "AWS IAM role"
+
     outputs:
       name:
         description: Name of the package built.
         value: ${{ jobs.build.outputs.name }}
 
-permissions:
-  id-token: write
-  contents: read
 # ==========================
 # Bibliography
 # ==========================
@@ -265,93 +260,50 @@ jobs:
             -r ${{ inputs.revision }} \
             -l ${{ needs.build-wazuh-plugins.outputs.hash }} \
 
-      - name: Clone Wazuh Automation repository and install dependencies
-        if: ${{ matrix.distribution == 'rpm' }}
-        env:
-          username: "wazuh-devel-xdrsiem-indexer"
-        run: |
-          git clone https://${{ env.username }}:${{ secrets.INDEXER_BOT_TOKEN }}@github.com/wazuh/wazuh-automation.git
-          cd wazuh-automation
-          sudo pip3 install -r deployability/deps/requirements.txt
-
-      - name: Configure AWS credentials
-        if: ${{ matrix.distribution == 'rpm' }}
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-region: "us-east-1"
-          role-to-assume: ${{ secrets.AWS_IAM_OVA_ROLE }}
-          role-session-name: "OVA-Builder"
-
-      - name: Setup RPM environment
-        if: ${{ matrix.distribution == 'rpm' }}
-        run: |
-          bash build-scripts/rpm_setup_enviroment.sh ${{ matrix.architecture }}
-
-          ansible_host=$(grep 'ansible_host:' /tmp/inventory.yaml | sed 's/.*: *//') 
-          ansible_port=$(grep 'ansible_port:' /tmp/inventory.yaml | sed 's/.*: *//') 
-          ansible_user=$(grep 'ansible_user:' /tmp/inventory.yaml | sed 's/.*: *//') 
-          ansible_ssh_private_key_file=$(grep 'ansible_ssh_private_key_file:' /tmp/inventory.yaml | sed 's/.*: *//')
-          ssh_command="ssh -o StrictHostKeyChecking=no -i $ansible_ssh_private_key_file -p $ansible_port $ansible_user@$ansible_host"
-          scp_command="scp -o StrictHostKeyChecking=no -i $ansible_ssh_private_key_file -P $ansible_port"
-
-          echo "ansible_host=$ansible_host" >> $GITHUB_OUTPUT
-          echo "ansible_port=$ansible_port" >> $GITHUB_OUTPUT
-          echo "ansible_user=$ansible_user" >> $GITHUB_OUTPUT
-          echo "ansible_ssh_private_key_file=$ansible_ssh_private_key_file" >> $GITHUB_OUTPUT
-          echo "ssh_command=$ssh_command" >> $GITHUB_OUTPUT
-          echo "scp_command=$scp_command" >> $GITHUB_OUTPUT
-        id: setup_rpm_env
-
       - name: Test RPM package installation
         if: ${{ matrix.distribution == 'rpm' }}
-        run: |
-          # This step sends the package to the Allocator machine and installs it
-
-          # echo "hello" is needed to create the SSH connection
-          ${{ steps.setup_rpm_env.outputs.ssh_command }} 'echo "hello"' 
-          ${{ steps.setup_rpm_env.outputs.scp_command }} artifacts/dist/${{ steps.package.outputs.name }} ${{ steps.setup_rpm_env.outputs.ansible_user }}@${{ steps.setup_rpm_env.outputs.ansible_host }}:/home/${{ steps.setup_rpm_env.outputs.ansible_user }}/
-          ${{ steps.setup_rpm_env.outputs.ssh_command }} 'sudo yum localinstall -y /home/${{ steps.setup_rpm_env.outputs.ansible_user }}/${{ steps.package.outputs.name }}'
+        uses: addnab/docker-run-action@v3
+        with:
+          image: redhat/ubi9:latest
+          options: -v ${{ github.workspace }}/artifacts/dist:/artifacts/dist
+          run: |
+            yum localinstall "/artifacts/dist/${{ steps.package.outputs.name }}" -y
+          
 
       - name: Test RPM package uninstallation
         if: ${{ matrix.distribution == 'rpm' }}
-        run: |
-          # This step uninstalls the package from the Allocator machine
-
-          ${{ steps.setup_rpm_env.outputs.ssh_command }} 'sudo yum remove wazuh-indexer -y'
+        uses: addnab/docker-run-action@v3
+        with:
+          image: redhat/ubi9:latest
+          options: -v ${{ github.workspace }}/artifacts/dist:/artifacts/dist
+          run: |
+            yum localinstall "/artifacts/dist/${{ steps.package.outputs.name }}" -y
+            sudo yum remove wazuh-indexer -y
 
       - name: Test RPM package update stopping the indexer
         if: ${{ matrix.distribution == 'rpm' && (matrix.architecture == 'x64' || (needs.setup.outputs.previous_version >= '4.12' && matrix.architecture == 'arm64'))}}
-        run: |
-          # This step sends the package to the Allocator machine and the script to install a previous version
-          # Then installs the previous version, stops the indexer and installs the new version
-
-          ${{ steps.setup_rpm_env.outputs.scp_command }} artifacts/dist/${{ steps.package.outputs.name }} ${{ steps.setup_rpm_env.outputs.ansible_user }}@${{ steps.setup_rpm_env.outputs.ansible_host }}:/home/${{ steps.setup_rpm_env.outputs.ansible_user }}/
-          ${{ steps.setup_rpm_env.outputs.scp_command }} build-scripts/indexer_node_install.sh ${{ steps.setup_rpm_env.outputs.ansible_user }}@${{ steps.setup_rpm_env.outputs.ansible_host }}:/home/${{ steps.setup_rpm_env.outputs.ansible_user }}/
-          ${{ steps.setup_rpm_env.outputs.ssh_command }} << EOF
-          sudo bash /home/${{ steps.setup_rpm_env.outputs.ansible_user }}/indexer_node_install.sh ${{ needs.setup.outputs.previous_version }}
-          sudo systemctl stop wazuh-indexer
-          sudo yum localinstall "/home/${{ steps.setup_rpm_env.outputs.ansible_user }}/${{ steps.package.outputs.name }}" -y
-          EOF
+        uses: addnab/docker-run-action@v3
+        with:
+          image: redhat/ubi9:latest
+          options: 
+            -v ${{ github.workspace }}/artifacts/dist:/artifacts/dist
+            -v ${{ github.workspace }}/build-scripts/:/build-scripts/
+          run: |
+            sudo bash /build-scripts/indexer_node_install.sh ${{ needs.setup.outputs.previous_version }}
+            sudo systemctl stop wazuh-indexer
+            sudo yum localinstall "/home/${{ steps.setup_rpm_env.outputs.ansible_user }}/${{ steps.package.outputs.name }}" -y
 
       - name: Test RPM package update without stopping the indexer
         if: ${{ matrix.distribution == 'rpm' && (matrix.architecture == 'x64' || (needs.setup.outputs.previous_version >= '4.12' && matrix.architecture == 'arm64'))}}
-        run: |
-          # This step sends the package to the Allocator machine and the script to install a previous version
-          # Then installs the previous version and installs the new version without stopping the indexer
-
-          ${{ steps.setup_rpm_env.outputs.ssh_command }} 'sudo yum remove wazuh-indexer -y'
-          ${{ steps.setup_rpm_env.outputs.scp_command }} artifacts/dist/${{ steps.package.outputs.name }} ${{ steps.setup_rpm_env.outputs.ansible_user }}@${{ steps.setup_rpm_env.outputs.ansible_host }}:/home/${{ steps.setup_rpm_env.outputs.ansible_user }}/
-          ${{ steps.setup_rpm_env.outputs.scp_command }} build-scripts/indexer_node_install.sh ${{ steps.setup_rpm_env.outputs.ansible_user }}@${{ steps.setup_rpm_env.outputs.ansible_host }}:/home/${{ steps.setup_rpm_env.outputs.ansible_user }}/
-          ${{ steps.setup_rpm_env.outputs.ssh_command }} << EOF
-          sudo bash /home/${{ steps.setup_rpm_env.outputs.ansible_user }}/indexer_node_install.sh ${{ needs.setup.outputs.previous_version }}
-          sudo yum localinstall "/home/${{ steps.setup_rpm_env.outputs.ansible_user }}/${{ steps.package.outputs.name }}" -y
-          EOF
-
-      - name: Destroy Allocator Machine
-        if: ${{ matrix.distribution == 'rpm' }}
-        run: |
-          cd wazuh-automation/deployability
-          python3 modules/allocation/main.py --action delete --track-output "/tmp/track.yaml"
+        uses: addnab/docker-run-action@v3
+        with:
+          image: redhat/ubi9:latest
+          options: 
+            -v ${{ github.workspace }}/artifacts/dist:/artifacts/dist
+            -v ${{ github.workspace }}/build-scripts/:/build-scripts/
+          run: |
+            sudo bash /build-scripts/indexer_node_install.sh ${{ needs.setup.outputs.previous_version }}
+            sudo yum localinstall "/home/${{ steps.setup_rpm_env.outputs.ansible_user }}/${{ steps.package.outputs.name }}" -y
 
       - name: Test DEB package installation
         if: ${{ matrix.distribution == 'deb' }}
@@ -408,9 +360,3 @@ jobs:
           aws s3 cp "$src" "$dest"
           s3uri="${dest}${{ steps.package.outputs.name }}.sha512"
           echo "::notice::S3 sha512 URI: ${s3uri}"
-
-      - name: On failure delete Allocator Machine
-        if: ${{ matrix.distribution == 'rpm' && failure() }}
-        run: |
-          cd wazuh-automation/deployability
-          python3 modules/allocation/main.py --action delete --track-output /tmp/track.yaml

--- a/build-scripts/indexer_node_install.sh
+++ b/build-scripts/indexer_node_install.sh
@@ -116,9 +116,15 @@ chown -R wazuh-indexer:wazuh-indexer /etc/wazuh-indexer/certs
 # =====
 # Reload systemd daemon and start the service
 # =====
-systemctl daemon-reload
-systemctl enable wazuh-indexer
-systemctl start wazuh-indexer
+if command -v apt-get &> /dev/null; then
+    systemctl daemon-reload
+    systemctl enable wazuh-indexer
+    systemctl start wazuh-indexer
+else
+    chkconfig --add wazuh-indexer
+    service wazuh-indexer start
+fi
+
 
 # =====
 # Initialize indexer security


### PR DESCRIPTION
### Description
This PR migrates the smoke tests performed in Allocator provided instances to use instead docker, it was possible because of the recent changes to the packages that allow the usage of `SysV init` 

### Related Issues
Resolves #888 

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
