### PR TITLE
Change log level from warn to info for dangling indices

### DIFF
--- a/server/src/main/java/org/opensearch/gateway/DanglingIndicesState.java
+++ b/server/src/main/java/org/opensearch/gateway/DanglingIndicesState.java
@@ -108,7 +108,7 @@ public class DanglingIndicesState implements ClusterStateListener {
         if (this.isAutoImportDanglingIndicesEnabled) {
             clusterService.addListener(this);
         } else {
-            logger.debug(
+            logger.info(
                 AUTO_IMPORT_DANGLING_INDICES_SETTING.getKey()
                     + " is disabled, dangling indices will not be automatically detected or imported and must be managed manually"
             );

--- a/server/src/main/java/org/opensearch/gateway/DanglingIndicesState.java
+++ b/server/src/main/java/org/opensearch/gateway/DanglingIndicesState.java
@@ -108,7 +108,7 @@ public class DanglingIndicesState implements ClusterStateListener {
         if (this.isAutoImportDanglingIndicesEnabled) {
             clusterService.addListener(this);
         } else {
-            logger.warn(
+            logger.debug(
                 AUTO_IMPORT_DANGLING_INDICES_SETTING.getKey()
                     + " is disabled, dangling indices will not be automatically detected or imported and must be managed manually"
             );


### PR DESCRIPTION
### Description
`gateway.auto_import_dangling_indices` is disabled by default and marked as deprecated. The constructor of `DanglingIndicesState` emitted a `[WARN]` on every startup, but the message is purely informational (it does not indicate an error or misconfiguration). Lowering it to `DEBUG` removes the noise from the log stream.

### Related Issues
Resolves wazuh/wazuh-indexer#1581
