### PR TITLE
Add prior versions to the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Prior versions
 
-There are no prior versions. This is the initial release of Wazuh Indexer.
+This is the initial release of Wazuh Indexer 5.0, so there are no prior 5.x versions. Previous releases can be found under the 4.x branch.
 
 [Unreleased 5.0.0]: https://github.com/wazuh/wazuh-indexer/compare/f79ea09c71af66902e1613e2a6de215631a34997...main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,4 +97,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 There are no prior versions. This is the initial release of Wazuh Indexer.
 
-[v5.0.0]: https://github.com/wazuh/wazuh-indexer/compare/f79ea09c71af66902e1613e2a6de215631a34997...v5.0.0
+[Unreleased 5.0.0]: https://github.com/wazuh/wazuh-indexer/compare/f79ea09c71af66902e1613e2a6de215631a34997...main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,8 +94,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Update CodeQL configuration [(#1220)](https://github.com/wazuh/wazuh-indexer/pull/1220)
 - Potential fix for code scanning alerts: Workflow does not contain permissions [(#1234)](https://github.com/wazuh/wazuh-indexer/pull/1234)
 
-## Prior versions
-
-This is the initial release of Wazuh Indexer 5.0, so there are no prior 5.x versions. Previous releases can be found under the 4.x branch.
+## Prior version
+- []()
 
 [Unreleased 5.0.0]: https://github.com/wazuh/wazuh-indexer/compare/f79ea09c71af66902e1613e2a6de215631a34997...main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). See the [CONTRIBUTING guide](./CONTRIBUTING.md#Changelog) for instructions on how to add changelog entries.
 
-## [Unreleased 5.0.0]
+## [v5.0.0]
 ### Added
 - Add new users, roles and mappings [(#886)](https://github.com/wazuh/wazuh-indexer/pull/886)
 - Add custom GitHub Action to validate commiter's emails by domain [(#896)](https://github.com/wazuh/wazuh-indexer/pull/896)
@@ -93,4 +93,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Update CodeQL configuration [(#1220)](https://github.com/wazuh/wazuh-indexer/pull/1220)
 - Potential fix for code scanning alerts: Workflow does not contain permissions [(#1234)](https://github.com/wazuh/wazuh-indexer/pull/1234)
 
-[Unreleased 5.0.0]: https://github.com/wazuh/wazuh-indexer/compare/f79ea09c71af66902e1613e2a6de215631a34997...main
+## Prior versions
+
+There are no prior versions. This is the initial release of Wazuh Indexer.
+
+[v5.0.0]: https://github.com/wazuh/wazuh-indexer/compare/f79ea09c71af66902e1613e2a6de215631a34997...v5.0.0


### PR DESCRIPTION
### Description
Applies the changelog standardization requirements from the issue related to the wazuh-indexer repository.

### Related Issues
Resolves https://github.com/wazuh/internal-devel-requests/issues/5216


