### PR TITLE
Add `path.shared_data` config variable for Ioc delivery

### DIFF
--- a/distribution/src/config/opensearch.prod.yml
+++ b/distribution/src/config/opensearch.prod.yml
@@ -38,3 +38,4 @@ plugins.security.restapi.roles_enabled:
 plugins.security.system_indices.enabled: true
 plugins.security.system_indices.indices: [".plugins-ml-model", ".plugins-ml-task", ".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-anomaly-results*", ".opendistro-anomaly-detector*", ".opendistro-anomaly-checkpoints", ".opendistro-anomaly-detection-state", ".opendistro-reports-*", ".opensearch-notifications-*", ".opensearch-notebooks", ".opensearch-observability", ".opendistro-asynchronous-search-response*", ".replication-metadata-store"]
 cluster.default_number_of_replicas: 0
+path.shared_data: /usr/share/wazuh-indexer/engine/data


### PR DESCRIPTION
### Description
This PR adds the `path.shared_data` config variable to `opensearch.yml` so that the Content Manager can dump Ioc data in a directory that's accessible by the built-in Wazuh Engine.

### Related Issues
Resolves https://github.com/wazuh/wazuh-indexer-plugins/issues/829