### PR TITLE
Modify builder workflow to use `run-identifier` 

### DIFF
--- a/.github/workflows/5_builderpackage_indexer.yml
+++ b/.github/workflows/5_builderpackage_indexer.yml
@@ -259,7 +259,7 @@ jobs:
 
   build-wazuh-engine:
     needs: [compatibility-check, branches]
-    uses: wazuh/wazuh/.github/workflows/5_builderpackage_engine-standalone.yml@${{ needs.branches.outputs.wazuh_ref }}
+    uses: wazuh/wazuh/.github/workflows/5_builderpackage_engine-standalone.yml@main
     secrets: inherit
     with:
       wazuh-branch: ${{ needs.branches.outputs.wazuh_ref }}


### PR DESCRIPTION
### Description
This PR modifies the workflow to use the new variable `run-identifier` when calling the engine workflow

### Related Issues
Resolves #1300 
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
