### PR TITLE
Set corresponding permissions to performance analyser binary

### DIFF
--- a/distribution/packages/src/deb/debmake_install.sh
+++ b/distribution/packages/src/deb/debmake_install.sh
@@ -44,8 +44,7 @@ find "${buildroot}" -type f -exec chmod 640 {} \;
 # Permissions for the Systemd files
 systemd_files=()
 systemd_files+=("${buildroot}/${service_dir}/${name}.service")
-systemd_files+=("${buildroot}/${service_dir}/${name}-performance-analyzer.service")
-systemd_files+=("${buildroot}/${service_dir}/${name}-performance-analyzer.service")
+systemd_files+=("${buildroot}/${service_dir}/${name}-performance-analyzer.service"
 systemd_files+=("${buildroot}/etc/init.d/${name}")
 systemd_files+=("${buildroot}/usr/lib/sysctl.d/${name}.conf")
 systemd_files+=("${buildroot}/usr/lib/tmpfiles.d/${name}.conf")
@@ -81,6 +80,7 @@ fi
 
 binary_files=()
 binary_files+=("${buildroot}${product_dir}"/bin/*)
+binary_files+=("${buildroot}${product_dir}"/bin/opensearch-performance-analyzer/*)
 binary_files+=("${buildroot}${product_dir}"/jdk/bin/*)
 binary_files+=("${buildroot}${product_dir}"/jdk/lib/jspawnhelper)
 binary_files+=("${buildroot}${product_dir}"/jdk/lib/modules)


### PR DESCRIPTION

### Description
Update the `DEB` packaging scripts to set the corresponding permissions to the performance analyser binary file at service installation.

### Related Issues
Closes #656 
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
