### PR TITLE
Block `5.x` updates from `4.x`

### DIFF
--- a/.github/workflows/5_builderpackage_indexer.yml
+++ b/.github/workflows/5_builderpackage_indexer.yml
@@ -914,35 +914,40 @@ jobs:
       - name: Test RPM package refuses upgrade from 4.x
         if: ${{ matrix.distribution == 'rpm' && needs.setup.outputs.previous_4x_version != '' }}
         run: |
-          docker run --rm --privileged \
+          cid=$(docker run -d --rm \
+            --privileged \
+            --cgroupns=host \
+            -v /sys/fs/cgroup:/sys/fs/cgroup:rw \
             -v "${{ github.workspace }}/artifacts/dist:/artifacts/dist" \
             -v "${{ github.workspace }}/build-scripts/:/build-scripts/" \
-            redhat/ubi9-init:latest \
-            bash -c '
-              set -e
-              bash /build-scripts/indexer_node_install.sh ${{ needs.setup.outputs.previous_4x_version }}
-              installed_before=$(rpm -q wazuh-indexer)
-              echo "Installed before upgrade: $installed_before"
+            redhat/ubi9-init:latest /sbin/init)
+          trap 'docker stop "$cid" >/dev/null 2>&1 || true' EXIT
 
-              set +e
-              out=$(yum localinstall "/artifacts/dist/${{ steps.package.outputs.name }}" -y 2>&1)
-              rc=$?
-              set -e
-              echo "$out"
+          docker exec "$cid" bash -c '
+            set -e
+            bash /build-scripts/indexer_node_install.sh ${{ needs.setup.outputs.previous_4x_version }}
+            installed_before=$(rpm -q wazuh-indexer)
+            echo "Installed before upgrade: $installed_before"
 
-              if [ "$rc" -eq 0 ]; then
-                echo "ERROR: upgrade unexpectedly succeeded"; exit 1
-              fi
-              if ! echo "$out" | grep -qF "Direct upgrade from Wazuh Indexer 4.X to 5.X is not supported"; then
-                echo "ERROR: expected block banner not found in output"; exit 1
-              fi
+            set +e
+            out=$(yum localinstall "/artifacts/dist/${{ steps.package.outputs.name }}" -y 2>&1)
+            rc=$?
+            set -e
+            echo "$out"
 
-              installed_after=$(rpm -q wazuh-indexer)
-              if [ "$installed_before" != "$installed_after" ]; then
-                echo "ERROR: package state changed (before=$installed_before after=$installed_after)"; exit 1
-              fi
-              echo "OK: 5.x package correctly refused upgrade from $installed_after"
-            '
+            if [ "$rc" -eq 0 ]; then
+              echo "ERROR: upgrade unexpectedly succeeded"; exit 1
+            fi
+            if ! echo "$out" | grep -qF "Direct upgrade from Wazuh Indexer 4.X to 5.X is not supported"; then
+              echo "ERROR: expected block banner not found in output"; exit 1
+            fi
+
+            installed_after=$(rpm -q wazuh-indexer)
+            if [ "$installed_before" != "$installed_after" ]; then
+              echo "ERROR: package state changed (before=$installed_before after=$installed_after)"; exit 1
+            fi
+            echo "OK: 5.x package correctly refused upgrade from $installed_after"
+          '
 
       - name: Test DEB package installation
         if: ${{ matrix.distribution == 'deb' }}

--- a/.github/workflows/5_builderpackage_indexer.yml
+++ b/.github/workflows/5_builderpackage_indexer.yml
@@ -373,6 +373,7 @@ jobs:
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
       previous_version: ${{ steps.previous_release.outputs.previous_version }}
+      previous_4x_version: ${{ steps.previous_4x.outputs.previous_4x_version }}
     steps:
       - id: matrix
         run: |
@@ -398,6 +399,19 @@ jobs:
           echo "Current version: $CURRENT"
           echo "Latest release detected: $PREVIOUS"
           echo "previous_version=$PREVIOUS" >> $GITHUB_OUTPUT
+      - id: previous_4x
+        name: Get latest Wazuh 4.x release from GitHub
+        run: |
+          set -o pipefail
+          PREVIOUS_4X=$(curl -sfSL --retry 3 --retry-all-errors --retry-delay 5 --connect-timeout 10 --max-time 30 \
+            -H "Authorization: Bearer ${{ github.token }}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/wazuh/wazuh-indexer/releases | jq -r '.[].tag_name' | grep -vE 'alpha|beta|rc' | sed 's/^v//' | \
+            grep -E '^4\.[0-9]+\.[0-9]+$' | sort -V | tail -n1)
+
+          echo "Latest 4.x release detected: $PREVIOUS_4X"
+          echo "previous_4x_version=$PREVIOUS_4X" >> $GITHUB_OUTPUT
 
   publish-common-utils:
     timeout-minutes: 10
@@ -897,6 +911,39 @@ jobs:
                      yum localinstall '/artifacts/dist/${{ steps.package.outputs.name }}' -y && \
                      if systemctl is-active --quiet wazuh-indexer; then echo 'Indexer running (expected)'; else echo 'Indexer not running (unexpected)'; exit 1; fi"
 
+      - name: Test RPM package refuses upgrade from 4.x
+        if: ${{ matrix.distribution == 'rpm' && needs.setup.outputs.previous_4x_version != '' }}
+        run: |
+          docker run --rm --privileged \
+            -v "${{ github.workspace }}/artifacts/dist:/artifacts/dist" \
+            -v "${{ github.workspace }}/build-scripts/:/build-scripts/" \
+            redhat/ubi9:latest \
+            bash -c '
+              set -e
+              bash /build-scripts/indexer_node_install.sh ${{ needs.setup.outputs.previous_4x_version }}
+              installed_before=$(rpm -q wazuh-indexer)
+              echo "Installed before upgrade: $installed_before"
+
+              set +e
+              out=$(yum localinstall "/artifacts/dist/${{ steps.package.outputs.name }}" -y 2>&1)
+              rc=$?
+              set -e
+              echo "$out"
+
+              if [ "$rc" -eq 0 ]; then
+                echo "ERROR: upgrade unexpectedly succeeded"; exit 1
+              fi
+              if ! echo "$out" | grep -qF "Direct upgrade from Wazuh Indexer 4.X to 5.X is not supported"; then
+                echo "ERROR: expected block banner not found in output"; exit 1
+              fi
+
+              installed_after=$(rpm -q wazuh-indexer)
+              if [ "$installed_before" != "$installed_after" ]; then
+                echo "ERROR: package state changed (before=$installed_before after=$installed_after)"; exit 1
+              fi
+              echo "OK: 5.x package correctly refused upgrade from $installed_after"
+            '
+
       - name: Test DEB package installation
         if: ${{ matrix.distribution == 'deb' }}
         run: |
@@ -918,6 +965,34 @@ jobs:
 
           sudo bash build-scripts/indexer_node_install.sh ${{ needs.setup.outputs.previous_version }}
           sudo DEBIAN_FRONTEND=noninteractive dpkg -i --force-confnew "artifacts/dist/${{ steps.package.outputs.name }}"
+
+      - name: Test DEB package refuses upgrade from 4.x
+        if: ${{ matrix.distribution == 'deb' && needs.setup.outputs.previous_4x_version != '' }}
+        run: |
+          set -e
+          sudo bash build-scripts/indexer_node_install.sh ${{ needs.setup.outputs.previous_4x_version }}
+          installed_before=$(dpkg-query -W -f='${Version}' wazuh-indexer)
+          echo "Installed before upgrade: wazuh-indexer=$installed_before"
+
+          set +e
+          out=$(sudo DEBIAN_FRONTEND=noninteractive dpkg -i --force-confnew \
+            "artifacts/dist/${{ steps.package.outputs.name }}" 2>&1)
+          rc=$?
+          set -e
+          echo "$out"
+
+          if [ "$rc" -eq 0 ]; then
+            echo "ERROR: upgrade unexpectedly succeeded"; exit 1
+          fi
+          if ! echo "$out" | grep -qF "Direct upgrade from Wazuh Indexer 4.X to 5.X is not supported"; then
+            echo "ERROR: expected block banner not found in output"; exit 1
+          fi
+
+          installed_after=$(dpkg-query -W -f='${Version}' wazuh-indexer)
+          if [ "$installed_before" != "$installed_after" ]; then
+            echo "ERROR: package state changed (before=$installed_before after=$installed_after)"; exit 1
+          fi
+          echo "OK: 5.x package correctly refused upgrade from wazuh-indexer=$installed_after"
 
       - name: Clean up DEB test environment
         if: ${{ always() && matrix.distribution == 'deb' }}

--- a/.github/workflows/5_builderpackage_indexer.yml
+++ b/.github/workflows/5_builderpackage_indexer.yml
@@ -894,7 +894,7 @@ jobs:
           docker run --rm --privileged \
             -v "${{ github.workspace }}/artifacts/dist:/artifacts/dist" \
             -v "${{ github.workspace }}/build-scripts/:/build-scripts/" \
-            redhat/ubi9:latest \
+            redhat/ubi9-init:latest \
             bash -c "bash /build-scripts/indexer_node_install.sh ${{ needs.setup.outputs.previous_version }} && \
                      systemctl stop wazuh-indexer && \
                      yum localinstall '/artifacts/dist/${{ steps.package.outputs.name }}' -y && \
@@ -906,7 +906,7 @@ jobs:
           docker run --rm --privileged \
             -v "${{ github.workspace }}/artifacts/dist:/artifacts/dist" \
             -v "${{ github.workspace }}/build-scripts/:/build-scripts/" \
-            redhat/ubi9:latest \
+            redhat/ubi9-init:latest \
             bash -c "bash /build-scripts/indexer_node_install.sh ${{ needs.setup.outputs.previous_version }} && \
                      yum localinstall '/artifacts/dist/${{ steps.package.outputs.name }}' -y && \
                      if systemctl is-active --quiet wazuh-indexer; then echo 'Indexer running (expected)'; else echo 'Indexer not running (unexpected)'; exit 1; fi"
@@ -917,7 +917,7 @@ jobs:
           docker run --rm --privileged \
             -v "${{ github.workspace }}/artifacts/dist:/artifacts/dist" \
             -v "${{ github.workspace }}/build-scripts/:/build-scripts/" \
-            redhat/ubi9:latest \
+            redhat/ubi9-init:latest \
             bash -c '
               set -e
               bash /build-scripts/indexer_node_install.sh ${{ needs.setup.outputs.previous_4x_version }}

--- a/.github/workflows/5_builderpackage_indexer.yml
+++ b/.github/workflows/5_builderpackage_indexer.yml
@@ -894,7 +894,7 @@ jobs:
           docker run --rm --privileged \
             -v "${{ github.workspace }}/artifacts/dist:/artifacts/dist" \
             -v "${{ github.workspace }}/build-scripts/:/build-scripts/" \
-            redhat/ubi9-init:latest \
+            redhat/ubi9:latest \
             bash -c "bash /build-scripts/indexer_node_install.sh ${{ needs.setup.outputs.previous_version }} && \
                      systemctl stop wazuh-indexer && \
                      yum localinstall '/artifacts/dist/${{ steps.package.outputs.name }}' -y && \
@@ -906,7 +906,7 @@ jobs:
           docker run --rm --privileged \
             -v "${{ github.workspace }}/artifacts/dist:/artifacts/dist" \
             -v "${{ github.workspace }}/build-scripts/:/build-scripts/" \
-            redhat/ubi9-init:latest \
+            redhat/ubi9:latest \
             bash -c "bash /build-scripts/indexer_node_install.sh ${{ needs.setup.outputs.previous_version }} && \
                      yum localinstall '/artifacts/dist/${{ steps.package.outputs.name }}' -y && \
                      if systemctl is-active --quiet wazuh-indexer; then echo 'Indexer running (expected)'; else echo 'Indexer not running (unexpected)'; exit 1; fi"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Merge CodeQL configurations into codeql-analysis.yml [(#1345)](https://github.com/wazuh/wazuh-indexer/pull/1345)
 - Improve build workflow and scripts reliability [(#1378)](https://github.com/wazuh/wazuh-indexer/pull/1378)
 - Update ruleset feed for 5.0.0 beta2 [(#1463)](https://github.com/wazuh/wazuh-indexer/pull/1463)
+- Block 5.x updates from 4.x [(#1545)](https://github.com/wazuh/wazuh-indexer/pull/1545)
 
 ### Deprecated
 -

--- a/build-scripts/indexer_node_install.sh
+++ b/build-scripts/indexer_node_install.sh
@@ -24,16 +24,22 @@ source "${SCRIPT_DIR}/lib/retry.sh"
 
 VERSION="$1"
 MAJOR_VERSION=$(printf '%s' "$VERSION" | sed -E 's/^v?([0-9]+).*/\1/')
+MINOR_VERSION=$(printf '%s' "$VERSION" | sed -E 's/^[0-9]+\.([0-9]+)\.[0-9]+/\1/')
 
 if ! [[ "$MAJOR_VERSION" =~ ^[0-9]+$ ]]; then
   echo "Error: Unable to extract major version from '$VERSION'."
   exit 1
 fi
 
+if ! [[ "$MINOR_VERSION" =~ ^[0-9]+$ ]]; then
+  echo "Error: Unable to extract minor version from '$VERSION'."
+  exit 1
+fi
+
 VERSION_SERIES="${MAJOR_VERSION}.x"
 
-retry 3 5 curl -sO --connect-timeout 10 --max-time 120 https://packages.wazuh.com/$VERSION_SERIES/wazuh-certs-tool.sh
-retry 3 5 curl -sO --connect-timeout 10 --max-time 120 https://packages.wazuh.com/$VERSION_SERIES/config.yml
+retry 3 5 curl -sO --connect-timeout 10 --max-time 120 https://packages.wazuh.com/$MAJOR_VERSION.$MINOR_VERSION/wazuh-certs-tool.sh
+retry 3 5 curl -sO --connect-timeout 10 --max-time 120 https://packages.wazuh.com/$MAJOR_VERSION.$MINOR_VERSION/config.yml
 
 # =====
 # Write to config.yml

--- a/build-scripts/indexer_node_install.sh
+++ b/build-scripts/indexer_node_install.sh
@@ -136,7 +136,7 @@ chown -R wazuh-indexer:wazuh-indexer /etc/wazuh-indexer/certs
 # =====
 # Reload systemd daemon and start the service
 # =====
-if command -v apt-get &> /dev/null; then
+if command -v systemctl &> /dev/null; then
     systemctl daemon-reload
     systemctl enable wazuh-indexer
     systemctl start wazuh-indexer

--- a/build-scripts/indexer_node_install.sh
+++ b/build-scripts/indexer_node_install.sh
@@ -70,7 +70,9 @@ if command -v apt-get &> /dev/null; then
     retry 3 10 apt-get update
     retry 3 10 apt-get -y install wazuh-indexer=$1-1
 else
-  retry 3 10 yum install coreutils -y
+  if ! rpm -qa | grep coreutils; then
+    retry 3 10 yum install coreutils -y
+  fi
 
   retry 3 5 rpm --import https://packages.wazuh.com/key/GPG-KEY-WAZUH
   echo -e '[wazuh]\ngpgcheck=1\ngpgkey=https://packages.wazuh.com/key/GPG-KEY-WAZUH\nenabled=1\nname=EL-$releasever - Wazuh\nbaseurl=https://packages.wazuh.com/'"$VERSION_SERIES"'/yum/\nprotect=1' | tee /etc/yum.repos.d/wazuh.repo

--- a/distribution/packages/src/deb/debian/preinst
+++ b/distribution/packages/src/deb/debian/preinst
@@ -20,17 +20,15 @@ echo "Running Wazuh Indexer Pre-Installation Script"
 case "$1" in
     upgrade)
         # Hard block: refuse 4.X -> 5.X upgrades
-        if [ "$1" = "upgrade" ]; then
-            if grep -lP '4.\d+.\d+' /usr/share/wazuh-indexer/VERSION* 2>/dev/null | grep -q .; then
-                cat >&2 <<'EOF'
+        if grep -Pq '4\.\d+\.\d+' /usr/share/wazuh-indexer/VERSION*; then
+            cat >&2 <<'EOF'
 ==============================================================
 ERROR: Direct upgrade from Wazuh Indexer 4.X to 5.X is not supported.
 
 A clean installation of Wazuh Indexer 5.x is required.
 ==============================================================
 EOF
-                exit 1
-            fi
+            exit 1
         fi
 
         # Stop existing ${name}.service

--- a/distribution/packages/src/deb/debian/preinst
+++ b/distribution/packages/src/deb/debian/preinst
@@ -19,6 +19,20 @@ echo "Running Wazuh Indexer Pre-Installation Script"
 
 case "$1" in
     upgrade)
+        # Hard block: refuse 4.X -> 5.X upgrades
+        if [ "$1" = "upgrade" ]; then
+            if grep -lP '4.\d+.\d+' /usr/share/wazuh-indexer/VERSION* 2>/dev/null | grep -q .; then
+                cat >&2 <<'EOF'
+==============================================================
+ERROR: Direct upgrade from Wazuh Indexer 4.X to 5.X is not supported.
+
+A clean installation of Wazuh Indexer 5.x is required.
+==============================================================
+        EOF
+                exit 1
+            fi
+        fi
+
         # Stop existing ${name}.service
         echo "Stop existing ${name}.service"
         if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1 && systemctl is-active ${name}.service > /dev/null 2>&1; then

--- a/distribution/packages/src/deb/debian/preinst
+++ b/distribution/packages/src/deb/debian/preinst
@@ -28,7 +28,7 @@ ERROR: Direct upgrade from Wazuh Indexer 4.X to 5.X is not supported.
 
 A clean installation of Wazuh Indexer 5.x is required.
 ==============================================================
-        EOF
+EOF
                 exit 1
             fi
         fi

--- a/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
+++ b/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
@@ -152,9 +152,13 @@ exit 0
 
 %pre
 set -e
-# Hard block: refuse 4.X -> 5.X upgrades
-if [ $1 -gt 1 ]; then
-    if grep -lP '4.\d+.\d+' /usr/share/wazuh-indexer/VERSION* 2>/dev/null | grep -q .; then
+
+# Stop the services to upgrade the package
+if [ $1 = 2 ]; then
+    echo "Running upgrade pre-script"
+
+    # Hard block: refuse 4.X -> 5.X upgrades
+    if grep -Pq '4\.\d+\.\d+' /usr/share/wazuh-indexer/VERSION*; then
         cat >&2 <<'EOF'
 ==============================================================
 ERROR: Direct upgrade from Wazuh Indexer 4.X to 5.X is not supported.
@@ -164,11 +168,6 @@ A clean installation of Wazuh Indexer 5.x is required.
 EOF
         exit 1
     fi
-fi
-
-# Stop the services to upgrade the package
-if [ $1 = 2 ]; then
-    echo "Running upgrade pre-script"
 
     # Stop wazuh-indexer service and mark if service is running
     if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1 && systemctl is-active %{name}.service > /dev/null 2>&1; then

--- a/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
+++ b/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
@@ -152,6 +152,19 @@ exit 0
 
 %pre
 set -e
+# Hard block: refuse 4.X -> 5.X upgrades
+if [ $1 -gt 1 ]; then
+    if grep -lP '4.\d+.\d+' /usr/share/wazuh-indexer/VERSION* 2>/dev/null | grep -q .; then
+        cat >&2 <<'EOF'
+==============================================================
+ERROR: Direct upgrade from Wazuh Indexer 4.X to 5.X is not supported.
+
+A clean installation of Wazuh Indexer 5.x is required.
+==============================================================
+EOF
+        exit 1
+    fi
+fi
 
 # Stop the services to upgrade the package
 if [ $1 = 2 ]; then


### PR DESCRIPTION
### Description
This PR introduces changes to the `preinst` and `rpm.spec` packaging files to refuse updates from `4.x` to `5.x` as these will not be supported (a reinstall is required).

### Related Issues
Resolves https://github.com/wazuh/internal-devel-requests/issues/4834