### PR TITLE
Fix demo certificates generation triggered by default 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix SysV service script permissions [(#1139)](https://github.com/wazuh/wazuh-indexer/pull/1139)
 - Fix unscaped commands in indexer-security-init.sh [(#1196)](https://github.com/wazuh/wazuh-indexer/pull/1196)
 - Fix broken link generation from the repository bumper script [(#1206)](https://github.com/wazuh/wazuh-indexer/pull/1206)
+- Fix demo certificates generation triggered by default [(#1235)](https://github.com/wazuh/wazuh-indexer/pull/1235)
 
 ### Security
 - Reduce risk of GITHUB_TOKEN exposure [(#960)](https://github.com/wazuh/wazuh-indexer/pull/960)

--- a/distribution/packages/src/deb/debian/postinst
+++ b/distribution/packages/src/deb/debian/postinst
@@ -16,6 +16,7 @@ echo "Running Wazuh Indexer Post-Installation Script"
 name="wazuh-indexer"
 product_dir=/usr/share/${name}
 config_dir=/etc/${name}
+certs_dir=${config_dir}/certs
 data_dir=/var/lib/${name}
 log_dir=/var/log/${name}
 pid_dir=/run/${name}
@@ -91,10 +92,10 @@ else
     fi
     # Create the certs directory and if required, install demo certificates.
     if [ "$GENERATE_CERTS" = "true" ] && [ -f "${product_dir}/plugins/opensearch-security/tools/install-demo-certificates.sh" ]; then
-        echo "### Installing ${name} demo certificates in ${config_dir}"
+        echo "### Installing ${name} demo certificates in ${certs_dir}"
         echo " See demo certs creation log at ${log_dir}/install_demo_certificates.log"
         bash "${product_dir}/plugins/opensearch-security/tools/install-demo-certificates.sh" >"${log_dir}/install_demo_certificates.log" 2>&1
-        yes | ${product_dir}/jdk/bin/keytool -trustcacerts -keystore ${product_dir}/jdk/lib/security/cacerts -importcert -alias wazuh-root-ca -file ${config_dir}/certs/root-ca.pem > /dev/null 2>&1
+        yes | ${product_dir}/jdk/bin/keytool -trustcacerts -keystore ${product_dir}/jdk/lib/security/cacerts -importcert -alias wazuh-root-ca -file ${certs_dir}/root-ca.pem > /dev/null 2>&1
     fi
 fi
 

--- a/distribution/packages/src/deb/debmake_install.sh
+++ b/distribution/packages/src/deb/debmake_install.sh
@@ -24,6 +24,7 @@ product_dir="/usr/share/${name}"
 config_dir="/etc/${name}"
 pid_dir="/run/${name}"
 service_dir="/usr/lib/systemd/system"
+certs_dir=${config_dir}/certs
 
 buildroot="${curdir}/debian/${name}"
 
@@ -31,6 +32,7 @@ buildroot="${curdir}/debian/${name}"
 mkdir -p "${buildroot}"
 mkdir -p "${buildroot}${pid_dir}"
 mkdir -p "${buildroot}${product_dir}/plugins"
+mkdir -p "${buildroot}${certs_dir}"
 
 # Install directories/files
 cp -a "${curdir}"/etc "${curdir}"/usr "${curdir}"/var "${buildroot}"/
@@ -70,6 +72,7 @@ fi
 
 # Files that need other permissions
 chmod -c 440 "${buildroot}${product_dir}/VERSION.json"
+chmod -c 500 "${buildroot}${certs_dir}"
 if [ -d "${buildroot}${product_dir}/plugins/opensearch-security" ]; then
 	chmod -c 0740 "${buildroot}${product_dir}"/plugins/opensearch-security/tools/*.sh
 fi

--- a/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
+++ b/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
@@ -24,6 +24,7 @@
 # User Define Variables
 %define product_dir %{_datadir}/%{name}
 %define config_dir %{_sysconfdir}/%{name}
+%define certs_dir %{config_dir}/certs
 %define data_dir %{_sharedstatedir}/%{name}
 %define log_dir %{_localstatedir}/log/%{name}
 %define pid_dir %{_localstatedir}/run/%{name}
@@ -66,6 +67,9 @@ cd %{_topdir} && pwd
 # Create necessary directories
 mkdir -p %{buildroot}%{pid_dir}
 mkdir -p %{buildroot}%{product_dir}/plugins
+
+# Create empty certs directory
+mkdir -p %{buildroot}%{certs_dir}
 
 # Install directories/files
 cp -a etc usr var %{buildroot}
@@ -234,10 +238,10 @@ else
         fi
     fi
     if [ "$GENERATE_CERTS" = "true" ] && [ -f %{product_dir}/plugins/opensearch-security/tools/install-demo-certificates.sh ]; then
-        echo "### Installing %{name} demo certificates in ${config_dir}"
+        echo "### Installing %{name} demo certificates in %{certs_dir}"
         echo " See demo certs creation log at ${log_dir}/install_demo_certificates.log"
         bash %{product_dir}/plugins/opensearch-security/tools/install-demo-certificates.sh > %{log_dir}/install_demo_certificates.log 2>&1
-        yes | /usr/share/%{name}/jdk/bin/keytool -trustcacerts -keystore /usr/share/%{name}/jdk/lib/security/cacerts -importcert -alias wazuh-root-ca -file %{config_dir}/certs/root-ca.pem > /dev/null 2>&1
+        yes | /usr/share/%{name}/jdk/bin/keytool -trustcacerts -keystore /usr/share/%{name}/jdk/lib/security/cacerts -importcert -alias wazuh-root-ca -file %{certs_dir}/root-ca.pem > /dev/null 2>&1
     fi
 fi
 exit 0
@@ -300,6 +304,9 @@ exit 0
 
 # Preserve service state flag across upgrade
 %ghost %attr(440, %{name}, %{name}) %{config_dir}/.was_active
+
+# Certificates files permissions
+%attr(500, %{name}, %{name}) %{certs_dir}
 
 %changelog
 * Thu Dec 18 2025 support <info@wazuh.com> - 5.0.0


### PR DESCRIPTION
### Description

Update the `DEB` and `RPM` distribution scripts implementing `GENERATE_CERTS` _optional_ env var to enable the demo certificates generation at package installation stage.
This way we fix the certificates generation at package installation by default but don't lose the possibility to generate them when required

**Usage:**
- Default - no demo certs: `dpkg -i wazuh-indexer_5.0.0-latest_arm64.deb`
- Demo certs generation: `GENERATE_CERTS=true dpkg -i wazuh-indexer_5.0.0-latest_arm64.deb`

#### Validations

> [!NOTE]
> The behavior is the same for `.rpm` and `.deb` packages

1. Demo certificates are not be installed by default
2. Demo certificates are installed when using `GENERATE_CERTS=true`
3. Demo certificates are not installed when using `GENERATE_CERTS=false`

<details><summary>RPM package</summary>

1. Installation with no flag
  ```shellsession
  # rpm -i wazuh-indexer_5.0.0-0_aarch64_5551f96f-b887939-0a1d7ab-f6c999f.rpm 
  ### NOT starting on installation, please execute the following statements to configure wazuh-indexer service to start automatically using systemd
   sudo systemctl daemon-reload
   sudo systemctl enable wazuh-indexer.service
  ### You can start wazuh-indexer service by executing
   sudo systemctl start wazuh-indexer.service
  ```
  ```shellsession
  # ls -ll /etc/wazuh-indexer/certs
  total 0
  ```
2. Installation with `GENERATE_CERTS=true`
  ```shellsession
  # GENERATE_CERTS=true rpm -i wazuh-indexer_5.0.0-0_aarch64_5551f96f-b887939-0a1d7ab-f6c999f.rpm 
  ### NOT starting on installation, please execute the following statements to configure wazuh-indexer service to start automatically using systemd
   sudo systemctl daemon-reload
   sudo systemctl enable wazuh-indexer.service
  ### You can start wazuh-indexer service by executing
   sudo systemctl start wazuh-indexer.service
  ### Installing wazuh-indexer demo certificates in /etc/wazuh-indexer/certs
   See demo certs creation log at /install_demo_certificates.log
  ```
  ```shellsession
  # ls /etc/wazuh-indexer/certs
  admin-key.pem  admin.pem  indexer-key.pem  indexer.pem  root-ca.pem
  ```
2. Installation with `GENERATE_CERTS=false`
  ```shellsession
  # GENERATE_CERTS=false rpm -i wazuh-indexer_5.0.0-0_aarch64_5551f96f-b887939-0a1d7ab-f6c999f.rpm 
  ### NOT starting on installation, please execute the following statements to configure wazuh-indexer service to start automatically using systemd
   sudo systemctl daemon-reload
   sudo systemctl enable wazuh-indexer.service
  ### You can start wazuh-indexer service by executing
   sudo systemctl start wazuh-indexer.service
  ```
  ```shellsession
  # ls -ll /etc/wazuh-indexer/certs
  total 0
  ```
</details>


<details><summary>DEB package</summary>

1. Installation with no flag
  ```shellsession
  # dpkg -i wazuh-indexer_5.0.0-0_arm64_5551f96f-b887939-0a1d7ab-f6c999f.deb 
  Selecting previously unselected package wazuh-indexer.
  (Reading database ... 29707 files and directories currently installed.)
  Preparing to unpack wazuh-indexer_5.0.0-0_arm64_5551f96f-b887939-0a1d7ab-f6c999f.deb ...
  Running Wazuh Indexer Pre-Installation Script
  Unpacking wazuh-indexer (5.0.0-0) ...
  Setting up wazuh-indexer (5.0.0-0) ...
  Running Wazuh Indexer Post-Installation Script
  ### NOT starting on installation, please execute the following statements to configure wazuh-indexer service to start automatically using systemd
   sudo systemctl daemon-reload
   sudo systemctl enable wazuh-indexer.service
  ### You can start wazuh-indexer service by executing
   sudo systemctl start wazuh-indexer.service
  ```
  ```shellsession
  # ls -ll /etc/wazuh-indexer/certs
  total 0
  ```
2. Installation with `GENERATE_CERTS=true`
  ```shellsession
  # GENERATE_CERTS=true dpkg -i wazuh-indexer_5.0.0-0_arm64_5551f96f-b887939-0a1d7ab-f6c999f.deb 
  Selecting previously unselected package wazuh-indexer.
  (Reading database ... 29707 files and directories currently installed.)
  Preparing to unpack wazuh-indexer_5.0.0-0_arm64_5551f96f-b887939-0a1d7ab-f6c999f.deb ...
  Running Wazuh Indexer Pre-Installation Script
  Unpacking wazuh-indexer (5.0.0-0) ...
  Setting up wazuh-indexer (5.0.0-0) ...
  Running Wazuh Indexer Post-Installation Script
  ### NOT starting on installation, please execute the following statements to configure wazuh-indexer service to start automatically using systemd
   sudo systemctl daemon-reload
   sudo systemctl enable wazuh-indexer.service
  ### You can start wazuh-indexer service by executing
   sudo systemctl start wazuh-indexer.service
  ### Installing wazuh-indexer demo certificates in /etc/wazuh-indexer/certs
   See demo certs creation log at /var/log/wazuh-indexer/install_demo_certificates.log 
  ```
  ```shellsession
  # ls /etc/wazuh-indexer/certs
  admin-key.pem  admin.pem  indexer-key.pem  indexer.pem	root-ca.pem
  ```
2. Installation with `GENERATE_CERTS=false`
  ```shellsession
  # GENERATE_CERTS=false dpkg -i wazuh-indexer_5.0.0-0_arm64_5551f96f-b887939-0a1d7ab-f6c999f.deb 
  Selecting previously unselected package wazuh-indexer.
  (Reading database ... 29707 files and directories currently installed.)
  Preparing to unpack wazuh-indexer_5.0.0-0_arm64_5551f96f-b887939-0a1d7ab-f6c999f.deb ...
  Running Wazuh Indexer Pre-Installation Script
  Unpacking wazuh-indexer (5.0.0-0) ...
  Setting up wazuh-indexer (5.0.0-0) ...
  Running Wazuh Indexer Post-Installation Script
  ### NOT starting on installation, please execute the following statements to configure wazuh-indexer service to start automatically using systemd
   sudo systemctl daemon-reload
   sudo systemctl enable wazuh-indexer.service
  ### You can start wazuh-indexer service by executing
   sudo systemctl start wazuh-indexer.service
  ```
  ```shellsession
  # ls -ll /etc/wazuh-indexer/certs
  total 0
  ```
</details>

### Related Issues
Closes #1223 
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
