### PR TITLE
Add `tzdb` directory to RPM spec file

### DIFF
--- a/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
+++ b/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
@@ -306,6 +306,7 @@ exit 0
 %attr(-, %{name}, %{name}) %{product_dir}/engine/sockets/.keep
 %attr(-, %{name}, %{name}) %{product_dir}/engine/bin/lib
 %attr(-, %{name}, %{name}) %{product_dir}/engine/data
+%attr(-, %{name}, %{name}) %{product_dir}/engine/data/tzdb
 %attr(-, %{name}, %{name}) %{product_dir}/engine/logs
 %attr(-, %{name}, %{name}) %{product_dir}/engine/schemas
 %attr(-, %{name}, %{name}) %{product_dir}/engine/README.md


### PR DESCRIPTION
### Description
This PR adds the `/usr/share/wazuh-indexer/engine/data/tzdb` directory to the RPM spec file as the Wazuh Engine now ships with it by default as per https://github.com/wazuh/wazuh/pull/35229

### Related Issues
Resolves https://github.com/wazuh/wazuh-indexer/issues/1407
