### PR TITLE
Change date format for the repository bumper 

### DIFF
--- a/.github/workflows/4_bumper_repository.yml
+++ b/.github/workflows/4_bumper_repository.yml
@@ -15,7 +15,7 @@ on:
         required: false
         type: string
       date:
-        description: 'Version release date (e.g. Mon Jan 02 2025)'
+        description: 'Version release date (yyyy-mm-dd, e.g. 2025-04-13)'
         default: ''
         required: false
         type: string

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -100,9 +100,12 @@ function validate_inputs() {
         exit 1
     fi
 
-    if ! [[ $date =~ ^[A-Za-z]{3}\ [A-Za-z]{3}\ [0-9]{1,2}\ [0-9]{4}$ ]]; then
+    if ! [[ $date =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
         log "Error: Invalid date format $date."
         exit 1
+    else
+        # Convert date to the required format for the script
+        date=$(LANG=en_US.UTF-8 date -d "$date" +"%a %b %d %Y")
     fi
 }
 

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -25,7 +25,7 @@ function usage() {
     echo "Usage: $0 <version> <stage> <date>"
     echo "  version:  The new version to set in VERSION.json (e.g., 4.5.0)"
     echo "  stage:    The new stage to set in VERSION.json (alpha, beta, rc, stable)"
-    echo "  date:     The date to set in the changelog (e.g., 'Mon Jan 02 2025')"
+    echo "  date:     The date to set in the changelog (e.g., '2025-04-13')"
     exit 1
 }
 
@@ -169,7 +169,6 @@ function update_rpm_changelog() {
             }
             END {
                 for (i = 1; i <= NR; i++) print lines[i]
-                if (updated) print ""
             }
         ' "$spec_file" >"${spec_file}.tmp" && mv "${spec_file}.tmp" "$spec_file"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This PR changes the date format for the repository bumper to follow the convention format: `date: string | (yyyy-mm-dd) (2025-04-13)`

### Related Issues
Resolves #942 
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
