### PR TITLE
Use revision instead of build.revision

### DIFF
--- a/.github/workflows/5_builderpackage_indexer.yml
+++ b/.github/workflows/5_builderpackage_indexer.yml
@@ -727,7 +727,7 @@ jobs:
 
       - name: Build with Gradle
         working-directory: .
-        run: ./gradlew build -x integTest -Dversion=${{ steps.version.outputs.version }} -Dbuild.revision=${{ inputs.revision }}
+        run: ./gradlew build -x integTest -Dversion=${{ steps.version.outputs.version }} -Drevision=${{ inputs.revision }}
 
       - run: ls -lR alerting/build/distributions
 


### PR DESCRIPTION
### Description
This PR changes the input while building to avoid failures in the build process

### Related Issues
Resolves #1430 
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
