### PR TITLE
Add workload-management plugin to resolve warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Improve build workflow and scripts reliability [(#1378)](https://github.com/wazuh/wazuh-indexer/pull/1378)
 - Update ruleset feed for 5.0.0 beta2 [(#1463)](https://github.com/wazuh/wazuh-indexer/pull/1463)
 - Block 5.x updates from 4.x [(#1545)](https://github.com/wazuh/wazuh-indexer/pull/1545)
+- Bundle missing workload-management dependency in the distribution package [(#1597)](https://github.com/wazuh/wazuh-indexer/pull/1597)
 
 ### Deprecated
 -

--- a/build-scripts/assemble.sh
+++ b/build-scripts/assemble.sh
@@ -28,6 +28,7 @@ else
         "opensearch-ml-plugin" # "opensearch-ml"
         "neural-search"        # "opensearch-neural-search"
         "opensearch-observability"
+        "workload-management"  # Required by "opensearch-security" (optional dependency)
         "opensearch-security"
         "opensearch-sql-plugin" # "opensearch-sql"
     )

--- a/build-scripts/assemble.sh
+++ b/build-scripts/assemble.sh
@@ -242,9 +242,9 @@ function install_plugins() {
         OPENSEARCH_PATH_CONF=$PATH_CONF "${PATH_BIN}/opensearch-plugin" install --batch --verbose "file:${maven_repo_local}/org/opensearch/plugin/${plugin}/${UPSTREAM_VERSION}.0/${plugin}-${UPSTREAM_VERSION}.0.zip"
     done
 
-    echo "Installing locally-built plugins"
+    echo "Installing internal-built plugins"
     for plugin in "${internal_plugins[@]}"; do
-        local plugin_path="$HOME/.m2/repository/org/opensearch/plugin/${plugin}/${UPSTREAM_VERSION}.0/${plugin}-${UPSTREAM_VERSION}.0.zip"
+        local plugin_path="${REPO_PATH}/plugins/${plugin}/build/distributions/${plugin}-${UPSTREAM_VERSION}.zip"
         OPENSEARCH_PATH_CONF=$PATH_CONF "${PATH_BIN}/opensearch-plugin" install --batch --verbose "file:${plugin_path}"
     done
 

--- a/build-scripts/assemble.sh
+++ b/build-scripts/assemble.sh
@@ -15,6 +15,7 @@ if ($TEST); then
     plugins=(
         "opensearch-security"
     )
+    internal_plugins=()
     wazuh_plugins=()
 else
     plugins=(
@@ -28,9 +29,13 @@ else
         "opensearch-ml-plugin" # "opensearch-ml"
         "neural-search"        # "opensearch-neural-search"
         "opensearch-observability"
-        "workload-management"  # Required by "opensearch-security" (optional dependency)
         "opensearch-security"
         "opensearch-sql-plugin" # "opensearch-sql"
+    )
+    # Plugins built from this repository, installed from the local Maven repo
+    # (published by ./gradlew publishToMavenLocal in build.sh)
+    internal_plugins=(
+        "workload-management"
     )
     wazuh_plugins=(
         "wazuh-indexer-setup"
@@ -235,6 +240,12 @@ function install_plugins() {
         local plugin_from_maven="org.opensearch.plugin:${plugin}:${UPSTREAM_VERSION}.0"
         retry 3 5 mvn -Dmaven.repo.local="${maven_repo_local}" org.apache.maven.plugins:maven-dependency-plugin:2.1:get -DrepoUrl=https://repo1.maven.org/maven2 -Dartifact="${plugin_from_maven}:zip"
         OPENSEARCH_PATH_CONF=$PATH_CONF "${PATH_BIN}/opensearch-plugin" install --batch --verbose "file:${maven_repo_local}/org/opensearch/plugin/${plugin}/${UPSTREAM_VERSION}.0/${plugin}-${UPSTREAM_VERSION}.0.zip"
+    done
+
+    echo "Installing locally-built plugins"
+    for plugin in "${internal_plugins[@]}"; do
+        local plugin_path="$HOME/.m2/repository/org/opensearch/plugin/${plugin}/${UPSTREAM_VERSION}.0/${plugin}-${UPSTREAM_VERSION}.0.zip"
+        OPENSEARCH_PATH_CONF=$PATH_CONF "${PATH_BIN}/opensearch-plugin" install --batch --verbose "file:${plugin_path}"
     done
 
     echo "Installing Wazuh plugins"

--- a/build-scripts/build.sh
+++ b/build-scripts/build.sh
@@ -158,6 +158,10 @@ function build() {
     # Assemble distribution artifact
     # see https://github.com/opensearch-project/OpenSearch/blob/main/settings.gradle#L34 for other distribution targets
     ./gradlew ":distribution:$TYPE:$TARGET:assemble" -Dbuild.snapshot="$SNAPSHOT" -Dbuild.version_qualifier="$QUALIFIER" -Pcrypto.standard=FIPS-140-3
+
+    # Build plugin ZIPs for internally-built plugins (not available on Maven Central)
+    echo "Building internal plugin ZIPs"
+    ./gradlew :plugins:workload-management:bundlePlugin -Dbuild.snapshot="$SNAPSHOT" -Dbuild.version_qualifier="$QUALIFIER" -Pcrypto.standard=FIPS-140-3
 }
 
 # ====


### PR DESCRIPTION
### Description
This PR includes the plugin in the distribution to eliminate log noise and satisfy the dependency requirements of the security plugin.

### Changes
- Modified `build-scripts/assemble.sh` to include workload-management in the new internal plugins array.
- Ensured `workload-management` is installed before `opensearch-security` to resolve dependencies correctly at runtime.
- Modified the `build.sh` script to ensure that the workload-management plugin is correctly bundled during the distribution assembly process.

### Related Issues
Resolves #1576


