### PR TITLE
Remove opensearch-knn and opensearch-neural-search plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Remove opensearch-performance-analyzer [(#892)](https://github.com/wazuh/wazuh-indexer/pull/892)
 - Remove SQL plugin from the distribution [(#1611)](https://github.com/wazuh/wazuh-indexer/pull/1611)
 - Remove opensearch-ml plugin [(#1615)](https://github.com/wazuh/wazuh-indexer/pull/1615)
+- Remove opensearch-knn and opensearch-neural-search plugins [(#1620)](https://github.com/wazuh/wazuh-indexer/pull/1620)
 
 ### Fixed
 - Fix package upload to bucket subfolder 5.x [(#846)](https://github.com/wazuh/wazuh-indexer/pull/846)

--- a/build-scripts/assemble.sh
+++ b/build-scripts/assemble.sh
@@ -25,8 +25,6 @@ else
         "opensearch-cross-cluster-replication"
         "geospatial" # "opensearch-geospatial"
         "opensearch-index-management"
-        "opensearch-knn"
-        "neural-search"        # "opensearch-neural-search"
         "opensearch-observability"
         "opensearch-security"
     )


### PR DESCRIPTION
### Description
Removes `opensearch-knn` and `opensearch-neural-search` from the list of bundled plugins in `assemble.sh`. Both plugins bundle `slf4j-api` without an SLF4J provider, causing startup warnings.

### Related Issues
Resolves #1577
