### PR TITLE
Use dedicates runners

### DIFF
--- a/.github/workflows/5_builderpackage_indexer.yml
+++ b/.github/workflows/5_builderpackage_indexer.yml
@@ -317,7 +317,6 @@ jobs:
 
   build-wazuh-engine:
     needs: [compatibility-check, branches]
-    # TODO
     uses: wazuh/wazuh/.github/workflows/5_builderpackage_engine-standalone.yml@main
     secrets: inherit
     with:


### PR DESCRIPTION
### Description

Use dedicates runners to speed up building of Indexer packages.

### Related Issues
Resolves N/A
