### PR TITLE
Add tmp size check on installation

### DIFF
--- a/distribution/packages/src/deb/debian/preinst
+++ b/distribution/packages/src/deb/debian/preinst
@@ -17,6 +17,27 @@ state_file=${config_dir}/.was_active
 
 echo "Running Wazuh Indexer Pre-Installation Script"
 
+# Check /tmp partition has at least 10 GB of total space.
+# The Content Manager plugin downloads CTI snapshots to /tmp 
+# which can exceed the default size
+MIN_TMP_SIZE_KB=$((10 * 1024 * 1024))
+tmp_size_kb=$(df --output=size /tmp 2>/dev/null | tail -1 | tr -d ' ')
+if [ -n "$tmp_size_kb" ] && [ "$tmp_size_kb" -lt "$MIN_TMP_SIZE_KB" ]; then
+    tmp_size_mb=$((tmp_size_kb / 1024))
+    cat >&2 <<EOF
+==============================================================
+ERROR: The /tmp partition is too small (${tmp_size_mb} MB).
+
+Wazuh Indexer requires at least 10 GB of space in /tmp for
+CTI snapshot downloads during content synchronization.
+
+Please resize the /tmp partition or mount a larger tmpfs
+before installing.
+==============================================================
+EOF
+    exit 1
+fi
+
 case "$1" in
     upgrade)
         # Hard block: refuse 4.X -> 5.X upgrades

--- a/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
+++ b/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
@@ -153,6 +153,27 @@ exit 0
 %pre
 set -e
 
+# Check /tmp partition has at least 10 GB of total space.
+# The Content Manager plugin downloads CTI snapshots to /tmp 
+# which can exceed the default size
+MIN_TMP_SIZE_KB=$((10 * 1024 * 1024)) 
+tmp_size_kb=$(df --output=size /tmp 2>/dev/null | tail -1 | tr -d ' ')
+if [ -n "$tmp_size_kb" ] && [ "$tmp_size_kb" -lt "$MIN_TMP_SIZE_KB" ]; then
+    tmp_size_mb=$((tmp_size_kb / 1024))
+    cat >&2 <<EOF
+==============================================================
+ERROR: The /tmp partition is too small (${tmp_size_mb} MB).
+
+Wazuh Indexer requires at least 10 GB of space in /tmp for
+CTI snapshot downloads during content synchronization.
+
+Please resize the /tmp partition or mount a larger tmpfs
+before installing.
+==============================================================
+EOF
+    exit 1
+fi
+
 # Stop the services to upgrade the package
 if [ $1 = 2 ]; then
     echo "Running upgrade pre-script"


### PR DESCRIPTION
### Description
This PR adds a check on the size of the `/tmp` folder size to guarantee that the indexer works correctly

### Related Issues
Resolves #1572

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
