### PR TITLE
Improve allocator usage

### DIFF
--- a/.github/workflows/5_builderpackage_indexer.yml
+++ b/.github/workflows/5_builderpackage_indexer.yml
@@ -338,12 +338,12 @@ jobs:
         with:
           aws-region: "us-east-1"
           role-to-assume: ${{ secrets.AWS_IAM_OVA_ROLE }}
-          role-session-name: "OVA-Builder"
+          role-session-name: "5_package_builder_indexer"
 
       - name: Setup RPM environment
         if: ${{ matrix.distribution == 'rpm' }}
         run: |
-          bash build-scripts/rpm_setup_enviroment.sh ${{ matrix.architecture }}
+          bash build-scripts/rpm_setup_enviroment.sh ${{ matrix.architecture }} ${{ github.run_id }}
 
           ansible_host=$(grep 'ansible_host:' /tmp/inventory.yaml | sed 's/.*: *//') 
           ansible_port=$(grep 'ansible_port:' /tmp/inventory.yaml | sed 's/.*: *//') 
@@ -468,7 +468,7 @@ jobs:
           echo "::notice::S3 sha512 URI: ${s3uri}"
 
       - name: On failure delete Allocator Machine
-        if: ${{ matrix.distribution == 'rpm' && failure() }}
+        if: ${{ matrix.distribution == 'rpm' && (failure() || cancelled()) }}
         run: |
           cd wazuh-automation/deployability
           python3 modules/allocation/main.py --action delete --track-output /tmp/track.yaml

--- a/build-scripts/rpm_setup_enviroment.sh
+++ b/build-scripts/rpm_setup_enviroment.sh
@@ -2,23 +2,24 @@
 
 # This script is used to set up the environment to perform the smoke tests in RPM distribution.
 #
-# Usage: rpm_setup_enviroment.sh [architecture]
+# Usage: rpm_setup_enviroment.sh [architecture] [run_id]
 #
 # Arguments:
 # - architecture    [required] The architecture of the target machine (x64 or arm64).
+# - run_id          [required] The run id to use it for the allocator instance name.
 
 
-if [ -z "$1" ]; then
-    echo "Error: Architecture argument is required."
+if [ -z "$2" ]; then
+    echo "Error: Architecture argument and run_id is required."
     exit 1
 fi
 # =====
 # Deployments based on architecture
 # =====
 if [ "$1" = "x64" ]; then
-    python3 wazuh-automation/deployability/modules/allocation/main.py --action create --provider aws --size large --composite-name linux-centos-9-amd64 --instance-name "centos_9_amd_large_aws" --inventory-output "/tmp/inventory.yaml" --track-output "/tmp/track.yaml" --label-team indexer --label-termination-date 1d --working-dir /tmp/indexer
+    python3 wazuh-automation/deployability/modules/allocation/main.py --action create --provider aws --size large --composite-name linux-centos-9-amd64 --instance-name "indexer_amd_$2" --inventory-output "/tmp/inventory.yaml" --track-output "/tmp/track.yaml" --label-team indexer --label-termination-date 1d --working-dir /tmp/indexer
 elif [ "$1" = "arm64" ]; then
-   python3 wazuh-automation/deployability/modules/allocation/main.py --action create --provider aws --size large --composite-name  linux-centos-8-arm64 --instance-name "centos_8_arm_large_aws" --inventory-output "/tmp/inventory.yaml" --track-output "/tmp/track.yaml" --label-team indexer --label-termination-date 1d --working-dir /tmp/indexer
+   python3 wazuh-automation/deployability/modules/allocation/main.py --action create --provider aws --size large --composite-name  linux-centos-8-arm64 --instance-name "indexer_arm_$2" --inventory-output "/tmp/inventory.yaml" --track-output "/tmp/track.yaml" --label-team indexer --label-termination-date 1d --working-dir /tmp/indexer
 else
     echo "Error: Invalid architecture argument. Use 'x64' or 'arm64'."
     exit 1


### PR DESCRIPTION
### Description
This PR improves the usage of allocator in our workflows
In order to do these improvements, we:
- Change the role name to a more distinctive one: `OVA-builder` → `5_package_builder_indexer`
- Add a way to delete the allocator provided machines on cancellation events
- Change the name of the instance to make it easy to understand where it comes from, we use the run ID related to the workflow to name the machines
  - Amd machines: `centos_9_amd_large_aws` → `indexer_amd_RUNID`
  - Arm machines: `centos_8_arm_large_aws` →  `indexer_arm_RUNID`

### Related Issues
Resolves https://github.com/wazuh/internal-devel-requests/issues/2535


### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
