### PR TITLE
Update indexer-security-init.sh to allow hyphens in domains

### DIFF
--- a/distribution/src/bin/indexer-security-init.sh
+++ b/distribution/src/bin/indexer-security-init.sh
@@ -65,7 +65,7 @@ getNetworkHost() {
     HOST=$(echo "${HOST}" | tr -d "[\"\']")
 
     isIP=$(echo "${HOST}" | grep -P "^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$")
-    isDNS=$(echo "${HOST}" | grep -P "^[a-zA-Z0-9][a-zA-Z0-9-]{1,61}[a-zA-Z0-9](?:\.[a-zA-Z]{2,})+$")
+    isDNS=$(echo "${HOST}" | grep -P "^[a-zA-Z0-9][a-zA-Z0-9-]{1,61}[a-zA-Z0-9](?:\.[a-zA-Z-]{2,})+$")
 
     # Allow to find ip with an interface
     if [ -z "${isIP}" ] && [ -z "${isDNS}" ]; then


### PR DESCRIPTION
### Description
When using the [indexer-security-init.sh](https://github.com/sds-rs/wazuh-indexer/blob/bugfix/allow-hyphens-in-domains/distribution/src/bin/indexer-security-init.sh) my domain containing a hyphen '-' is not parsed correctly.

I added the concerning hyphen in the regex to allow hyphen in a domain.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
