### PR TITLE
Revert auto-replicas setting for Inventory Enrichment tier 2 indices

### DIFF
--- a/ecs/states-inventory-browser-extensions/fields/template-settings-legacy.json
+++ b/ecs/states-inventory-browser-extensions/fields/template-settings-legacy.json
@@ -5,7 +5,6 @@
     "index": {
       "number_of_shards": "1",
       "number_of_replicas": "0",
-      "auto_expand_replicas": "0-1",
       "refresh_interval": "2s",
       "query.default_field": [
         "agent.host.architecture",

--- a/ecs/states-inventory-browser-extensions/fields/template-settings.json
+++ b/ecs/states-inventory-browser-extensions/fields/template-settings.json
@@ -8,7 +8,6 @@
             "index": {
                 "number_of_shards": "1",
                 "number_of_replicas": "0",
-                "auto_expand_replicas": "0-1",
                 "refresh_interval": "2s",
                 "query.default_field": [
                     "agent.host.architecture",

--- a/ecs/states-inventory-services/fields/template-settings-legacy.json
+++ b/ecs/states-inventory-services/fields/template-settings-legacy.json
@@ -7,7 +7,6 @@
         "index": {
             "number_of_shards": "1",
             "number_of_replicas": "0",
-            "auto_expand_replicas": "0-1",
             "refresh_interval": "2s",
             "query.default_field": [
                 "agent.host.architecture",

--- a/ecs/states-inventory-services/fields/template-settings.json
+++ b/ecs/states-inventory-services/fields/template-settings.json
@@ -8,7 +8,6 @@
             "index": {
                 "number_of_shards": "1",
                 "number_of_replicas": "0",
-                "auto_expand_replicas": "0-1",
                 "refresh_interval": "2s",
                 "query.default_field": [
                     "agent.host.architecture",


### PR DESCRIPTION
### Description
This PR removes the index setting to automatically create replicas whenever possible from the  Inventory Enrichment tier 2 indices.

### Related Issues
Resolves #1102 

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
