### PR TITLE
Add default configuration to allow the AI assistant deployment from the UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - Add check to confirm if wazuh-indexer service is running after upgrade [(#940)](https://github.com/wazuh/wazuh-indexer/pull/940)
 - Add users and groups ECS mappings [(#890)](https://github.com/wazuh/wazuh-indexer/pull/890)
+- Add default configuration to allow the AI assistant deployment from the UI [(#1077)](https://github.com/wazuh/wazuh-indexer/pull/1077)
 
 ### Dependencies
 -

--- a/distribution/src/config/opensearch.prod.yml
+++ b/distribution/src/config/opensearch.prod.yml
@@ -36,7 +36,17 @@ plugins.security.restapi.roles_enabled:
 - "security_rest_api_access"
 
 plugins.security.system_indices.enabled: true
-plugins.security.system_indices.indices: [".plugins-ml-model", ".plugins-ml-task", ".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-anomaly-results*", ".opendistro-anomaly-detector*", ".opendistro-anomaly-checkpoints", ".opendistro-anomaly-detection-state", ".opendistro-reports-*", ".opensearch-notifications-*", ".opensearch-notebooks", ".opensearch-observability", ".opendistro-asynchronous-search-response*", ".replication-metadata-store"]
+plugins.security.system_indices.permission.enabled: true
+plugins.security.system_indices.indices: [.plugins-ml-agent, .plugins-ml-config, .plugins-ml-connector,
+  .plugins-ml-controller, .plugins-ml-model-group, .plugins-ml-model, .plugins-ml-task,
+  .plugins-ml-conversation-meta, .plugins-ml-conversation-interactions, .plugins-ml-memory-meta,
+  .plugins-ml-memory-message, .plugins-ml-stop-words, .opendistro-alerting-config,
+  .opendistro-alerting-alert*, .opendistro-anomaly-results*, .opendistro-anomaly-detector*,
+  .opendistro-anomaly-checkpoints, .opendistro-anomaly-detection-state, .opendistro-reports-*,
+  .opensearch-notifications-*, .opensearch-notebooks, .opensearch-observability, .ql-datasources,
+  .opendistro-asynchronous-search-response*, .replication-metadata-store, .opensearch-knn-models,
+  .geospatial-ip2geo-data*, .plugins-flow-framework-config, .plugins-flow-framework-templates,
+  .plugins-flow-framework-state, .plugins-search-relevance-experiment, .plugins-search-relevance-judgment-cache]
 
 ### Option to allow Filebeat-oss 7.10.2 to work ###
 compatibility.override_main_response_version: true

--- a/distribution/src/config/security/roles.yml
+++ b/distribution/src/config/security/roles.yml
@@ -391,3 +391,38 @@ manage_wazuh_index:
     - "index"
   tenant_permissions: []
   static: false
+
+# Role to grant read access to ML related indices. Used to configure the AI assistant from the UI.
+ml_config_read:
+  reserved: true
+  hidden: false
+  cluster_permissions: []
+  index_permissions:
+  - index_patterns:
+    - ".plugins-ml-model"
+    - ".plugins-ml-connector"
+    - ".plugins-ml-agent"
+    - ".plugins-ml-config"
+    dls: ""
+    fls: []
+    masked_fields: []
+    allowed_actions:
+    - "read"
+  tenant_permissions: []
+  static: false
+
+# Role to grant write access to ML related indices. Used to configure the AI assistant from the UI.
+ml_config_write:
+  reserved: true
+  hidden: false
+  cluster_permissions: []
+  index_permissions:
+  - index_patterns:
+    - ".plugins-ml-config"
+    dls: ""
+    fls: []
+    masked_fields: []
+    allowed_actions:
+    - "write"
+  tenant_permissions: []
+  static: false

--- a/distribution/src/config/security/roles_mapping.yml
+++ b/distribution/src/config/security/roles_mapping.yml
@@ -85,3 +85,21 @@ manage_wazuh_index:
   users:
   - "kibanaserver"
   and_backend_roles: []
+
+# To allow the AI assistant deployment from the UI.
+ml_config_read:
+  reserved: true
+  hidden: false
+  backend_roles: []
+  hosts: []
+  users:
+  - "admin"
+  and_backend_roles: []
+ml_config_write:
+  reserved: true
+  hidden: false
+  backend_roles: []
+  hosts: []
+  users:
+  - "admin"
+  and_backend_roles: []


### PR DESCRIPTION
### Description
This PR adds the required configuration settings to enable the deployment of the AI assistant.

It also includes two new roles to grant access to system indices that take part in the AI assistant deployment. They are mapped to the `admin` user by default.

### Related Issues
Resolves #1067

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
