### PR TITLE
Add SLF4J provider to reindex module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Resolve dependency mismatch between Alerting and Notifications plugins [(#1379)](https://github.com/wazuh/wazuh-indexer/pull/1379)
 - Fix `/etc/default/wazuh-indexer` ownership and permissions in deb [(#1533)](https://github.com/wazuh/wazuh-indexer/pull/1533)
 - Fix Java warnings by updating JVM options for native access [(#1574)](https://github.com/wazuh/wazuh-indexer/pull/1574)
+- Fix SLF4J startup warning in reindex module by adding Log4j2 provider [(#1617)](https://github.com/wazuh/wazuh-indexer/pull/1617)
 
 ### Dependencies
 -

--- a/modules/reindex/build.gradle
+++ b/modules/reindex/build.gradle
@@ -65,6 +65,7 @@ test {
 
 dependencies {
   api project(":client:rest")
+  runtimeOnly "org.apache.logging.log4j:log4j-slf4j2-impl:${versions.log4j}"
   api project(":libs:opensearch-ssl-config")
   // for http - testing reindex from remote
   testImplementation project(':modules:transport-netty4')


### PR DESCRIPTION
### Description
The reindex module pulls in `slf4j-api` 2.x transitively via Apache HttpComponents 5, but had no SLF4J provider on the classpath. Adds `log4j-slf4j2-impl` as a `runtimeOnly` dependency to bridge SLF4J calls to the existing Log4j2 backend.

### Issues Resolved
Resolves #1577
