### PR TITLE
Fix auto-generated demo certificates naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix package upload to bucket subfolder 5.x [(#846)](https://github.com/wazuh/wazuh-indexer/pull/846)
 - Fix seccomp error on `wazuh-indexer.service` [(#912)](https://github.com/wazuh/wazuh-indexer/pull/912)
 - Fix CodeQL workflow [(#963)](https://github.com/wazuh/wazuh-indexer/pull/963)
+- Fix auto-generated demo certificates naming [(#1010)](https://github.com/wazuh/wazuh-indexer/pull/1010)
 
 ### Security
 - Reduce risk of GITHUB_TOKEN exposure [(#960)](https://github.com/wazuh/wazuh-indexer/pull/960)

--- a/build-scripts/indexer_node_install.sh
+++ b/build-scripts/indexer_node_install.sh
@@ -107,6 +107,7 @@ EOF
 # =====
 mkdir -p /etc/wazuh-indexer/certs
 tar -xf ./wazuh-certificates.tar -C /etc/wazuh-indexer/certs/ ./node-1.pem ./node-1-key.pem ./admin.pem ./admin-key.pem ./root-ca.pem
+# Differs from the install documentation replacing `mv -n` to just `mv` ensuring the files are always moved, even if they already exist.
 mv /etc/wazuh-indexer/certs/node-1.pem /etc/wazuh-indexer/certs/indexer.pem
 mv /etc/wazuh-indexer/certs/node-1-key.pem /etc/wazuh-indexer/certs/indexer-key.pem
 chmod 500 /etc/wazuh-indexer/certs

--- a/build-scripts/indexer_node_install.sh
+++ b/build-scripts/indexer_node_install.sh
@@ -107,8 +107,8 @@ EOF
 # =====
 mkdir -p /etc/wazuh-indexer/certs
 tar -xf ./wazuh-certificates.tar -C /etc/wazuh-indexer/certs/ ./node-1.pem ./node-1-key.pem ./admin.pem ./admin-key.pem ./root-ca.pem
-mv -n /etc/wazuh-indexer/certs/node-1.pem /etc/wazuh-indexer/certs/indexer.pem
-mv -n /etc/wazuh-indexer/certs/node-1-key.pem /etc/wazuh-indexer/certs/indexer-key.pem
+mv /etc/wazuh-indexer/certs/node-1.pem /etc/wazuh-indexer/certs/indexer.pem
+mv /etc/wazuh-indexer/certs/node-1-key.pem /etc/wazuh-indexer/certs/indexer-key.pem
 chmod 500 /etc/wazuh-indexer/certs
 chmod 400 /etc/wazuh-indexer/certs/*
 chown -R wazuh-indexer:wazuh-indexer /etc/wazuh-indexer/certs

--- a/distribution/packages/src/common/scripts/install-demo-certificates.sh
+++ b/distribution/packages/src/common/scripts/install-demo-certificates.sh
@@ -9,6 +9,7 @@
 # Directories
 TMP_DIR="/tmp/wazuh-indexer/certs"
 CERTS_DIR="/etc/wazuh-indexer/certs"
+$CERTS_NAME="indexer"
 
 # Create directories
 mkdir -p "$TMP_DIR"
@@ -24,9 +25,9 @@ openssl req -new -key "$TMP_DIR/admin-key.pem" -subj "/C=US/L=California/O=Wazuh
 openssl x509 -req -in "$TMP_DIR/admin.csr" -CA "$TMP_DIR/root-ca.pem" -CAkey "$TMP_DIR/root-ca-key-temp.pem" -CAcreateserial -sha256 -out "$TMP_DIR/admin.pem" -days 3650
 
 # Node cert
-openssl genrsa -out "$TMP_DIR/indexer-1-key-temp.pem" 2048
-openssl pkcs8 -inform PEM -outform PEM -in "$TMP_DIR/indexer-1-key-temp.pem" -topk8 -nocrypt -v1 PBE-SHA1-3DES -out "$TMP_DIR/indexer-1-key.pem"
-openssl req -new -key "$TMP_DIR/indexer-1-key.pem" -subj "/C=US/L=California/O=Wazuh/OU=Wazuh/CN=node-0.wazuh.indexer" -out "$TMP_DIR/indexer.csr"
+openssl genrsa -out "$TMP_DIR/$CERTS_NAME-key-temp.pem" 2048
+openssl pkcs8 -inform PEM -outform PEM -in "$TMP_DIR/$CERTS_NAME-key-temp.pem" -topk8 -nocrypt -v1 PBE-SHA1-3DES -out "$TMP_DIR/$CERTS_NAME-key.pem"
+openssl req -new -key "$TMP_DIR/$CERTS_NAME-key.pem" -subj "/C=US/L=California/O=Wazuh/OU=Wazuh/CN=node-0.wazuh.indexer" -out "$TMP_DIR/indexer.csr"
 cat <<'INDEXER_EXT' >$TMP_DIR/indexer.ext
 subjectAltName = @alt_names
 [alt_names]
@@ -37,7 +38,7 @@ IP.1 = 127.0.0.1
 IP.2 =  0:0:0:0:0:0:0:1
 INDEXER_EXT
 
-openssl x509 -req -in "$TMP_DIR/indexer.csr" -CA "$TMP_DIR/root-ca.pem" -CAkey "$TMP_DIR/root-ca-key-temp.pem" -CAcreateserial -sha256 -out "$TMP_DIR/indexer-1.pem" -days 3650 -extfile "$TMP_DIR/indexer.ext"
+openssl x509 -req -in "$TMP_DIR/indexer.csr" -CA "$TMP_DIR/root-ca.pem" -CAkey "$TMP_DIR/root-ca-key-temp.pem" -CAcreateserial -sha256 -out "$TMP_DIR/$CERTS_NAME.pem" -days 3650 -extfile "$TMP_DIR/indexer.ext"
 
 # Cleanup temporary files
 rm "$TMP_DIR/"*.csr "$TMP_DIR"/*.ext "$TMP_DIR"/*.srl "$TMP_DIR"/*-temp.pem

--- a/distribution/packages/src/common/scripts/install-demo-certificates.sh
+++ b/distribution/packages/src/common/scripts/install-demo-certificates.sh
@@ -9,7 +9,7 @@
 # Directories
 TMP_DIR="/tmp/wazuh-indexer/certs"
 CERTS_DIR="/etc/wazuh-indexer/certs"
-$CERTS_NAME="indexer"
+CERTS_NAME="indexer"
 
 # Create directories
 mkdir -p "$TMP_DIR"


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Fix the naming of the auto-generated demo certificates to match the defaults on the `opensearch.yml` configuration file.

### Related Issues
Resolves #1011 

### Validation
- RPM package installs and generates the certificates correctly
    ```console
    # rpm -i wazuh-indexer_5.0.0-0_aarch64_34c35184-162b39d.rpm 
    ### NOT starting on installation, please execute the following statements to configure wazuh-indexer service to start automatically using systemd
     sudo systemctl daemon-reload
     sudo systemctl enable wazuh-indexer.service
    ### You can start wazuh-indexer service by executing
     sudo systemctl start wazuh-indexer.service
    ### Installing wazuh-indexer demo certificates in /etc/wazuh-indexer
     If you are using a custom certificates path, ignore this message
     See demo certs creation log in /var/log/wazuh-indexer/install_demo_certificates.log
    ```
    ```console
    # ls /etc/wazuh-indexer/certs/
    admin-key.pem  admin.pem  indexer-key.pem  indexer.pem  root-ca.pem
    ```
- DEB package installs and generates the certificates correctly
    ```console
    # dpkg -i wazuh-indexer_5.0.0-0_arm64_34c35184-162b39d.deb 
    Selecting previously unselected package wazuh-indexer.
    (Reading database ... 29249 files and directories currently installed.)
    Preparing to unpack wazuh-indexer_5.0.0-0_arm64_34c35184-162b39d.deb ...
    Running Wazuh Indexer Pre-Installation Script
    Unpacking wazuh-indexer (5.0.0-0) ...
    Setting up wazuh-indexer (5.0.0-0) ...
    Running Wazuh Indexer Post-Installation Script
    ### NOT starting on installation, please execute the following statements to configure wazuh-indexer service to start automatically using systemd
     sudo systemctl daemon-reload
     sudo systemctl enable wazuh-indexer.service
    ### You can start wazuh-indexer service by executing
     sudo systemctl start wazuh-indexer.service
    ### Installing wazuh-indexer demo certificates in /etc/wazuh-indexer
     If you are using a custom certificates path, ignore this message
     See demo certs creation log in /var/log/wazuh-indexer/install_demo_certificates.log
    ```
    ```console
    ls /etc/wazuh-indexer/certs/
    admin-key.pem  admin.pem  indexer-key.pem  indexer.pem	root-ca.pem
    ```
### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
