### PR TITLE
Add Publish commons library to mavenLocal for SAP plugin to build

### DIFF
--- a/.github/workflows/5_builderpackage_indexer.yml
+++ b/.github/workflows/5_builderpackage_indexer.yml
@@ -393,6 +393,13 @@ jobs:
         id: version
         run: echo "version=$(jq .version -r VERSION.json)" >> "$GITHUB_OUTPUT"
 
+      - name: Publish commons library to mavenLocal
+        run: |
+          cd commons
+          ../gradlew publishToMavenLocal -x check \
+            -Dversion=${{ steps.version.outputs.version }} \
+            -Drevision=${{ inputs.revision }}
+
       - name: Build with Gradle
         run: ./gradlew build -x integTest -Dversion=${{ steps.version.outputs.version }} -Drevision=${{ inputs.revision }}
 


### PR DESCRIPTION
### Description

This PR adds a new step to the job `build-security-analytics-plugin` to publish the commons library:

```yaml
- name: Publish commons library to mavenLocal
        run: |
          cd commons
          ../gradlew publishToMavenLocal -x check \
            -Dversion=${{ steps.version.outputs.version }} \
            -Drevision=${{ inputs.revision }}
```

### Related Issues
Resolves #1288 

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
