### PR TITLE
Add rpm spec to not reverted files

### DIFF
--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -173,6 +173,7 @@ jobs:
           # Remove the files to prevent them from being included in the revert commit
           git checkout HEAD -- VERSION.json 2>/dev/null || true
           git checkout HEAD -- CHANGELOG.md 2>/dev/null || true
+          git checkout HEAD -- distribution/packages/src/rpm/wazuh-indexer.rpm.spec 2>/dev/null || true
           # Add any other repository-specific version files here
 
           if git diff --staged --quiet; then


### PR DESCRIPTION
### Description
This PR adds rpm spec to the file that are not reverted since it includes a date and should not be reverted 

### Related Issues
Resolves #1446

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
