### PR TITLE
Change value of `OPENSEARCH_TMPDIR` environment variable

### DIFF
--- a/distribution/packages/src/common/env/wazuh-indexer
+++ b/distribution/packages/src/common/env/wazuh-indexer
@@ -18,6 +18,10 @@ OPENSEARCH_PATH_CONF=${path.conf}
 # Additional Java OPTS
 #OPENSEARCH_JAVA_OPTS=
 
+# Temporary directory used by the JVM and OpenSearch for snapshot downloads,
+# extraction, and other transient files.
+OPENSEARCH_TMPDIR=/var/lib/wazuh-indexer/tmp
+
 # Configure restart on package upgrade (true, every other setting will lead to not restarting)
 #RESTART_ON_UPGRADE=true
 

--- a/distribution/packages/src/deb/debian/postinst
+++ b/distribution/packages/src/deb/debian/postinst
@@ -23,6 +23,10 @@ pid_dir=/run/${name}
 defaults_file=/etc/default/${name}
 state_file=${config_dir}/.was_active
 
+# Create tmp directory for snapshot operations (avoids filling /tmp)
+tmp_dir=${data_dir}/tmp
+mkdir -p ${tmp_dir}
+
 # Set owner
 chown -R ${name}:${name} ${product_dir}
 chown -R ${name}:${name} ${config_dir}

--- a/distribution/packages/src/deb/debian/postinst
+++ b/distribution/packages/src/deb/debian/postinst
@@ -34,6 +34,7 @@ chown -R ${name}:${name} ${log_dir}
 chown -R ${name}:${name} ${data_dir}
 chown -R ${name}:${name} ${pid_dir}
 chown ${name}:${name} ${defaults_file}
+chown ${name}:${name} ${tmp_dir}
 
 # Change permissions for Wazuh Engine
 ENGINE_DIR="${product_dir}/engine"

--- a/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
+++ b/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
@@ -196,6 +196,10 @@ exit 0
 %post
 set -e
 
+# Create tmp directory for snapshot operations (avoids filling /tmp)
+mkdir -p %{data_dir}/tmp
+chown %{name}:%{name} %{data_dir}/tmp
+
 # Fix ownership and permissions
 chown -R %{name}:%{name} %{config_dir}
 chown -R %{name}:%{name} %{log_dir}


### PR DESCRIPTION
### Description
This PR adds a different approach to the `/tmp` problem, where instead of blocking the install, we use a different path to ensure that the operations work correctly . The default directory is: `/var/lib/wazuh-indexer/tmp`, and the rest of the code changes are to ensure the folder is created

### Related Issues
Resolves #1572

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
