### PR TITLE
Delete line refering to default-security-policy

### DIFF
--- a/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
+++ b/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
@@ -306,7 +306,6 @@ exit 0
 %attr(-, %{name}, %{name}) %{product_dir}/engine/sockets/.keep
 %attr(-, %{name}, %{name}) %{product_dir}/engine/bin/lib
 %attr(-, %{name}, %{name}) %{product_dir}/engine/data
-%attr(-, %{name}, %{name}) %{product_dir}/engine/default-security-policy
 %attr(-, %{name}, %{name}) %{product_dir}/engine/logs
 %attr(-, %{name}, %{name}) %{product_dir}/engine/schemas
 %attr(-, %{name}, %{name}) %{product_dir}/engine/README.md


### PR DESCRIPTION

### Description
This PR deletes the line related to the deleted folder inside the engine package, `default-security-policy`



### Related Issues
Resolves #1300 
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
