### PR TITLE
Change Eclipse mirror

### DIFF
--- a/gradle/formatting.gradle
+++ b/gradle/formatting.gradle
@@ -82,7 +82,7 @@ allprojects {
               '\\#java|\\#org.opensearch|\\#org.hamcrest|\\#'
           )
 
-          eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://mirror.umd.edu/eclipse/")).configFile rootProject.file('buildSrc/formatterConfig.xml')
+          eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://mirrors.xmission.com/eclipse/")).configFile rootProject.file('buildSrc/formatterConfig.xml')
           trimTrailingWhitespace()
           endWithNewline()
 


### PR DESCRIPTION
### Description
This PR updates the Eclipse mirror, replacing the down site https://mirror.umd.edu/eclipse/ with https://mirrors.xmission.com/eclipse/.

> [!NOTE]
> This PR is a temporary measure to allow buidling packages on the main branch. We expected the main mirror to be online again soon, so this PR is not planned to be merged for now. 

### Related Issues
Resolves #1106

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
