### PR TITLE
Change wazuh-automation branch to VERSION.json branch

### DIFF
--- a/.github/workflows/4_builderpackage_indexer.yml
+++ b/.github/workflows/4_builderpackage_indexer.yml
@@ -183,7 +183,7 @@ jobs:
         env:
           username: "wazuh-devel-xdrsiem-indexer"
         run: |
-          git clone https://${{ env.username }}:${{ secrets.INDEXER_BOT_TOKEN }}@github.com/wazuh/wazuh-automation.git
+          git clone https://${{ env.username }}:${{ secrets.INDEXER_BOT_TOKEN }}@github.com/wazuh/wazuh-automation.git -b $(bash packaging_scripts/product_version.sh)
           cd wazuh-automation
           sudo pip3 install -r deployability/deps/requirements.txt
 


### PR DESCRIPTION
### Description
This PR adapts the 4.x code to IDR3636, where the allocator composite names will be changed.

To fix this, instead of cloning the main branch (5.0.0) it will be cloned the actual branch that the workflow is being executed (VERSION.json)

Before:
4.14.3 branch clones 5.0.0 branch
Now:
4.14.3 branch clones 4.14.3 branch

### Related Issues
IDR3636

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
