### PR TITLE
Change transport.port to http.port in indexer-security-init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 -
 
 ### Changed
-- 
+- Change transport.port to http.port in indexer-security-init [(#1233)](https://github.com/wazuh/wazuh-indexer/pull/1233)
 
 ### Deprecated
 -

--- a/distribution/src/bin/indexer-security-init.sh
+++ b/distribution/src/bin/indexer-security-init.sh
@@ -87,7 +87,7 @@ getNetworkHost() {
 # -----------------------------------------------------------------------------
 getPort() {
 
-    PORT=$(grep -hr 'transport.tcp.port' "${CONFIG_FILE}" 2>&1)
+    PORT=$(grep -hr 'http.port' "${CONFIG_FILE}" 2>&1)
     if [ "${PORT}" ]; then
         PORT=$(echo "${PORT}" | cut -d' ' -f2 | cut -d'-' -f1)
     else


### PR DESCRIPTION
### Description
Backports changes from https://github.com/wazuh/wazuh-indexer/issues/1227 into Wazuh Indexer `4.14.2`

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
