### PR TITLE
Supress Warn messages about compliance on openserach.yml

### DIFF
--- a/build-scripts/docker/config/opensearch.yml
+++ b/build-scripts/docker/config/opensearch.yml
@@ -23,4 +23,13 @@ plugins.security.restapi.roles_enabled:
 - "security_rest_api_access"
 plugins.security.system_indices.enabled: true
 plugins.security.system_indices.indices: [".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-anomaly-results*", ".opendistro-anomaly-detector*", ".opendistro-anomaly-checkpoints", ".opendistro-anomaly-detection-state", ".opendistro-reports-*", ".opendistro-notifications-*", ".opendistro-notebooks", ".opensearch-observability", ".opendistro-asynchronous-search-response*", ".replication-metadata-store", ".wazuh-internal-state"]
+
+# Disable compliance features (field masking is not used by Wazuh Indexer).
+# This suppresses irrelevant WARN messages about compliance salt at startup.
+plugins.security.compliance.salt: wz8hndx3rSlt16ch
+plugins.security.compliance.history.internal_config_enabled: false
+plugins.security.compliance.history.external_config_enabled: false
+plugins.security.compliance.history.read.watched_fields: {}
+plugins.security.compliance.history.write.watched_indices: []
+
 cluster.default_number_of_replicas: 0

--- a/distribution/src/config/opensearch.prod.yml
+++ b/distribution/src/config/opensearch.prod.yml
@@ -37,4 +37,13 @@ plugins.security.restapi.roles_enabled:
 
 plugins.security.system_indices.enabled: true
 plugins.security.system_indices.indices: [".plugins-ml-model", ".plugins-ml-task", ".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-anomaly-results*", ".opendistro-anomaly-detector*", ".opendistro-anomaly-checkpoints", ".opendistro-anomaly-detection-state", ".opendistro-reports-*", ".opensearch-notifications-*", ".opensearch-notebooks", ".opensearch-observability", ".opendistro-asynchronous-search-response*", ".replication-metadata-store", ".wazuh-internal-state"]
+
+# Disable compliance features (field masking is not used by Wazuh Indexer).
+# This suppresses irrelevant WARN messages about compliance salt at startup.
+plugins.security.compliance.salt: wz8hndx3rSlt16ch
+plugins.security.compliance.history.internal_config_enabled: false
+plugins.security.compliance.history.external_config_enabled: false
+plugins.security.compliance.history.read.watched_fields: {}
+plugins.security.compliance.history.write.watched_indices: []
+
 cluster.default_number_of_replicas: 0

--- a/docker/prod/config/opensearch.yml
+++ b/docker/prod/config/opensearch.yml
@@ -24,3 +24,11 @@ plugins.security.restapi.roles_enabled:
 - "security_rest_api_access"
 plugins.security.system_indices.enabled: true
 plugins.security.system_indices.indices: [".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-anomaly-results*", ".opendistro-anomaly-detector*", ".opendistro-anomaly-checkpoints", ".opendistro-anomaly-detection-state", ".opendistro-reports-*", ".opendistro-notifications-*", ".opendistro-notebooks", ".opensearch-observability", ".opendistro-asynchronous-search-response*", ".replication-metadata-store", ".wazuh-internal-state"]
+
+# Disable compliance features (field masking is not used by Wazuh Indexer).
+# This suppresses irrelevant WARN messages about compliance salt at startup.
+plugins.security.compliance.salt: wz8hndx3rSlt16ch
+plugins.security.compliance.history.internal_config_enabled: false
+plugins.security.compliance.history.external_config_enabled: false
+plugins.security.compliance.history.read.watched_fields: {}
+plugins.security.compliance.history.write.watched_indices: []


### PR DESCRIPTION
### Description
This PR addresses the issue where `WARN` level log messages regarding the `compliance salt` appear during the Wazuh Indexer startup. These warnings are triggered by the security plugin's compliance module, specifically related to the field masking feature, which is not utilized by Wazuh Indexer.

To eliminate these logs and ensure a cleaner startup sequence, this change explicitly configures a default compliance salt and disables unused compliance history features.

### Changes
The following configurations were added to the `opensearch.yml` templates (production, Docker build, and Docker production):
- `plugins.security.compliance.salt`: Set to a static 16-character string to satisfy the plugin's requirement and suppress the `o.o.s.c.Salt warning`.


### Related Issues
Resolves #1604