### PR TITLE
Comment out DLS, FLS and masked fields configurations in default roles

### DIFF
--- a/distribution/src/config/security/roles.wazuh.yml
+++ b/distribution/src/config/security/roles.wazuh.yml
@@ -6,9 +6,9 @@ manage_wazuh_index:
   index_permissions:
   - index_patterns:
     - "wazuh-*"
-    dls: ""
-    fls: []
-    masked_fields: []
+    # dls: ""
+    # fls: []
+    # masked_fields: []
     allowed_actions:
     - "read"
     - "delete"
@@ -25,9 +25,9 @@ stateful-read:
   index_permissions:
     - index_patterns:
         - "wazuh-states-*"
-      dls: ""
-      fls: []
-      masked_fields: []
+      # dls: ""
+      # fls: []
+      # masked_fields: []
       allowed_actions:
         - "read"
   tenant_permissions: []
@@ -39,9 +39,9 @@ stateful-write:
   index_permissions:
     - index_patterns:
         - "wazuh-states-*"
-      dls: ""
-      fls: []
-      masked_fields: []
+      # dls: ""
+      # fls: []
+      # masked_fields: []
       allowed_actions:
         - "index"
   tenant_permissions: []
@@ -53,9 +53,9 @@ stateful-delete:
   index_permissions:
     - index_patterns:
         - "wazuh-states-*"
-      dls: ""
-      fls: []
-      masked_fields: []
+      # dls: ""
+      # fls: []
+      # masked_fields: []
       allowed_actions:
         - "delete"
   tenant_permissions: []
@@ -68,9 +68,9 @@ stateless-read:
     - index_patterns:
         - "wazuh-alerts*"
         - "wazuh-archives*"
-      dls: ""
-      fls: []
-      masked_fields: []
+      # dls: ""
+      # fls: []
+      # masked_fields: []
       allowed_actions:
         - "read"
   tenant_permissions: []
@@ -83,9 +83,9 @@ stateless-write:
     - index_patterns:
         - "wazuh-alerts*"
         - "wazuh-archives*"
-      dls: ""
-      fls: []
-      masked_fields: []
+      # dls: ""
+      # fls: []
+      # masked_fields: []
       allowed_actions:
         - "index"
   tenant_permissions: []
@@ -98,9 +98,9 @@ metrics-read:
     - index_patterns:
         - "wazuh-monitoring*"
         - "wazuh-statistics*"
-      dls: ""
-      fls: []
-      masked_fields: []
+      # dls: ""
+      # fls: []
+      # masked_fields: []
       allowed_actions:
         - "read"
   tenant_permissions: []
@@ -113,9 +113,9 @@ metrics-write:
     - index_patterns:
         - "wazuh-monitoring*"
         - "wazuh-statistics*"
-      dls: ""
-      fls: []
-      masked_fields: []
+      # dls: ""
+      # fls: []
+      # masked_fields: []
       allowed_actions:
         - "index"
   tenant_permissions: []
@@ -127,9 +127,9 @@ sample-data-management:
   index_permissions:
     - index_patterns:
         - "*-sample-*"
-      dls: ""
-      fls: []
-      masked_fields: []
+      # dls: ""
+      # fls: []
+      # masked_fields: []
       allowed_actions:
         - "data_access"
         - "manage"
@@ -147,9 +147,9 @@ ml_config_read:
     - ".plugins-ml-connector"
     - ".plugins-ml-agent"
     - ".plugins-ml-config"
-    dls: ""
-    fls: []
-    masked_fields: []
+    # dls: ""
+    # fls: []
+    # masked_fields: []
     allowed_actions:
     - "read"
     - "system:admin/system_index"
@@ -164,9 +164,9 @@ ml_config_write:
   index_permissions:
   - index_patterns:
     - ".plugins-ml-config"
-    dls: ""
-    fls: []
-    masked_fields: []
+    # dls: ""
+    # fls: []
+    # masked_fields: []
     allowed_actions:
     - "write"
     - "system:admin/system_index"


### PR DESCRIPTION
### Description

Comment out DLS, FLS and masked fields configurations in default roles, as these are currently unused.

### Related Issues
Resolves #1525 

### Check List

1. Modify your `roles.yml` file in a working environment with the changes on this pull request.
2. Run the `indexer-security-init.sh` script.
3. Restart the indexer.
4. Check for logs.

```console
root@default:/home/vagrant# grep "Invalid DLS query for role" /var/log/wazuh-indexer/wazuh-cluster.log 
root@default:/home/vagrant# 
```
