### PR TITLE
Reduce risk of `GITHUB_TOKEN` exposure

### DIFF
--- a/.github/workflows/5_builderpackage_docker.yml
+++ b/.github/workflows/5_builderpackage_docker.yml
@@ -69,6 +69,10 @@ on:
 
 jobs:
   call-build-workflow:
+    permissions:
+      contents: read
+      id-token: write
+      actions: read
     uses: ./.github/workflows/5_builderpackage_indexer.yml
     with:
       revision: ${{ inputs.revision }}

--- a/.github/workflows/5_builderpackage_docker_onpush.yml
+++ b/.github/workflows/5_builderpackage_docker_onpush.yml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   call-docker-workflow:
+    permissions:
+      actions: read
     uses: ./.github/workflows/5_builderpackage_docker.yml
     secrets: inherit
     with:

--- a/.github/workflows/5_builderpackage_docker_onpush.yml
+++ b/.github/workflows/5_builderpackage_docker_onpush.yml
@@ -12,6 +12,8 @@ jobs:
   call-docker-workflow:
     permissions:
       actions: read
+      contents: read
+      id-token: write
     uses: ./.github/workflows/5_builderpackage_docker.yml
     secrets: inherit
     with:

--- a/.github/workflows/5_builderpackage_indexer_onpush.yml
+++ b/.github/workflows/5_builderpackage_indexer_onpush.yml
@@ -10,6 +10,10 @@ on:
 
 jobs:
   call-build-workflow:
+    permissions:
+      actions: read
+      id-token: write
+      contents: read
     uses: ./.github/workflows/5_builderpackage_indexer.yml
     secrets: inherit
     with:

--- a/.github/workflows/6_builderpackage_indexer_onpush.yml
+++ b/.github/workflows/6_builderpackage_indexer_onpush.yml
@@ -12,6 +12,8 @@ on:
 
 jobs:
   call-build-workflow:
+    permissions:
+      actions: read
     uses: ./.github/workflows/5_builderpackage_indexer.yml
     secrets: inherit
     with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix seccomp error on `wazuh-indexer.service` [(#912)](https://github.com/wazuh/wazuh-indexer/pull/912)
 
 ### Security
--
+- Reduce risk of GITHUB_TOKEN exposure [(#960)](https://github.com/wazuh/wazuh-indexer/pull/960)
 
 [Unreleased 5.0.0]: https://github.com/wazuh/wazuh-indexer/compare/4.14.0...5.0.0


### PR DESCRIPTION
### Description
This PR adds permissions to the workflows of main branch that use `GITHUB_TOKEN` to reduce the risk of exposure of the token

### Issues Resolved
Closes https://github.com/wazuh/internal-devel-requests/issues/2508
