### PR TITLE
Include Reporting plugin in Wazuh Indexer by default

### DIFF
--- a/.github/workflows/5_builderpackage_docker.yml
+++ b/.github/workflows/5_builderpackage_docker.yml
@@ -26,6 +26,11 @@ on:
         type: string
         default: "main"
         required: false
+      reporting_plugin_ref:
+        description: "Branch, commit or tag for the wazuh-indexer-reporting repository."
+        type: string
+        default: "main"
+        required: false
   workflow_call:
     inputs:
       revision:
@@ -43,6 +48,11 @@ on:
         required: false
       wazuh_plugins_ref:
         description: "Branch, commit or tag for the wazuh-indexer-plugins repository."
+        type: string
+        default: "main"
+        required: false
+      reporting_plugin_ref:
+        description: "Branch, commit or tag for the wazuh-indexer-reporting repository."
         type: string
         default: "main"
         required: false
@@ -81,6 +91,7 @@ jobs:
       architecture: '[ "x64" ]'
       id: ${{ inputs.id }}
       wazuh_plugins_ref: ${{ inputs.wazuh_plugins_ref }}
+      reporting_plugin_ref: ${{ inputs.reporting_plugin_ref }}
     secrets: inherit
 
   build-and-push-docker-image:

--- a/.github/workflows/5_builderpackage_docker_onpush.yml
+++ b/.github/workflows/5_builderpackage_docker_onpush.yml
@@ -23,3 +23,4 @@ jobs:
     with:
       id: ${{ github.ref }}
       wazuh_plugins_ref: ${{ github.event.repository.default_branch }}
+      reporting_plugin_ref: ${{ github.event.repository.default_branch }}

--- a/.github/workflows/5_builderpackage_indexer.yml
+++ b/.github/workflows/5_builderpackage_indexer.yml
@@ -150,24 +150,43 @@ jobs:
       - name: Read versions from wazuh-indexer-plugins
         id: plugins_version
         run: |
-          ls scripts/
           echo "version=$(bash ./scripts/product_version.sh)" >> "$GITHUB_OUTPUT"
 
           # Extracts the Opensearch version
-          opensearch_version=$(bash scripts/opensearch_version.sh "setup") >> "$GITHUB_OUTPUT"
+          opensearch_version=$(bash scripts/opensearch_version.sh "setup")
           echo "opensearch_version=$opensearch_version" >> "$GITHUB_OUTPUT"
+        
+  get-versions-wazuh-indexer-reporting:
+    runs-on: ubuntu-24.04
+    outputs:
+      version: ${{ steps.reporting_version.outputs.version }}
+      opensearch_version: ${{ steps.reporting_version.outputs.opensearch_version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: wazuh/wazuh-indexer-reporting
+          ref: ${{ inputs.reporting_plugin_ref }}
+
+      - name: Read versions from wazuh-indexer-reporting
+        id: reporting_version
+        run: |
+           echo "version=$(bash ./tools/product_version.sh)" >> "$GITHUB_OUTPUT"
+
+            # Extracts the Opensearch version
+            opensearch_version=$(bash tools/opensearch_version.sh)
+            echo "opensearch_version=$opensearch_version" >> "$GITHUB_OUTPUT"
 
   compatibility-check:
     runs-on: ubuntu-24.04
-    needs: [get-versions-wazuh-indexer, get-versions-wazuh-indexer-plugins]
+    needs: [get-versions-wazuh-indexer, get-versions-wazuh-indexer-plugins,  get-versions-wazuh-indexer-reporting]
     steps:
       - name: Check version compatibility
         run: |
-          if [[ "${{ needs.get-versions-wazuh-indexer.outputs.version }}" != "${{ needs.get-versions-wazuh-indexer-plugins.outputs.version }}" ]]; then
-            echo "The Wazuh Indexer version is not compatible with the plugins version."
+          if [[ ("${{ needs.get-versions-wazuh-indexer.outputs.version }}" != "${{ needs.get-versions-wazuh-indexer-plugins.outputs.version }}") || ("${{ needs.get-versions-wazuh-indexer.outputs.version }}" != "${{ needs.get-versions-wazuh-indexer-reporting.outputs.version }}") ]]; then
+            echo "The Wazuh Indexer version is not compatible with the plugins or reporting version."
             exit 1
-          elif [[ "${{ needs.get-versions-wazuh-indexer.outputs.opensearch_version }}" != "${{ needs.get-versions-wazuh-indexer-plugins.outputs.opensearch_version }}" ]]; then
-            echo "The Wazuh Indexer Opensearch version is not compatible with the plugins Opensearch version."
+          elif [[ ("${{ needs.get-versions-wazuh-indexer.outputs.opensearch_version }}" != "${{ needs.get-versions-wazuh-indexer-plugins.outputs.opensearch_version }}") && ("${{ needs.get-versions-wazuh-indexer.outputs.opensearch_version }}" != "${{ needs.get-versions-wazuh-indexer-reporting.outputs.opensearch_version }}") ]]; then
+            echo "The Wazuh Indexer Opensearch version is not compatible with the plugins or reporting Opensearch version."
             exit 1
           else
             echo "The Wazuh Indexer version and the plugins version are compatible."
@@ -251,6 +270,7 @@ jobs:
           if-no-files-found: error
 
   build-reporting-plugin:
+    needs: [compatibility-check]
     if: ${{ inputs.reporting_plugin_ref != '' }}
     runs-on: ubuntu-24.04
     outputs:

--- a/.github/workflows/5_builderpackage_indexer.yml
+++ b/.github/workflows/5_builderpackage_indexer.yml
@@ -57,6 +57,10 @@ on:
         description: "Branch, commit or tag for the wazuh-indexer-plugins repository."
         type: string
         default: "main"
+      reporting_plugin_ref:
+        description: "Branch, commit or tag for the wazuh-indexer-reporting repository."
+        type: string
+        default: "main"
   workflow_call:
     inputs:
       revision:
@@ -82,6 +86,9 @@ on:
         type: string
         required: false
       wazuh_plugins_ref:
+        type: string
+        default: "main"
+      reporting_plugin_ref:
         type: string
         default: "main"
     secrets:
@@ -243,8 +250,49 @@ jobs:
           path: "./plugins/${{ matrix.plugins }}/build/distributions/${{ env.plugin_name }}-${{ steps.version.outputs.version }}.${{ inputs.revision }}.zip"
           if-no-files-found: error
 
+  build-reporting-plugin:
+    if: ${{ inputs.reporting_plugin_ref != '' }}
+    runs-on: ubuntu-24.04
+    outputs:
+      hash: ${{ steps.save-hash.outputs.hash }}
+    env:
+      plugin_name: wazuh-indexer-reports-scheduler
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: wazuh/wazuh-indexer-reporting
+          ref: ${{ inputs.reporting_plugin_ref }}
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Setup Gradle # Used for caching
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Get version
+        id: version
+        run: echo "version=$(jq .version -r VERSION.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Build with Gradle
+        run: ./gradlew build -Dversion=${{ steps.version.outputs.version }} -Drevision=${{ inputs.revision }}
+
+      - run: ls -lR build/distributions
+
+      - name: Save commit hash
+        id: save-hash
+        run: echo "hash=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.plugin_name }}-${{ steps.version.outputs.version }}.${{ inputs.revision }}.zip
+          path: build/distributions/${{ env.plugin_name }}-${{ steps.version.outputs.version }}.${{ inputs.revision }}.zip
+          if-no-files-found: error
+  
   build:
-    needs: [setup, build-wazuh-plugins]
+    needs: [setup, build-wazuh-plugins, build-reporting-plugin]
     runs-on: ${{ matrix.architecture == 'arm64' && 'wz-linux-arm64' || 'ubuntu-24.04' }}
     strategy:
       fail-fast: false
@@ -257,13 +305,13 @@ jobs:
       # Download plugins
       - name: Download plugins
         uses: actions/download-artifact@v4
-        if: ${{ inputs.wazuh_plugins_ref != '' }}
+        if: ${{ inputs.wazuh_plugins_ref != '' || inputs.reporting_plugin_ref != '' }}
         with:
           path: ./artifacts/plugins
           merge-multiple: true
 
       - name: Display structure of downloaded files
-        if: ${{ inputs.wazuh_plugins_ref != '' }}
+        if: ${{ inputs.wazuh_plugins_ref != '' || inputs.reporting_plugin_ref != '' }}
         run: ls -lR ./artifacts/plugins
 
       - uses: actions/setup-java@v4
@@ -286,6 +334,7 @@ jobs:
             -d ${{ matrix.distribution }}  \
             -r ${{ inputs.revision }} \
             -l ${{ needs.build-wazuh-plugins.outputs.hash }} \
+            -e ${{ needs.build-reporting-plugin.outputs.hash }} \
             ${{ inputs.is_stage && '-x' || '' }} \
           )
           echo "name=$name" >> $GITHUB_OUTPUT
@@ -298,6 +347,7 @@ jobs:
             -d ${{ matrix.distribution }}  \
             -r ${{ inputs.revision }} \
             -l ${{ needs.build-wazuh-plugins.outputs.hash }} \
+            -e ${{ needs.build-reporting-plugin.outputs.hash }} \
             ${{ inputs.is_stage && '-x' || '' }} \
           )
           echo "name=$name" >> $GITHUB_OUTPUT
@@ -317,6 +367,7 @@ jobs:
             -d ${{ matrix.distribution }} \
             -r ${{ inputs.revision }} \
             -l ${{ needs.build-wazuh-plugins.outputs.hash }} \
+            -e ${{ needs.build-reporting-plugin.outputs.hash }}
 
       - name: Test RPM package installation
         if: ${{ matrix.distribution == 'rpm' }}

--- a/.github/workflows/5_builderpackage_indexer_onpush.yml
+++ b/.github/workflows/5_builderpackage_indexer_onpush.yml
@@ -23,3 +23,4 @@ jobs:
     with:
       id: ${{ github.ref }}
       wazuh_plugins_ref: ${{ github.event.repository.default_branch }}
+      reporting_plugin_ref: ${{ github.event.repository.default_branch }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add custom GitHub Action to validate commiter's emails by domain [(#896)](https://github.com/wazuh/wazuh-indexer/pull/896)
 - Migrate to OpenSearch 3.0.0 [(#903)](https://github.com/wazuh/wazuh-indexer/pull/903)
 - Add Wazuh version comparison [(#936)](https://github.com/wazuh/wazuh-indexer/pull/936)
+- Include Reporting plugin in Wazuh Indexer by default [(#1008)](https://github.com/wazuh/wazuh-indexer/pull/1008)
 
 ### Dependencies
 -

--- a/build-scripts/README.md
+++ b/build-scripts/README.md
@@ -41,6 +41,7 @@ Usage: ./builder.sh [args]
 
 Arguments:
 -p INDEXER_PLUGINS_BRANCH     [Optional] wazuh-indexer-plugins repo branch, default is 'main'.
+-r INDEXER_REPORTING_BRANCH   [Optional] wazuh-indexer-reporting repo branch, default is 'main'
 -R REVISION                   [Optional] Package revision, default is '0'.
 -s STAGE                      [Optional] Staging build, default is 'false'.
 -d DISTRIBUTION               [Optional] Distribution, default is 'rpm'.
@@ -58,7 +59,7 @@ bash builder.sh -d deb -a x64 -R 1 -s true
 
 The resulting package will be stored at `wazuh-indexer/artifacts/dist`.
 
-> The `STAGE` option defines the naming of the package. When set to `false`, the package will be unequivocally named with the commits' SHA of the `wazuh-indexer` and `wazuh-indexer-plugins`repositories, in that order. For example: `wazuh-indexer_<version>-<revision>_x86_64_aff30960363-846f143.rpm`.
+> The `STAGE` option defines the naming of the package. When set to `false`, the package will be unequivocally named with the commits' SHA of the `wazuh-indexer`, `wazuh-indexer-plugins` and `wazuh-indexer-reporting` repositories, in that order. For example: `wazuh-indexer_6.0.0-0_x86_64_aff30960363-846f143-494d125.rpm`.
 
 ## Building wazuh-indexer Docker images
 

--- a/build-scripts/README.md
+++ b/build-scripts/README.md
@@ -59,7 +59,7 @@ bash builder.sh -d deb -a x64 -R 1 -s true
 
 The resulting package will be stored at `wazuh-indexer/artifacts/dist`.
 
-> The `STAGE` option defines the naming of the package. When set to `false`, the package will be unequivocally named with the commits' SHA of the `wazuh-indexer`, `wazuh-indexer-plugins` and `wazuh-indexer-reporting` repositories, in that order. For example: `wazuh-indexer_6.0.0-0_x86_64_aff30960363-846f143-494d125.rpm`.
+> The `STAGE` option defines the naming of the package. When set to `false`, the package will be unequivocally named with the commits' SHA of the `wazuh-indexer`, `wazuh-indexer-plugins` and `wazuh-indexer-reporting` repositories, in that order. For example: `wazuh-indexer_<version>-<revision>_x86_64_aff30960363-846f143-494d125.rpm`.
 
 ## Building wazuh-indexer Docker images
 

--- a/build-scripts/REFERENCE.md
+++ b/build-scripts/REFERENCE.md
@@ -49,6 +49,7 @@ scripts:
       distribution: [tar, deb, rpm]
       revision: revision number. 0 by default.
       plugins_hash: Commit hash of the `wazuh-indexer-plugins` repository.
+      reporting_hash: Commit hash of the `wazuh-indexer-reporting` repository.
       is_release: if set, uses release naming convention.
       is_min: if set, the package name will start by `wazuh-indexer-min`. Used on the build stage.
     outputs:

--- a/build-scripts/assemble.sh
+++ b/build-scripts/assemble.sh
@@ -41,7 +41,6 @@ else
     wazuh_plugins=(
         "wazuh-indexer-setup"
         "wazuh-indexer-reports-scheduler"
-
     )
 fi
 
@@ -257,7 +256,7 @@ function generate_installer_version_file() {
     local dir
     dir="${1}"
     jq \
-        --arg commit "${INDEXER_HASH}-${PLUGINS_HASH}-${REPORTING_HASH}" \
+      --arg commit "${INDEXER_HASH}-${PLUGINS_HASH}-${REPORTING_HASH}" \
       '. + {"commit": $commit}' \
       "${REPO_PATH}"/VERSION.json > "${dir}"/VERSION.json
 }

--- a/build-scripts/assemble.sh
+++ b/build-scripts/assemble.sh
@@ -67,7 +67,7 @@ function usage() {
 # ====
 function parse_args() {
 
-    while getopts ":h:o:p:a:d:r:l:e:" arg; do
+    while getopts ":ho:p:a:d:r:l:e:" arg; do
         case $arg in
         h)
             usage

--- a/build-scripts/assemble.sh
+++ b/build-scripts/assemble.sh
@@ -40,6 +40,8 @@ else
     )
     wazuh_plugins=(
         "wazuh-indexer-setup"
+        "wazuh-indexer-reports-scheduler"
+
     )
 fi
 
@@ -55,6 +57,7 @@ function usage() {
     echo -e "-d DISTRIBUTION\t[Optional] Distribution, default is 'tar'."
     echo -e "-r REVISION\t[Optional] Package revision, default is '0'."
     echo -e "-l PLUGINS_HASH\t[Optional] wazuh-indexer-plugins commit hash, default is '0'."
+    echo -e "-e REPORTING_HASH\t[Optional] wazuh-indexer-reporting commit hash, default is '0'."
     echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."
     echo -e "-h help"
 }
@@ -88,6 +91,11 @@ function parse_args() {
         l)
             PLUGINS_HASH=$OPTARG
             ;;
+        e)
+
+            REPORTING_HASH=$OPTARG
+
+            ;;
         :)
             echo "Error: -${OPTARG} requires an argument"
             usage
@@ -110,6 +118,7 @@ function parse_args() {
     [ -z "$DISTRIBUTION" ] && DISTRIBUTION="tar"
     [ -z "$REVISION" ] && REVISION="0"
     [ -z "$PLUGINS_HASH" ] && PLUGINS_HASH="0"
+    [ -z "$REPORTING_HASH" ] && REPORTING_HASH="0"
 
     case $PLATFORM-$DISTRIBUTION-$ARCHITECTURE in
     linux-tar-x64 | darwin-tar-x64)
@@ -248,7 +257,7 @@ function generate_installer_version_file() {
     local dir
     dir="${1}"
     jq \
-      --arg commit "${INDEXER_HASH}-${PLUGINS_HASH}" \
+        --arg commit "${INDEXER_HASH}-${PLUGINS_HASH}-${REPORTING_HASH}" \
       '. + {"commit": $commit}' \
       "${REPO_PATH}"/VERSION.json > "${dir}"/VERSION.json
 }

--- a/build-scripts/baptizer.sh
+++ b/build-scripts/baptizer.sh
@@ -11,6 +11,7 @@ function usage() {
     echo -e "-d DISTRIBUTION\t[Optional] Distribution, default is 'tar'."
     echo -e "-r REVISION\t[Optional] Package revision, default is '0'."
     echo -e "-l PLUGINS_HASH\t[Optional] Commit hash from the wazuh-indexer-plugins repository"
+    echo -e "-e REPORTING_HASH\t[Optional] Commit hash from the wazuh-indexer-reporting repository"
     echo -e "-m MIN\t[Optional] Use naming convention for minimal packages, default is 'false'."
     echo -e "-x RELEASE\t[Optional] Use release naming convention, default is 'false'."
     echo -e "-h help"
@@ -41,6 +42,11 @@ function parse_args() {
             ;;
         l)
             PLUGINS_HASH=$OPTARG
+            ;;
+         e)
+
+            REPORTING_HASH=$OPTARG
+
             ;;
         m)
             IS_MIN=true
@@ -133,8 +139,8 @@ function get_devel_name() {
         PREFIX="$PREFIX"-min
     fi
     # Generate composed commit hash
-    if [ -n "$PLUGINS_HASH" ]; then
-        COMMIT_HASH="$GIT_COMMIT"-"$PLUGINS_HASH"
+    if [ -n "$PLUGINS_HASH" ] && [ -n "$REPORTING_HASH" ]; then
+        COMMIT_HASH="$GIT_COMMIT"-"$PLUGINS_HASH"-"$REPORTING_HASH"
     fi
     PACKAGE_NAME="$PREFIX"_"$VERSION"-"$REVISION"_"$SUFFIX"_"$COMMIT_HASH"."$EXT"
 }

--- a/build-scripts/baptizer.sh
+++ b/build-scripts/baptizer.sh
@@ -22,7 +22,7 @@ function usage() {
 # ====
 function parse_args() {
 
-    while getopts ":h:p:a:d:r:l:e:mx" arg; do
+    while getopts ":hp:a:d:r:l:e:mx" arg; do
         case $arg in
         h)
             usage

--- a/build-scripts/build.sh
+++ b/build-scripts/build.sh
@@ -32,7 +32,7 @@ function usage() {
 # ====
 function parse_args() {
 
-    while getopts ":h:q:s:o:p:a:d:r:b:n:" arg; do
+    while getopts ":hq:s:o:p:a:d:r:b:n:" arg; do
         case $arg in
         h)
             usage

--- a/build-scripts/builder/Dockerfile
+++ b/build-scripts/builder/Dockerfile
@@ -61,7 +61,9 @@ RUN addgroup --gid 1000 wazuh-indexer && \
 
 # Create repositories path
 RUN mkdir -p /repositories/wazuh-indexer-plugins && \
-    chown wazuh-indexer:wazuh-indexer /repositories/wazuh-indexer-plugins
+    mkdir -p /repositories/wazuh-indexer-reporting && \
+    chown wazuh-indexer:wazuh-indexer /repositories/wazuh-indexer-plugins && \
+    chown wazuh-indexer:wazuh-indexer /repositories/wazuh-indexer-reporting
 
 # Copy your build scripts into the container as root
 COPY build-scripts/builder/entrypoint.sh /

--- a/build-scripts/builder/builder.sh
+++ b/build-scripts/builder/builder.sh
@@ -35,6 +35,9 @@ function parse_args() {
         p)
             INDEXER_PLUGINS_BRANCH=$OPTARG
             ;;
+        r)
+            INDEXER_REPORTING_BRANCH=$OPTARG
+            ;;
         R)
             REVISION=$OPTARG
             ;;
@@ -64,6 +67,7 @@ function parse_args() {
 
     ## Set defaults:
     [ -z "$INDEXER_PLUGINS_BRANCH" ] && INDEXER_PLUGINS_BRANCH="main"
+    [ -z "$INDEXER_REPORTING_BRANCH" ] && INDEXER_REPORTING_BRANCH="main"
     [ -z "$REVISION" ] && REVISION="0"
     [ -z "$IS_STAGE" ] && IS_STAGE="false"
     [ -z "$DISTRIBUTION" ] && DISTRIBUTION="rpm"
@@ -79,6 +83,7 @@ function usage() {
     echo ""
     echo "Arguments:"
     echo -e "-p INDEXER_PLUGINS_BRANCH\t[Optional] wazuh-indexer-plugins repo branch, default is 'main'."
+    echo -e "-r INDEXER_REPORTING_BRANCH\t[Optional] wazuh-indexer-reporting repo branch, default is 'main'."
     echo -e "-R REVISION\t[Optional] Package revision, default is '0'."
     echo -e "-s STAGE\t[Optional] Staging build, default is 'false'."
     echo -e "-d DISTRIBUTION\t[Optional] Distribution, default is 'rpm'."
@@ -99,6 +104,7 @@ function main() {
     export REPO_PATH
     export VERSION
     export INDEXER_PLUGINS_BRANCH
+    export INDEXER_REPORTING_BRANCH
     export REVISION
     export IS_STAGE
     export DISTRIBUTION

--- a/build-scripts/builder/compose.yml
+++ b/build-scripts/builder/compose.yml
@@ -7,6 +7,7 @@ services:
       dockerfile: ${REPO_PATH}/build-scripts/builder/Dockerfile
     environment:
       - INDEXER_PLUGINS_BRANCH=${INDEXER_PLUGINS_BRANCH:-main}
+      - INDEXER_REPORTING_BRANCH=${INDEXER_REPORTING_BRANCH:-main}
       - REVISION=${REVISION:-0}
       - IS_STAGE=${IS_STAGE:-false}
       - DISTRIBUTION=${DISTRIBUTION:-rpm}
@@ -14,8 +15,10 @@ services:
     volumes:
       - ${REPO_PATH}:/home/wazuh-indexer
       - wazuh-indexer-plugins:/home/wazuh-indexer/wazuh-indexer-plugins
+      - wazuh-indexer-reporting:/home/wazuh-indexer/wazuh-indexer-reporting
     entrypoint: ["/bin/bash", "/entrypoint.sh"]
     user: "1000:1000"
     working_dir: /home/wazuh-indexer
 volumes:
   wazuh-indexer-plugins:
+  wazuh-indexer-reporting:


### PR DESCRIPTION
### Description
This PR adds the reporting plugin from [wazuh-indexer-reporting](https://github.com/wazuh/wazuh-indexer-reporting) repository to wazuh indexer package by default

To include the plugin, the workflows and build-scripts have received changes

### Related Issues
Resolves #999 

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
