### PR TITLE
Fix Java warnings by updating JVM options for native access and Unsafe deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 - Set secure permissions (750) for engine sockets directory [(#1330)](https://github.com/wazuh/wazuh-indexer/pull/1330)
 - Resolve dependency mismatch between Alerting and Notifications plugins [(#1379)](https://github.com/wazuh/wazuh-indexer/pull/1379)
-- Fix /etc/default/wazuh-indexer ownership and permissions in deb [(#1533)](https://github.com/wazuh/wazuh-indexer/pull/1533)
+- Fix `/etc/default/wazuh-indexer` ownership and permissions in deb [(#1533)](https://github.com/wazuh/wazuh-indexer/pull/1533)
+- Fix Java warnings by updating JVM options for native access [(#1574)](https://github.com/wazuh/wazuh-indexer/pull/1574)
 
 ### Dependencies
 -
@@ -41,7 +42,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Replace and remove deprecated settings [(#894)](https://github.com/wazuh/wazuh-indexer/pull/894)
 - Backport packaging improvements [(#906)](https://github.com/wazuh/wazuh-indexer/pull/906)
 - Apply Lintian overrides [(#908)](https://github.com/wazuh/wazuh-indexer/pull/908)
-- Add noninteractive option for DEB packages testing [(#914)](https://github.com/wazuh/wazuh-indexer/pull/914)
+- Add non-interactive option for DEB packages testing [(#914)](https://github.com/wazuh/wazuh-indexer/pull/914)
 - Migrate smoke tests from Allocator to docker [(#931)](https://github.com/wazuh/wazuh-indexer/pull/931)
 - Migrate builder workflows from [(#930)](https://github.com/wazuh/wazuh-indexer/pull/930)
 - Rename bumper workflow file [(#986)](https://github.com/wazuh/wazuh-indexer/pull/986)
@@ -51,7 +52,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Update GitHub Actions versions in main branch [(#1131)](https://github.com/wazuh/wazuh-indexer/pull/1131)
 - Refactor GH workflow to build packages to use a single branch input [(#1145)](https://github.com/wazuh/wazuh-indexer/pull/1145) [(#1169)](https://github.com/wazuh/wazuh-indexer/pull/1169)
 - Enhance maintenance workflows [(#1192)](https://github.com/wazuh/wazuh-indexer/pull/1192)
-- Change transport.port to http.port in indexer-security-init [(#1233)](https://github.com/wazuh/wazuh-indexer/pull/1233)
+- Change `transport.port` to `http.port` in indexer-security-init [(#1233)](https://github.com/wazuh/wazuh-indexer/pull/1233)
 - Update builder script to detect SAP branch [(#1271)](https://github.com/wazuh/wazuh-indexer/pull/1271)
 - Build SAP in CM workflow [(#1272)](https://github.com/wazuh/wazuh-indexer/pull/1272)
 - Use docker commands directly instead of addnab/docker-run-action [(#1326)](https://github.com/wazuh/wazuh-indexer/pull/1326)
@@ -76,14 +77,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix service status preservation during upgrade in RPM packages [(#1031)](https://github.com/wazuh/wazuh-indexer/pull/1031)
 - Fix Deprecation warning due to set-output command [(#1112)](https://github.com/wazuh/wazuh-indexer/pull/1112)
 - Fix SysV service script permissions [(#1139)](https://github.com/wazuh/wazuh-indexer/pull/1139)
-- Fix unscaped commands in indexer-security-init.sh [(#1196)](https://github.com/wazuh/wazuh-indexer/pull/1196)
+- Fix unescaped commands in indexer-security-init.sh [(#1196)](https://github.com/wazuh/wazuh-indexer/pull/1196)
 - Fix broken link generation from the repository bumper script [(#1206)](https://github.com/wazuh/wazuh-indexer/pull/1206)
 - Fix demo certificates generation triggered by default [(#1235)](https://github.com/wazuh/wazuh-indexer/pull/1235)
 - Fix link-checker workflow [(#1344)](https://github.com/wazuh/wazuh-indexer/pull/1344)
 
 ### Security
-- Reduce risk of GITHUB_TOKEN exposure [(#960)](https://github.com/wazuh/wazuh-indexer/pull/960)
-- Use latest Amazon Linux 2023 Docker image [(#1182)](https://github.com/wazuh/wazuh-indexer/pull/1182)
+- Reduce risk of `GITHUB_TOKEN` exposure [(#960)](https://github.com/wazuh/wazuh-indexer/pull/960)
+- Use the latest Amazon Linux 2023 Docker image [(#1182)](https://github.com/wazuh/wazuh-indexer/pull/1182)
 - Update CodeQL configuration [(#1220)](https://github.com/wazuh/wazuh-indexer/pull/1220)
 - Potential fix for code scanning alerts: Workflow does not contain permissions [(#1234)](https://github.com/wazuh/wazuh-indexer/pull/1234)
 

--- a/distribution/src/config/jvm.options
+++ b/distribution/src/config/jvm.options
@@ -85,7 +85,13 @@ ${error.file}
 23:-XX:CompileCommand=dontinline,java/lang/invoke/MethodHandle.asTypeUncached
 
 21-:-javaagent:agent/opensearch-agent.jar
-21-:--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED
+21-:--add-opens=java.base/java.nio=ALL-UNNAMED
+
+# To silence the JNA restricted-native warning
+21-:--enable-native-access=ALL-UNNAMED
+
+# To silence the sun.misc.Unsafe terminal deprecation warning from ByteBuddy
+24-:--sun-misc-unsafe-memory-access=allow
 
 # For cases with high memory-mapped file counts, a lower value can improve stability and
 # prevent issues like "leaked" maps or performance degradation. A value of 1 effectively


### PR DESCRIPTION
### Description
Suppresses warnings when running `systemctl status wazuh-indexer`.

### Related Issues
Resolves #1573

### Validation

Run `systemctl status wazuh-indexer`

```
● wazuh-indexer.service - wazuh-indexer
     Loaded: loaded (/lib/systemd/system/wazuh-indexer.service; enabled; vendor preset: enabled)
     Active: active (running) since Tue 2026-05-26 12:15:27 UTC; 4s ago
       Docs: https://documentation.wazuh.com
   Main PID: 120874 (java)
      Tasks: 101 (limit: 9389)
     Memory: 4.4G
        CPU: 33.199s
     CGroup: /system.slice/wazuh-indexer.service
             ├─120874 /usr/share/wazuh-indexer/jdk/bin/java -Xshare:auto -Dopensearch.networkaddress.cache.ttl=60 -Dope>
             └─120875 /usr/share/wazuh-indexer/engine/bin/wazuh-engine -f

May 26 12:15:13 default systemd[1]: Starting wazuh-indexer...
May 26 12:15:15 default wazuh-indexer[120874]: WARNING: Using incubator modules: jdk.incubator.vector
May 26 12:15:27 default systemd[1]: Started wazuh-indexer.
```

> [!NOTE]
>  Looks like the warning `WARNING: Using incubator modules: jdk.incubator.vector` cannot be supressed. See https://lists.apache.org/thread/8t3v69ndx2rxf4l38lt162x21t6h9c1n
