### PR TITLE
Fix SysV service script permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix auto-generated demo certificates naming [(#1010)](https://github.com/wazuh/wazuh-indexer/pull/1010)
 - Fix service status preservation during upgrade in RPM packages [(#1031)](https://github.com/wazuh/wazuh-indexer/pull/1031)
 - Fix Deprecation warning due to set-output command [(#1112)](https://github.com/wazuh/wazuh-indexer/pull/1112)
+- Fix SysV service script permissions [(#1139)](https://github.com/wazuh/wazuh-indexer/pull/1139)
 
 ### Security
 - Reduce risk of GITHUB_TOKEN exposure [(#960)](https://github.com/wazuh/wazuh-indexer/pull/960)

--- a/distribution/packages/src/deb/debmake_install.sh
+++ b/distribution/packages/src/deb/debmake_install.sh
@@ -40,18 +40,12 @@ find "${buildroot}" -type d -exec chmod 750 {} \;
 find "${buildroot}" -type f -exec chmod 640 {} \;
 
 # Permissions for the Systemd files
-systemd_executables=()
-systemd_executables+=("${buildroot}/etc/init.d/${name}")
-
 systemd_configs=()
 systemd_configs+=("${buildroot}/${service_dir}/${name}.service")
 systemd_configs+=("${buildroot}/usr/lib/sysctl.d/${name}.conf")
 systemd_configs+=("${buildroot}/usr/lib/tmpfiles.d/${name}.conf")
 
 # Apply permissions
-for i in "${systemd_executables[@]}"; do
-	chmod -c 0744 "$i"
-done
 for i in "${systemd_configs[@]}"; do
 	chmod -c 0644 "$i"
 done
@@ -83,6 +77,7 @@ fi
 
 binary_files=()
 binary_files+=("${buildroot}${product_dir}"/bin/*)
+binary_files+=("${buildroot}/etc/init.d/${name}")
 binary_files+=("${buildroot}${product_dir}"/jdk/bin/*)
 binary_files+=("${buildroot}${product_dir}"/jdk/lib/jspawnhelper)
 binary_files+=("${buildroot}${product_dir}"/jdk/lib/modules)

--- a/distribution/packages/src/deb/debmake_install.sh
+++ b/distribution/packages/src/deb/debmake_install.sh
@@ -45,7 +45,6 @@ systemd_files+=("${buildroot}/${service_dir}/${name}.service")
 systemd_files+=("${buildroot}/usr/lib/sysctl.d/${name}.conf")
 systemd_files+=("${buildroot}/usr/lib/tmpfiles.d/${name}.conf")
 
-# Apply permissions
 for i in "${systemd_files[@]}"; do
 	chmod -c 0644 "$i"
 done

--- a/distribution/packages/src/deb/debmake_install.sh
+++ b/distribution/packages/src/deb/debmake_install.sh
@@ -40,13 +40,19 @@ find "${buildroot}" -type d -exec chmod 750 {} \;
 find "${buildroot}" -type f -exec chmod 640 {} \;
 
 # Permissions for the Systemd files
-systemd_files=()
-systemd_files+=("${buildroot}/${service_dir}/${name}.service")
-systemd_files+=("${buildroot}/etc/init.d/${name}")
-systemd_files+=("${buildroot}/usr/lib/sysctl.d/${name}.conf")
-systemd_files+=("${buildroot}/usr/lib/tmpfiles.d/${name}.conf")
+systemd_executables=()
+systemd_executables+=("${buildroot}/etc/init.d/${name}")
 
-for i in "${systemd_files[@]}"; do
+systemd_configs=()
+systemd_configs+=("${buildroot}/${service_dir}/${name}.service")
+systemd_configs+=("${buildroot}/usr/lib/sysctl.d/${name}.conf")
+systemd_configs+=("${buildroot}/usr/lib/tmpfiles.d/${name}.conf")
+
+# Apply permissions
+for i in "${systemd_executables[@]}"; do
+	chmod -c 0744 "$i"
+done
+for i in "${systemd_configs[@]}"; do
 	chmod -c 0644 "$i"
 done
 

--- a/distribution/packages/src/deb/debmake_install.sh
+++ b/distribution/packages/src/deb/debmake_install.sh
@@ -40,13 +40,13 @@ find "${buildroot}" -type d -exec chmod 750 {} \;
 find "${buildroot}" -type f -exec chmod 640 {} \;
 
 # Permissions for the Systemd files
-systemd_configs=()
-systemd_configs+=("${buildroot}/${service_dir}/${name}.service")
-systemd_configs+=("${buildroot}/usr/lib/sysctl.d/${name}.conf")
-systemd_configs+=("${buildroot}/usr/lib/tmpfiles.d/${name}.conf")
+systemd_files=()
+systemd_files+=("${buildroot}/${service_dir}/${name}.service")
+systemd_files+=("${buildroot}/usr/lib/sysctl.d/${name}.conf")
+systemd_files+=("${buildroot}/usr/lib/tmpfiles.d/${name}.conf")
 
 # Apply permissions
-for i in "${systemd_configs[@]}"; do
+for i in "${systemd_files[@]}"; do
 	chmod -c 0644 "$i"
 done
 


### PR DESCRIPTION
### Description
This PR fixes the permissions for the Systemd files to enable the executable files to be executable, fixing the bug reported in the issue

### Related Issues
Resolves #1135 
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
