### PR TITLE
Change the order of SAP installation

### DIFF
--- a/build-scripts/assemble.sh
+++ b/build-scripts/assemble.sh
@@ -39,9 +39,9 @@ else
     )
     wazuh_plugins=(
         "wazuh-indexer-setup"
+        "wazuh-indexer-security-analytics" # Flagged as Trojan by some antivirus software
         "wazuh-indexer-content-manager"
         "wazuh-indexer-reports-scheduler"
-        "wazuh-indexer-security-analytics" # Flagged as Trojan by some antivirus software
     )
 fi
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This PR changes the order of the plugins to be installed, since content-manager plugin extends the security-analytics plugin it must be installed after it

### Related Issues
Resolves #1267 
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
