### PR TITLE
Add content-manager plugin to wazuh-indexer package

### DIFF
--- a/.github/workflows/5_builderpackage_indexer.yml
+++ b/.github/workflows/5_builderpackage_indexer.yml
@@ -256,7 +256,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        plugins: ["setup"]
+        plugins: ["setup", "content-manager"]
     runs-on: ubuntu-24.04
     env:
       plugin_name: wazuh-indexer-${{ matrix.plugins }}

--- a/build-scripts/assemble.sh
+++ b/build-scripts/assemble.sh
@@ -39,6 +39,7 @@ else
     )
     wazuh_plugins=(
         "wazuh-indexer-setup"
+        "wazuh-indexer-content-manager"
         "wazuh-indexer-reports-scheduler"
         "wazuh-indexer-security-analytics" # Flagged as Trojan by some antivirus software
     )

--- a/build-scripts/builder/entrypoint.sh
+++ b/build-scripts/builder/entrypoint.sh
@@ -43,6 +43,9 @@ build_plugins() {
     cd ${PLUGINS_REPO_DIR}/plugins/setup
     echo "Building setup plugin..."
     ./gradlew build -Dversion="$version" -Drevision="$revision" --no-daemon
+    cd ${PLUGINS_REPO_DIR}/plugins/content-manager
+    echo "Building content-manager plugin..."
+    ./gradlew build -Dversion="$version" -Drevision="$revision" --no-daemon
 }
 
 # Function to build wazuh-indexer-reporting
@@ -67,6 +70,8 @@ copy_builds() {
     mkdir -p ~/artifacts/plugins
     echo "Copying setup plugin..."
     cp ${PLUGINS_REPO_DIR}/plugins/setup/build/distributions/wazuh-indexer-setup-"$version"."$revision".zip ~/artifacts/plugins
+    echo "Copying content-manager plugin..."
+    cp ${PLUGINS_REPO_DIR}/plugins/content-manager/build/distributions/wazuh-indexer-content-manager-"$version"."$revision".zip ~/artifacts/plugins
     echo "Copying reporting..."
     cp ${REPORTING_REPO_DIR}/build/distributions/wazuh-indexer-reports-scheduler-"$version"."$revision".zip ~/artifacts/plugins
 }


### PR DESCRIPTION
### Description
This PR add the wazuh-indexer-content-manager plugin to the wazuh-indexer package

### Related Issues
Resolves https://github.com/wazuh/internal-devel-requests/issues/3450

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
