### PR TITLE
Reclassify JUL stderr messages to correct Log4j levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Resolve dependency mismatch between Alerting and Notifications plugins [(#1379)](https://github.com/wazuh/wazuh-indexer/pull/1379)
 - Fix `/etc/default/wazuh-indexer` ownership and permissions in deb [(#1533)](https://github.com/wazuh/wazuh-indexer/pull/1533)
 - Fix Java warnings by updating JVM options for native access [(#1574)](https://github.com/wazuh/wazuh-indexer/pull/1574)
+- Suppress AgentPolicy nad PanamaVectorizationProvider stderr WARN logs [(#1604)](https://github.com/wazuh/wazuh-indexer/pull/1604)
 
 ### Dependencies
 -

--- a/server/src/main/java/org/opensearch/common/logging/LoggingOutputStream.java
+++ b/server/src/main/java/org/opensearch/common/logging/LoggingOutputStream.java
@@ -39,6 +39,8 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Locale;
+import java.util.regex.Pattern;
 
 /**
  * A stream whose output is sent to the configured logger, line by line.
@@ -52,6 +54,14 @@ class LoggingOutputStream extends OutputStream {
     // limit a single log message to 64k
     static final int MAX_BUFFER_LENGTH = DEFAULT_BUFFER_LENGTH * 64;
 
+    /**
+     * Pattern matching JUL SimpleFormatter header lines, e.g.:
+     * "May 25, 2026 1:25:13 PM org.opensearch.javaagent.bootstrap.AgentPolicy setPolicy"
+     */
+    private static final Pattern JUL_HEADER_PATTERN = Pattern.compile(
+        "^(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\\s+\\d{1,2},\\s+\\d{4}\\s+\\d{1,2}:\\d{2}:\\d{2}\\s+(AM|PM)\\s+\\S+"
+    );
+
     class Buffer {
 
         /** The buffer of bytes sent to the stream */
@@ -63,6 +73,9 @@ class LoggingOutputStream extends OutputStream {
 
     // each thread gets its own buffer so messages don't get garbled
     ThreadLocal<Buffer> threadLocal = ThreadLocal.withInitial(Buffer::new);
+
+    // per-thread pending JUL header line awaiting level detection from the next line
+    private final ThreadLocal<String> pendingJulHeader = new ThreadLocal<>();
 
     private final Logger logger;
 
@@ -126,11 +139,62 @@ class LoggingOutputStream extends OutputStream {
 
     @Override
     public void close() {
+        // Flush any pending JUL header before closing
+        String header = pendingJulHeader.get();
+        if (header != null) {
+            logger.log(level, header);
+            pendingJulHeader.remove();
+        }
         threadLocal = null;
     }
 
     // pkg private for testing
     void log(String msg) {
-        logger.log(level, msg);
+        Level detectedLevel = detectJulLevel(msg);
+        if (detectedLevel != null) {
+            // This line starts with a JUL level prefix (e.g., "INFO: message")
+            String header = pendingJulHeader.get();
+            if (header != null) {
+                logger.log(detectedLevel, header);
+                pendingJulHeader.remove();
+            }
+            logger.log(detectedLevel, msg);
+        } else if (JUL_HEADER_PATTERN.matcher(msg).find()) {
+            // This line matches a JUL SimpleFormatter header; buffer it until we see the level line
+            String previousHeader = pendingJulHeader.get();
+            if (previousHeader != null) {
+                // Flush the previous unbounded header at default level
+                logger.log(level, previousHeader);
+            }
+            pendingJulHeader.set(msg);
+        } else {
+            // Regular stderr output
+            String header = pendingJulHeader.get();
+            if (header != null) {
+                logger.log(level, header);
+                pendingJulHeader.remove();
+            }
+            logger.log(level, msg);
+        }
+    }
+
+    /**
+     * Detects a JUL-style level prefix at the start of a message and returns the corresponding Log4j level.
+     * Returns null if no JUL level prefix is found.
+     */
+    static Level detectJulLevel(String msg) {
+        String upper = msg.toUpperCase(Locale.ROOT);
+        if (upper.startsWith("INFO:")) {
+            return Level.INFO;
+        } else if (upper.startsWith("WARNING:")) {
+            return Level.WARN;
+        } else if (upper.startsWith("SEVERE:")) {
+            return Level.ERROR;
+        } else if (upper.startsWith("CONFIG:")) {
+            return Level.DEBUG;
+        } else if (upper.startsWith("FINE:") || upper.startsWith("FINER:") || upper.startsWith("FINEST:")) {
+            return Level.TRACE;
+        }
+        return null;
     }
 }

--- a/server/src/test/java/org/opensearch/common/logging/LoggingOutputStreamTests.java
+++ b/server/src/test/java/org/opensearch/common/logging/LoggingOutputStreamTests.java
@@ -32,6 +32,12 @@
 
 package org.opensearch.common.logging;
 
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
 import org.opensearch.test.OpenSearchTestCase;
 import org.junit.Before;
 
@@ -40,6 +46,7 @@ import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import static org.opensearch.common.logging.LoggingOutputStream.DEFAULT_BUFFER_LENGTH;
 import static org.opensearch.common.logging.LoggingOutputStream.MAX_BUFFER_LENGTH;
@@ -138,5 +145,169 @@ public class LoggingOutputStreamTests extends OpenSearchTestCase {
         thread2.join();
         printStream.flush();
         assertThat(loggingStream.lines, contains("from thread 2", "from thread 1"));
+    }
+
+    public void testDetectJulLevelInfo() {
+        assertThat(LoggingOutputStream.detectJulLevel("INFO: some message"), equalTo(Level.INFO));
+    }
+
+    public void testDetectJulLevelWarning() {
+        assertThat(LoggingOutputStream.detectJulLevel("WARNING: some message"), equalTo(Level.WARN));
+    }
+
+    public void testDetectJulLevelSevere() {
+        assertThat(LoggingOutputStream.detectJulLevel("SEVERE: some message"), equalTo(Level.ERROR));
+    }
+
+    public void testDetectJulLevelConfig() {
+        assertThat(LoggingOutputStream.detectJulLevel("CONFIG: some message"), equalTo(Level.DEBUG));
+    }
+
+    public void testDetectJulLevelFine() {
+        assertThat(LoggingOutputStream.detectJulLevel("FINE: some message"), equalTo(Level.TRACE));
+        assertThat(LoggingOutputStream.detectJulLevel("FINER: some message"), equalTo(Level.TRACE));
+        assertThat(LoggingOutputStream.detectJulLevel("FINEST: some message"), equalTo(Level.TRACE));
+    }
+
+    public void testDetectJulLevelNone() {
+        assertNull(LoggingOutputStream.detectJulLevel("regular stderr output"));
+        assertNull(LoggingOutputStream.detectJulLevel("some error happened"));
+    }
+
+    public void testJulInfoMessageLoggedAtInfoLevel() {
+        Logger logger = LogManager.getLogger("test.stderr.jul");
+        org.apache.logging.log4j.core.Logger coreLogger = (org.apache.logging.log4j.core.Logger) logger;
+
+        List<LogEvent> events = new CopyOnWriteArrayList<>();
+        AbstractAppender appender = new AbstractAppender("test", null, null, true, Property.EMPTY_ARRAY) {
+            @Override
+            public void append(LogEvent event) {
+                events.add(event.toImmutable());
+            }
+        };
+        appender.start();
+        coreLogger.addAppender(appender);
+        coreLogger.setLevel(Level.ALL);
+
+        try {
+            LoggingOutputStream stream = new LoggingOutputStream(logger, Level.WARN);
+            PrintStream ps = new PrintStream(stream, false, StandardCharsets.UTF_8);
+
+            ps.println("May 25, 2026 1:25:13 PM org.opensearch.javaagent.bootstrap.AgentPolicy setPolicy");
+            ps.println("INFO: Policy attached successfully");
+
+            assertThat(events.size(), equalTo(2));
+            // Both lines should be logged at INFO level, not WARN
+            assertThat(events.get(0).getLevel(), equalTo(Level.INFO));
+            assertThat(events.get(0).getMessage().getFormattedMessage(), containsString("AgentPolicy setPolicy"));
+            assertThat(events.get(1).getLevel(), equalTo(Level.INFO));
+            assertThat(events.get(1).getMessage().getFormattedMessage(), containsString("INFO: Policy attached successfully"));
+
+            ps.close();
+        } finally {
+            coreLogger.removeAppender(appender);
+            appender.stop();
+        }
+    }
+
+    public void testJulWarningMessageLoggedAtWarnLevel() {
+        Logger logger = LogManager.getLogger("test.stderr.jul.warn");
+        org.apache.logging.log4j.core.Logger coreLogger = (org.apache.logging.log4j.core.Logger) logger;
+
+        List<LogEvent> events = new CopyOnWriteArrayList<>();
+        AbstractAppender appender = new AbstractAppender("test", null, null, true, Property.EMPTY_ARRAY) {
+            @Override
+            public void append(LogEvent event) {
+                events.add(event.toImmutable());
+            }
+        };
+        appender.start();
+        coreLogger.addAppender(appender);
+        coreLogger.setLevel(Level.ALL);
+
+        try {
+            LoggingOutputStream stream = new LoggingOutputStream(logger, Level.WARN);
+            PrintStream ps = new PrintStream(stream, false, StandardCharsets.UTF_8);
+
+            ps.println("Jun 01, 2026 10:00:00 AM org.example.SomeClass someMethod");
+            ps.println("WARNING: something went wrong");
+
+            assertThat(events.size(), equalTo(2));
+            // Both lines should be logged at WARN level
+            assertThat(events.get(0).getLevel(), equalTo(Level.WARN));
+            assertThat(events.get(1).getLevel(), equalTo(Level.WARN));
+
+            ps.close();
+        } finally {
+            coreLogger.removeAppender(appender);
+            appender.stop();
+        }
+    }
+
+    public void testRegularStderrStillLoggedAtDefaultLevel() {
+        Logger logger = LogManager.getLogger("test.stderr.regular");
+        org.apache.logging.log4j.core.Logger coreLogger = (org.apache.logging.log4j.core.Logger) logger;
+
+        List<LogEvent> events = new CopyOnWriteArrayList<>();
+        AbstractAppender appender = new AbstractAppender("test", null, null, true, Property.EMPTY_ARRAY) {
+            @Override
+            public void append(LogEvent event) {
+                events.add(event.toImmutable());
+            }
+        };
+        appender.start();
+        coreLogger.addAppender(appender);
+        coreLogger.setLevel(Level.ALL);
+
+        try {
+            LoggingOutputStream stream = new LoggingOutputStream(logger, Level.WARN);
+            PrintStream ps = new PrintStream(stream, false, StandardCharsets.UTF_8);
+
+            ps.println("some random third-party stderr output");
+
+            assertThat(events.size(), equalTo(1));
+            // Regular stderr should still be logged at WARN (the default)
+            assertThat(events.get(0).getLevel(), equalTo(Level.WARN));
+            assertThat(events.get(0).getMessage().getFormattedMessage(), containsString("some random third-party stderr output"));
+
+            ps.close();
+        } finally {
+            coreLogger.removeAppender(appender);
+            appender.stop();
+        }
+    }
+
+    public void testLucenePanamaVectorizationInfoMessage() {
+        Logger logger = LogManager.getLogger("test.stderr.lucene");
+        org.apache.logging.log4j.core.Logger coreLogger = (org.apache.logging.log4j.core.Logger) logger;
+
+        List<LogEvent> events = new CopyOnWriteArrayList<>();
+        AbstractAppender appender = new AbstractAppender("test", null, null, true, Property.EMPTY_ARRAY) {
+            @Override
+            public void append(LogEvent event) {
+                events.add(event.toImmutable());
+            }
+        };
+        appender.start();
+        coreLogger.addAppender(appender);
+        coreLogger.setLevel(Level.ALL);
+
+        try {
+            LoggingOutputStream stream = new LoggingOutputStream(logger, Level.WARN);
+            PrintStream ps = new PrintStream(stream, false, StandardCharsets.UTF_8);
+
+            ps.println("May 25, 2026 1:25:14 PM org.apache.lucene.internal.vectorization.PanamaVectorizationProvider");
+            ps.println("INFO: Java vector incubator API enabled; uses preferredBitSize=256; FMA enabled");
+
+            assertThat(events.size(), equalTo(2));
+            // Both should be at INFO level
+            assertThat(events.get(0).getLevel(), equalTo(Level.INFO));
+            assertThat(events.get(1).getLevel(), equalTo(Level.INFO));
+
+            ps.close();
+        } finally {
+            coreLogger.removeAppender(appender);
+            appender.stop();
+        }
     }
 }


### PR DESCRIPTION
### Description
This PR addresses the issue where informational messages from the Java agent bootstrap and Lucene's Panama vectorization provider are incorrectly tagged as `WARN` during Wazuh Indexer startup.

### Changes
`LoggingOutputStream.java`: Implemented a buffering mechanism to detect java.util.logging (JUL) SimpleFormatter patterns.
* Step 1: The code now identifies JUL headers (timestamp + class name) using regex and buffers them.
* Step 2: It inspects the subsequent line for JUL severity prefixes (INFO:, WARNING:, SEVERE:).
* Step 3: If a match is found, the log is emitted using the mapped Log4j level.

Fallback: Standard stderr output that doesn't match the JUL pattern continues to be logged as WARN to ensure no critical error information is lost or downgraded.

`LoggingOutputStreamTests.java`: Added unit tests to verify:
* Correct reclassification of `INFO` messages from `AgentPolicy`.
* Correct reclassification of `INFO` messages from `PanamaVectorizationProvider`.
* Retention of `WARN` level for non-JUL standard error strings.
### Related Issues
Resolves #1575

