### PR TITLE
Update `host.cpu.cores` field type to `short`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,22 +9,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add index templates for FIM and Inventory [(#744)](https://github.com/wazuh/wazuh-indexer/pull/744)
 
 ### Dependencies
-- 
+-
 
 ### Changed
 - Update setup-gradle version [(#831)](https://github.com/wazuh/wazuh-indexer/pull/831)
 - Reorganize ecs folder [(#899)](https://github.com/wazuh/wazuh-indexer/pull/899)
+- Update `host.cpu.cores` field type to `short` [(#945)](https://github.com/wazuh/wazuh-indexer/pull/945)
 
 ### Deprecated
-- 
+-
 
 ### Removed
-- 
+-
 
 ### Fixed
-- 
+-
 
 ### Security
-- 
+-
 
 [Unreleased 4.13.x]: https://github.com/wazuh/wazuh-indexer/compare/4.12.0...4.13.0

--- a/ecs/states-inventory-hardware/docs/fields.csv
+++ b/ecs/states-inventory-hardware/docs/fields.csv
@@ -1,17 +1,15 @@
 ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
-8.11.0,true,base,@timestamp,date,core,,2016-05-23T08:05:34.853Z,Date/time when the event originated.
-8.11.0,true,base,tags,keyword,core,array,"[""production"", ""env2""]",List of keywords used to tag each event.
 8.11.0,true,agent,agent.host.architecture,keyword,core,,x86_64,Operating system architecture.
 8.11.0,true,agent,agent.host.ip,ip,core,array,,Host ip addresses.
 8.11.0,true,agent,agent.id,keyword,core,,8a4f500d,Unique identifier of this agent.
 8.11.0,true,agent,agent.name,keyword,core,,foo,Custom name of the agent.
 8.11.0,true,agent,agent.version,keyword,core,,6.0.0-rc2,Version of the agent.
-8.11.0,true,host,host.cpu.cores,byte,custom,,8,Number of CPU cores.
+8.11.0,true,host,host.cpu.cores,short,custom,,8,Number of CPU cores.
 8.11.0,true,host,host.cpu.name,keyword,custom,,Intel(R) Core(TM) i7-9700K CPU @ 3.60GHz,Name/model of the CPU.
 8.11.0,true,host,host.cpu.speed,long,custom,,3600,CPU clock speed in MHz.
 8.11.0,true,host,host.memory.free,long,custom,,87191,"Free memory, in Bytes."
 8.11.0,true,host,host.memory.total,long,custom,,52584,"Total memory, in Bytes."
-8.11.0,true,host,host.memory.usage,scaled_float,custom,,0.75,"Percent memory used, between 0 and 1."
+8.11.0,true,host,host.memory.usage,float,custom,,0.75,"Percent memory used, between 0 and 1."
 8.11.0,true,host,host.memory.used,long,custom,,123456,"Used memory, in Bytes."
 8.11.0,true,host,host.serial_number,keyword,custom,,DJGAQS4CW5,Serial Number of the device.
 8.11.0,true,wazuh,wazuh.cluster.name,keyword,custom,,,Wazuh cluster name.

--- a/ecs/states-inventory-hardware/docs/fields.csv
+++ b/ecs/states-inventory-hardware/docs/fields.csv
@@ -9,7 +9,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.11.0,true,host,host.cpu.speed,long,custom,,3600,CPU clock speed in MHz.
 8.11.0,true,host,host.memory.free,long,custom,,87191,"Free memory, in Bytes."
 8.11.0,true,host,host.memory.total,long,custom,,52584,"Total memory, in Bytes."
-8.11.0,true,host,host.memory.usage,float,custom,,0.75,"Percent memory used, between 0 and 1."
+8.11.0,true,host,host.memory.usage,scaled_float,custom,,0.75,"Percent memory used, between 0 and 1."
 8.11.0,true,host,host.memory.used,long,custom,,123456,"Used memory, in Bytes."
 8.11.0,true,host,host.serial_number,keyword,custom,,DJGAQS4CW5,Serial Number of the device.
 8.11.0,true,wazuh,wazuh.cluster.name,keyword,custom,,,Wazuh cluster name.

--- a/ecs/states-inventory-hardware/fields/custom/host.yml
+++ b/ecs/states-inventory-hardware/fields/custom/host.yml
@@ -39,7 +39,7 @@
     - name: cpu.cores
       description: >
         Number of CPU cores.
-      type: byte
+      type: short
       level: custom
       example: 8
     - name: cpu.speed


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Update the field `host.cpu.cores` from `wazuh-states-inventory-hardware` index changing its type to `short`

### Related Issues
Resolves #943 
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
