### PR TITLE
Add aws installation to provision script

### DIFF
--- a/build-scripts/provision.sh
+++ b/build-scripts/provision.sh
@@ -33,7 +33,7 @@ if [[ "$ARCH" == "aarch64" ]]; then
     sudo apt-get update
     sudo apt-get install -y maven rpm cpio
     sudo apt-get update && sudo apt-get install -y unzip
-    curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip"
     unzip -q awscliv2.zip
     sudo ./aws/install --update
     


### PR DESCRIPTION
### Description
This PR adds the installation of aws cli to provision script to avoid errors during the nighly

### Related Issues
Resolves #1356 

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
