### PR TITLE
Remove opensearch-ml plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Remove extra files [(#866)](https://github.com/wazuh/wazuh-indexer/pull/866) [(#1074)](https://github.com/wazuh/wazuh-indexer/pull/1074)
 - Remove references to legacy VERSION file [(#908)](https://github.com/wazuh/wazuh-indexer/pull/908)
 - Remove opensearch-performance-analyzer [(#892)](https://github.com/wazuh/wazuh-indexer/pull/892)
+- Remove opensearch-ml plugin [(#1615)](https://github.com/wazuh/wazuh-indexer/pull/1615)
 
 ### Fixed
 - Fix package upload to bucket subfolder 5.x [(#846)](https://github.com/wazuh/wazuh-indexer/pull/846)

--- a/build-scripts/assemble.sh
+++ b/build-scripts/assemble.sh
@@ -26,7 +26,6 @@ else
         "geospatial" # "opensearch-geospatial"
         "opensearch-index-management"
         "opensearch-knn"
-        "opensearch-ml-plugin" # "opensearch-ml"
         "neural-search"        # "opensearch-neural-search"
         "opensearch-observability"
         "opensearch-security"

--- a/build-scripts/indexer_node_install.sh
+++ b/build-scripts/indexer_node_install.sh
@@ -117,7 +117,7 @@ plugins.security.restapi.roles_enabled:
 - "security_rest_api_access"
 
 plugins.security.system_indices.enabled: true
-plugins.security.system_indices.indices: [".plugins-ml-model", ".plugins-ml-task", ".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-anomaly-results*", ".opendistro-anomaly-detector*", ".opendistro-anomaly-checkpoints", ".opendistro-anomaly-detection-state", ".opendistro-reports-*", ".opensearch-notifications-*", ".opensearch-notebooks", ".opensearch-observability", ".opendistro-asynchronous-search-response*", ".replication-metadata-store"]
+plugins.security.system_indices.indices: [".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-anomaly-results*", ".opendistro-anomaly-detector*", ".opendistro-anomaly-checkpoints", ".opendistro-anomaly-detection-state", ".opendistro-reports-*", ".opensearch-notifications-*", ".opensearch-notebooks", ".opensearch-observability", ".opendistro-asynchronous-search-response*", ".replication-metadata-store"]
 cluster.default_number_of_replicas: 0
 EOF
 

--- a/distribution/src/config/opensearch.prod.yml
+++ b/distribution/src/config/opensearch.prod.yml
@@ -36,5 +36,5 @@ plugins.security.restapi.roles_enabled:
 - "security_rest_api_access"
 
 plugins.security.system_indices.enabled: true
-plugins.security.system_indices.indices: [".plugins-ml-model", ".plugins-ml-task", ".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-anomaly-results*", ".opendistro-anomaly-detector*", ".opendistro-anomaly-checkpoints", ".opendistro-anomaly-detection-state", ".opendistro-reports-*", ".opensearch-notifications-*", ".opensearch-notebooks", ".opensearch-observability", ".opendistro-asynchronous-search-response*", ".replication-metadata-store", ".wazuh-internal-state"]
+plugins.security.system_indices.indices: [".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-anomaly-results*", ".opendistro-anomaly-detector*", ".opendistro-anomaly-checkpoints", ".opendistro-anomaly-detection-state", ".opendistro-reports-*", ".opensearch-notifications-*", ".opensearch-notebooks", ".opensearch-observability", ".opendistro-asynchronous-search-response*", ".replication-metadata-store", ".wazuh-internal-state"]
 cluster.default_number_of_replicas: 0

--- a/distribution/src/config/security/roles.wazuh.yml
+++ b/distribution/src/config/security/roles.wazuh.yml
@@ -136,42 +136,6 @@ sample-data-management:
   tenant_permissions: []
   static: true
 
-# Role to grant read access to ML related indices. Used to configure the AI assistant from the UI.
-ml_config_read:
-  reserved: true
-  hidden: false
-  cluster_permissions: []
-  index_permissions:
-  - index_patterns:
-    - ".plugins-ml-model"
-    - ".plugins-ml-connector"
-    - ".plugins-ml-agent"
-    - ".plugins-ml-config"
-    # dls: ""
-    # fls: []
-    # masked_fields: []
-    allowed_actions:
-    - "read"
-    - "system:admin/system_index"
-  tenant_permissions: []
-  static: false
-
-# Role to grant write access to ML related indices. Used to configure the AI assistant from the UI.
-ml_config_write:
-  reserved: true
-  hidden: false
-  cluster_permissions: []
-  index_permissions:
-  - index_patterns:
-    - ".plugins-ml-config"
-    # dls: ""
-    # fls: []
-    # masked_fields: []
-    allowed_actions:
-    - "write"
-    - "system:admin/system_index"
-  tenant_permissions: []
-  static: false
 
 # Roles for Content Manager plugin subscription management
 cm_subscription_read:

--- a/distribution/src/config/security/roles_mapping.wazuh.yml
+++ b/distribution/src/config/security/roles_mapping.wazuh.yml
@@ -83,25 +83,6 @@ sample-data-management:
     - "wazuh-dashboard"
   and_backend_roles: [ ]
 
-# To allow the AI assistant deployment from the UI.
-ml_config_read:
-  reserved: true
-  hidden: false
-  backend_roles: []
-  hosts: []
-  users:
-  - "admin"
-  and_backend_roles: []
-
-ml_config_write:
-  reserved: true
-  hidden: false
-  backend_roles: []
-  hosts: []
-  users:
-  - "admin"
-  and_backend_roles: []
-
 # Allow the dashboard to pre-configure integrations.
 alerting_full_access:
   reserved: true


### PR DESCRIPTION
### Description
The plugin logs `StreamTransportService is not available` WARNs on every startup because Wazuh does not use 'Arrow Flight RPC'. No Wazuh component depends on it (it was originally added for a planned AI assistant feature that was later discarded).

Removes the plugin from the build, cleans up system indices references, and removes the unused `ml_config_read`/`ml_config_write` security roles.

### Related Issues
Resolves #1582
