### PR TITLE
Add support to new Ubuntu LTS 26.04

### DIFF
--- a/.github/actions/5_builderpackage_indexer_branch_resolver/README.md
+++ b/.github/actions/5_builderpackage_indexer_branch_resolver/README.md
@@ -71,7 +71,7 @@ Diagnostic messages are sent to stderr, allowing easy parsing of stdout.
 ```yaml
 jobs:
   branches:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     outputs:
       wazuh_plugins_ref: ${{ steps.resolve.outputs.wazuh_indexer_plugins_branch }}
       reporting_plugin_ref: ${{ steps.resolve.outputs.wazuh_indexer_reporting_branch }}
@@ -95,7 +95,7 @@ jobs:
 
   build-plugins:
     needs: [branches]
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/4_builderpackage_indexer.yml
+++ b/.github/workflows/4_builderpackage_indexer.yml
@@ -94,7 +94,7 @@ permissions:
 jobs:
   setup:
     name: Set up variables
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
       previous_version: ${{ steps.product_versions.outputs.previous_version }}

--- a/.github/workflows/5_codequality_changelog.yml
+++ b/.github/workflows/5_codequality_changelog.yml
@@ -9,7 +9,7 @@ jobs:
   # Enforces the update of a changelog file on every pull request
   verify-changelog:
     if: github.repository == 'wazuh/wazuh-indexer'
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/5_codequality_email.yml
+++ b/.github/workflows/5_codequality_email.yml
@@ -9,7 +9,7 @@ jobs:
   # Checks if the email domain is @wazuh.com, if not the workflow will fail
   verify-email:
     if: github.repository == 'wazuh/wazuh-indexer'
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/5_codequality_signed_commits.yml
+++ b/.github/workflows/5_codequality_signed_commits.yml
@@ -7,7 +7,7 @@ jobs:
   # Checks if the commits are signed, if not the workflow will fail
   verify-signed-commits:
     if: github.repository == 'wazuh/wazuh-indexer'
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
     steps:

--- a/.github/workflows/5_testunit_version.yml
+++ b/.github/workflows/5_testunit_version.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   check-version:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/6_builderpackage_indexer.yml
+++ b/.github/workflows/6_builderpackage_indexer.yml
@@ -121,7 +121,7 @@ on:
 jobs:
   matrix:
     name: Set up matrix
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     outputs:
       matrix: ${{ steps.setup.outputs.matrix }}
     steps:
@@ -140,7 +140,7 @@ jobs:
       fail-fast: false
       matrix:
         plugins: ["setup", "command-manager", "content-manager"]
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     env:
       plugin_name: wazuh-indexer-${{ matrix.plugins }}
     outputs:
@@ -183,7 +183,7 @@ jobs:
 
   build-reporting-plugin:
     if: ${{ inputs.reporting_plugin_ref != '' }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     outputs:
       hash: ${{ steps.save-hash.outputs.hash }}
     env:
@@ -224,7 +224,7 @@ jobs:
 
   build:
     needs: [matrix, build-wazuh-plugins, build-reporting-plugin]
-    runs-on: ${{ matrix.architecture == 'arm64' && 'wz-linux-arm64' || 'ubuntu-24.04' }}
+    runs-on: ${{ matrix.architecture == 'arm64' && 'wz-linux-arm64' || 'ubuntu-26.04' }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.matrix.outputs.matrix) }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -28,7 +28,7 @@ jobs:
     #   - https://gh.io/supported-runners-and-hardware-resources
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
-    runs-on: 'ubuntu-24.04'
+    runs-on: 'ubuntu-26.04'
     timeout-minutes: 360
     permissions:
       actions: read

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -7,7 +7,7 @@ permissions:
   contents: read
 jobs:
   linkchecker:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This PR updates the Ubuntu version used into GHA workflows to latest LTS version, 26.04

### Related Issues
Closes https://github.com/wazuh/wazuh/issues/35754
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
