### PR TITLE
Remove opensearch-security-analytics plugin from Wazuh Indexer packages

### DIFF
--- a/packaging_scripts/assemble.sh
+++ b/packaging_scripts/assemble.sh
@@ -37,7 +37,7 @@ else
         "performance-analyzer" # "opensearch-performance-analyzer"
         "opensearch-reports-scheduler"
         "opensearch-security"
-        "opensearch-security-analytics"
+        # "opensearch-security-analytics" # Flagged as Trojan by some antivirus software
         "opensearch-sql-plugin" # "opensearch-sql"
     )
 fi


### PR DESCRIPTION
### Description
The PR removes the opensearch-security-analytics plugin from the Wazuh Indexer packages.

### Related Issues
Resolves n/a

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
