### PR TITLE
Add architecture param to build engine standalone

### DIFF
--- a/.github/workflows/5_builderpackage_indexer.yml
+++ b/.github/workflows/5_builderpackage_indexer.yml
@@ -264,6 +264,7 @@ jobs:
     with:
       wazuh-branch: ${{ needs.branches.outputs.wazuh_ref }}
       build-type: 'release'
+      arch: ${{ inputs.architecture }}
 
   build-wazuh-plugins:
     needs: [compatibility-check, branches]


### PR DESCRIPTION
## Description

This pull request improves the standalone engine CI workflow reliability and debuggability, addressing the limitations described in [wazuh/wazuh-indexer#1313](https://github.com/wazuh/wazuh-indexer/issues/1313)
.

Previously, when the standalone engine failed to start during CI validation, the workflow did not preserve execution logs, making root cause analysis difficult. Additionally, the startup validation timing and matrix configuration resulted in unnecessary complexity and longer execution times.

This change enhances failure visibility, improves startup validation robustness, and reduces the number of generated build combinations.

## Proposed Changes

- Always upload standalone engine logs as artifacts, even when the engine fails to start, ensuring post-mortem analysis is possible in CI runs.

- Increase the wait time before performing the API health check, allowing the engine sufficient time to initialize and reducing false negatives during startup validation.

- Allow selecting a single target architecture (amd64 or arm64) when invoking the standalone engine workflow, reducing the build matrix from eight combinations to four when multi-architecture builds are not required.

- Improve overall CI feedback by preserving execution context and making startup failures observable instead of silent.

### Results and Evidence

Only x86 arch
https://github.com/wazuh/wazuh-indexer/actions/runs/21729276402

both arch
https://github.com/wazuh/wazuh-indexer/actions/runs/21730054420

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
