### PR TITLE
Update 6_builderpackage_indexer_onpush.yml

### DIFF
--- a/.github/workflows/6_builderpackage_indexer_onpush.yml
+++ b/.github/workflows/6_builderpackage_indexer_onpush.yml
@@ -18,6 +18,8 @@ jobs:
   call-build-workflow:
     permissions:
       actions: read
+      contents: read
+      id-token: write
     uses: ./.github/workflows/6_builderpackage_indexer.yml
     secrets: inherit
     with:


### PR DESCRIPTION
### Description
This PR adds the required permissions to the `6_builderpackage_indexer_onpush.yml` workflow.

> [!NOTE]
> Needs port to 6.0.0. 

### Related Issues
Resolves #988 

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
