### PR TITLE
Reduce risk of `GITHUB_TOKEN` exposure 

### DIFF
--- a/.github/workflows/build_on_push.yml
+++ b/.github/workflows/build_on_push.yml
@@ -12,6 +12,10 @@ on:
 
 jobs:
   call-build-workflow:
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
     uses: ./.github/workflows/build.yml
     secrets: inherit
     with:

--- a/.github/workflows/changelog_verifier.yml
+++ b/.github/workflows/changelog_verifier.yml
@@ -1,0 +1,21 @@
+name: "Changelog Verifier"
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+jobs:
+  # Enforces the update of a changelog file on every pull request
+  verify-changelog:
+    if: github.repository == 'wazuh/wazuh-indexer'
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: dangoslen/changelog-enforcer@v3
+        id: verify-changelog
+        with:
+          skipLabels: "autocut, skip-changelog"
+          changeLogPath: "CHANGELOG.md"
+          

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 -
 
 ### Security
--
+- Reduce risk of GITHUB_TOKEN exposure [(#959)](https://github.com/wazuh/wazuh-indexer/pull/959)
 
 [Unreleased 4.13.x]: https://github.com/wazuh/wazuh-indexer/compare/4.12.0...4.13.0


### PR DESCRIPTION
### Description
This PR adds permissions to the workflows of 4.13 branch that use `GITHUB_TOKEN` to reduce the risk of exposure of the token

### Issues Resolved
Closes https://github.com/wazuh/internal-devel-requests/issues/2508
