### PR TITLE
Migrate `packages-dev.internal.wazuh.com` bucket to `xdrsiem-packages-dev-internal` 4.10.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -191,7 +191,7 @@ jobs:
         if: ${{ inputs.upload }}
         run: |
           src="artifacts/dist/${{ steps.package.outputs.name }}"
-          dest="s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/main/packages/"
+          dest="s3://xdrsiem-packages-dev-internal/development/wazuh/4.x/main/packages/"
           aws s3 cp "$src" "$dest"
           s3uri="${dest}${{ steps.package.outputs.name }}"
           echo "S3 URI: ${s3uri}"
@@ -200,7 +200,7 @@ jobs:
         if: ${{ inputs.upload && inputs.checksum }}
         run: |
           src="artifacts/dist/${{ steps.package.outputs.name }}.sha512"
-          dest="s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/main/packages/"
+          dest="s3://xdrsiem-packages-dev-internal/development/wazuh/4.x/main/packages/"
           aws s3 cp "$src" "$dest"
           s3uri="${dest}${{ steps.package.outputs.name }}.sha512"
           echo "S3 sha512 URI: ${s3uri}"


### PR DESCRIPTION
### Description
This PR migrates the bucket from `packages-dev.internal.wazuh.com` to `xdrsiem-packages-dev-internal` in the build.yml workflow.

> [!NOTE]
> This commit will be cherry-picked to branches up to 4.14.0

### Related Issues
Resolves #https://github.com/wazuh/internal-devel-requests/issues/2560
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
