### PR TITLE
Fix scripts path for wazuh-indexer-plugins in package builder

### DIFF
--- a/.github/workflows/5_builderpackage_indexer.yml
+++ b/.github/workflows/5_builderpackage_indexer.yml
@@ -158,10 +158,10 @@ jobs:
       - name: Read versions from wazuh-indexer-plugins
         id: plugins_version
         run: |
-          echo "version=$(bash ./scripts/product_version.sh)" >> "$GITHUB_OUTPUT"
+          echo "version=$(bash ./tools/product_version.sh)" >> "$GITHUB_OUTPUT"
 
           # Extracts the Opensearch version
-          opensearch_version=$(bash scripts/opensearch_version.sh "setup")
+          opensearch_version=$(bash ./tools/opensearch_version.sh "setup")
           echo "opensearch_version=$opensearch_version" >> "$GITHUB_OUTPUT"
         
   get-versions-wazuh-indexer-reporting:


### PR DESCRIPTION
### Description
This PR fixes the scripts' path from the wazuh-indexer-plugins repository, which was changed in https://github.com/wazuh/wazuh-indexer-plugins/issues/624

### Related Issues
Resolves #1202 

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
