### PR TITLE
Fix `/etc/default/wazuh-indexer` ownership and permissions in `deb`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 - Set secure permissions (750) for engine sockets directory [(#1330)](https://github.com/wazuh/wazuh-indexer/pull/1330)
 - Resolve dependency mismatch between Alerting and Notifications plugins [(#1379)](https://github.com/wazuh/wazuh-indexer/pull/1379)
+- Fix /etc/default/wazuh-indexer ownership and permissions in deb [(#1533)](https://github.com/wazuh/wazuh-indexer/pull/1533)
 
 ### Dependencies
 -

--- a/distribution/packages/src/deb/debian/postinst
+++ b/distribution/packages/src/deb/debian/postinst
@@ -16,6 +16,7 @@ echo "Running Wazuh Indexer Post-Installation Script"
 name="wazuh-indexer"
 product_dir=/usr/share/${name}
 config_dir=/etc/${name}
+defaults_dir=/etc/default/${name}
 certs_dir=${config_dir}/certs
 data_dir=/var/lib/${name}
 log_dir=/var/log/${name}
@@ -27,6 +28,7 @@ chown -R ${name}:${name} ${product_dir}
 chown -R ${name}:${name} ${config_dir}
 chown -R ${name}:${name} ${log_dir}
 chown -R ${name}:${name} ${data_dir}
+chown -R ${name}:${name} ${defaults_dir}
 chown -R ${name}:${name} ${pid_dir}
 
 # Change permissions for Wazuh Engine

--- a/distribution/packages/src/deb/debian/postinst
+++ b/distribution/packages/src/deb/debian/postinst
@@ -16,11 +16,11 @@ echo "Running Wazuh Indexer Post-Installation Script"
 name="wazuh-indexer"
 product_dir=/usr/share/${name}
 config_dir=/etc/${name}
-defaults_dir=/etc/default/${name}
 certs_dir=${config_dir}/certs
 data_dir=/var/lib/${name}
 log_dir=/var/log/${name}
 pid_dir=/run/${name}
+defaults_file=/etc/default/${name}
 state_file=${config_dir}/.was_active
 
 # Set owner
@@ -28,8 +28,8 @@ chown -R ${name}:${name} ${product_dir}
 chown -R ${name}:${name} ${config_dir}
 chown -R ${name}:${name} ${log_dir}
 chown -R ${name}:${name} ${data_dir}
-chown -R ${name}:${name} ${defaults_dir}
 chown -R ${name}:${name} ${pid_dir}
+chown ${name}:${name} ${defaults_file}
 
 # Change permissions for Wazuh Engine
 ENGINE_DIR="${product_dir}/engine"

--- a/distribution/packages/src/deb/debmake_install.sh
+++ b/distribution/packages/src/deb/debmake_install.sh
@@ -22,7 +22,6 @@ name="wazuh-indexer"
 
 product_dir="/usr/share/${name}"
 config_dir="/etc/${name}"
-defaults_dir="/etc/default/${name}"
 pid_dir="/run/${name}"
 service_dir="/usr/lib/systemd/system"
 certs_dir=${config_dir}/certs
@@ -61,9 +60,6 @@ config_files+=("${buildroot}/${config_dir}/opensearch.yml")
 for i in "${config_files[@]}"; do
 	chmod -c 0660 "$i"
 done
-
-# Permissions for default folder
-chmod -c 750 "${buildroot}${defaults_dir}"
 
 # Plugin-related files
 if [ -e "${buildroot}/${config_dir}/opensearch-observability/observability.yml" ]; then

--- a/distribution/packages/src/deb/debmake_install.sh
+++ b/distribution/packages/src/deb/debmake_install.sh
@@ -22,6 +22,7 @@ name="wazuh-indexer"
 
 product_dir="/usr/share/${name}"
 config_dir="/etc/${name}"
+defaults_dir="/etc/default/${name}"
 pid_dir="/run/${name}"
 service_dir="/usr/lib/systemd/system"
 certs_dir=${config_dir}/certs
@@ -60,6 +61,9 @@ config_files+=("${buildroot}/${config_dir}/opensearch.yml")
 for i in "${config_files[@]}"; do
 	chmod -c 0660 "$i"
 done
+
+# Permissions for default folder
+chmod -c 750 "${buildroot}${defaults_dir}"
 
 # Plugin-related files
 if [ -e "${buildroot}/${config_dir}/opensearch-observability/observability.yml" ]; then


### PR DESCRIPTION
### Description
This PR fixes an issue where `/etc/default/wazuh-indexer` is created with `root` ownership and `640` permissions, where it should be `wazuh-indexer`, and `750`.

### Related Issues
Resolves #1532 