### PR TITLE
Removed non-essential plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Remove SQL plugin from the distribution [(#1611)](https://github.com/wazuh/wazuh-indexer/pull/1611)
 - Remove opensearch-ml plugin [(#1615)](https://github.com/wazuh/wazuh-indexer/pull/1615)
 - Remove opensearch-knn and opensearch-neural-search plugins [(#1620)](https://github.com/wazuh/wazuh-indexer/pull/1620)
+- Remove asynchronous-search, opensearch-anomaly-detection, opensearch-observability plugins [(#1645)](https://github.com/wazuh/wazuh-indexer/pull/1645)
 
 ### Fixed
 - Fix package upload to bucket subfolder 5.x [(#846)](https://github.com/wazuh/wazuh-indexer/pull/846)

--- a/build-scripts/assemble.sh
+++ b/build-scripts/assemble.sh
@@ -20,12 +20,9 @@ if ($TEST); then
 else
     plugins=(
         "opensearch-job-scheduler"
-        "opensearch-anomaly-detection" # Requires "opensearch-job-scheduler"
-        "asynchronous-search"          # "opensearch-asynchronous-search"
         "opensearch-cross-cluster-replication"
         "geospatial" # "opensearch-geospatial"
         "opensearch-index-management"
-        "opensearch-observability"
         "opensearch-security"
     )
     # Plugins built from this repository, installed from the local Maven repo

--- a/build-scripts/docker/config/opensearch.yml
+++ b/build-scripts/docker/config/opensearch.yml
@@ -22,5 +22,5 @@ plugins.security.restapi.roles_enabled:
 - "all_access"
 - "security_rest_api_access"
 plugins.security.system_indices.enabled: true
-plugins.security.system_indices.indices: [".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-reports-*", ".opendistro-notifications-*", ".opendistro-notebooks", ".replication-metadata-store", ".wazuh-internal-state"]
+plugins.security.system_indices.indices: [".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-reports-*", ".opendistro-notifications-*", ".replication-metadata-store", ".wazuh-internal-state"]
 cluster.default_number_of_replicas: 0

--- a/build-scripts/docker/config/opensearch.yml
+++ b/build-scripts/docker/config/opensearch.yml
@@ -22,5 +22,5 @@ plugins.security.restapi.roles_enabled:
 - "all_access"
 - "security_rest_api_access"
 plugins.security.system_indices.enabled: true
-plugins.security.system_indices.indices: [".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-anomaly-results*", ".opendistro-anomaly-detector*", ".opendistro-anomaly-checkpoints", ".opendistro-anomaly-detection-state", ".opendistro-reports-*", ".opendistro-notifications-*", ".opendistro-notebooks", ".opensearch-observability", ".opendistro-asynchronous-search-response*", ".replication-metadata-store", ".wazuh-internal-state"]
+plugins.security.system_indices.indices: [".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-reports-*", ".opendistro-notifications-*", ".opendistro-notebooks", ".replication-metadata-store", ".wazuh-internal-state"]
 cluster.default_number_of_replicas: 0

--- a/build-scripts/indexer_node_install.sh
+++ b/build-scripts/indexer_node_install.sh
@@ -117,7 +117,7 @@ plugins.security.restapi.roles_enabled:
 - "security_rest_api_access"
 
 plugins.security.system_indices.enabled: true
-plugins.security.system_indices.indices: [".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-anomaly-results*", ".opendistro-anomaly-detector*", ".opendistro-anomaly-checkpoints", ".opendistro-anomaly-detection-state", ".opendistro-reports-*", ".opensearch-notifications-*", ".opensearch-notebooks", ".opensearch-observability", ".opendistro-asynchronous-search-response*", ".replication-metadata-store"]
+plugins.security.system_indices.indices: [".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-reports-*", ".opensearch-notifications-*", ".opensearch-notebooks", ".replication-metadata-store"]
 cluster.default_number_of_replicas: 0
 EOF
 

--- a/build-scripts/indexer_node_install.sh
+++ b/build-scripts/indexer_node_install.sh
@@ -117,7 +117,7 @@ plugins.security.restapi.roles_enabled:
 - "security_rest_api_access"
 
 plugins.security.system_indices.enabled: true
-plugins.security.system_indices.indices: [".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-reports-*", ".opensearch-notifications-*", ".opensearch-notebooks", ".replication-metadata-store"]
+plugins.security.system_indices.indices: [".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-reports-*", ".opensearch-notifications-*", ".replication-metadata-store"]
 cluster.default_number_of_replicas: 0
 EOF
 

--- a/distribution/packages/src/deb/debmake_install.sh
+++ b/distribution/packages/src/deb/debmake_install.sh
@@ -62,10 +62,6 @@ for i in "${config_files[@]}"; do
 done
 
 # Plugin-related files
-if [ -e "${buildroot}/${config_dir}/opensearch-observability/observability.yml" ]; then
-	chmod -c 660 "${buildroot}/${config_dir}/opensearch-observability/observability.yml"
-fi
-
 if [ -e "${buildroot}/${config_dir}/opensearch-reports-scheduler/reports-scheduler.yml" ]; then
 	chmod -c 660 "${buildroot}/${config_dir}/opensearch-reports-scheduler/reports-scheduler.yml"
 fi

--- a/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
+++ b/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
@@ -57,7 +57,6 @@ For more information, see: https://www.wazuh.com/
 
 %build
 
-%define observability_plugin %( if [ -f %{_topdir}/etc/wazuh-indexer/opensearch-observability/observability.yml ]; then echo "1" ; else echo "0"; fi )
 %define reportsscheduler_plugin %( if [ -f %{_topdir}/etc/wazuh-indexer/opensearch-reports-scheduler/reports-scheduler.yml ]; then echo "1" ; else echo "0"; fi )
 
 %install
@@ -79,7 +78,6 @@ if [ -d %{buildroot}%{product_dir}/plugins/opensearch-security ]; then
 fi
 
 # Pre-populate the folders to ensure rpm build success even without all plugins
-mkdir -p %{buildroot}%{config_dir}/opensearch-observability
 mkdir -p %{buildroot}%{config_dir}/opensearch-reports-scheduler
 
 # Build a filelist to be included in the %files section
@@ -130,12 +128,7 @@ set -- "$@" "%{_sysconfdir}/sysconfig/%{name}"
 set -- "$@" "%{_prefix}/lib/sysctl.d/%{name}.conf"
 set -- "$@" "%{_prefix}/lib/tmpfiles.d/%{name}.conf"
 
-# Check if we are including the observability and reports scheduler
-# plugins
-if [ %observability_plugin -eq 1 ]; then
-    set -- "$@" "%{config_dir}/opensearch-observability/observability.yml"
-fi
-
+# Check if we are including the reports scheduler plugin
 if [ %reportsscheduler_plugin -eq 1 ]; then
     set -- "$@" "%{config_dir}/opensearch-reports-scheduler/reports-scheduler.yml"
 fi
@@ -304,10 +297,6 @@ exit 0
 %config(noreplace) %attr(660, %{name}, %{name}) %{config_dir}/jvm.options
 %config(noreplace) %attr(660, %{name}, %{name}) %{config_dir}/opensearch.yml
 %config(noreplace) %attr(640, %{name}, %{name}) %{config_dir}/opensearch-security/*
-
-%if %observability_plugin
-%config(noreplace) %attr(660, %{name}, %{name}) %{config_dir}/opensearch-observability/observability.yml
-%endif
 
 %if %reportsscheduler_plugin
 %config(noreplace) %attr(660, %{name}, %{name}) %{config_dir}/opensearch-reports-scheduler/reports-scheduler.yml

--- a/distribution/src/config/opensearch.prod.yml
+++ b/distribution/src/config/opensearch.prod.yml
@@ -36,5 +36,5 @@ plugins.security.restapi.roles_enabled:
 - "security_rest_api_access"
 
 plugins.security.system_indices.enabled: true
-plugins.security.system_indices.indices: [".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-reports-*", ".opensearch-notifications-*", ".opensearch-notebooks", ".replication-metadata-store", ".wazuh-internal-state"]
+plugins.security.system_indices.indices: [".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-reports-*", ".opensearch-notifications-*", ".replication-metadata-store", ".wazuh-internal-state"]
 cluster.default_number_of_replicas: 0

--- a/distribution/src/config/opensearch.prod.yml
+++ b/distribution/src/config/opensearch.prod.yml
@@ -36,5 +36,5 @@ plugins.security.restapi.roles_enabled:
 - "security_rest_api_access"
 
 plugins.security.system_indices.enabled: true
-plugins.security.system_indices.indices: [".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-anomaly-results*", ".opendistro-anomaly-detector*", ".opendistro-anomaly-checkpoints", ".opendistro-anomaly-detection-state", ".opendistro-reports-*", ".opensearch-notifications-*", ".opensearch-notebooks", ".opensearch-observability", ".opendistro-asynchronous-search-response*", ".replication-metadata-store", ".wazuh-internal-state"]
+plugins.security.system_indices.indices: [".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-reports-*", ".opensearch-notifications-*", ".opensearch-notebooks", ".replication-metadata-store", ".wazuh-internal-state"]
 cluster.default_number_of_replicas: 0

--- a/docker/prod/config/config.sh
+++ b/docker/prod/config/config.sh
@@ -51,9 +51,6 @@ cp -pr /wazuh-certificates/root-ca.pem ${TARGET_DIR}${CONFIG_DIR}/certs/root-ca.
 cp -pr /wazuh-certificates/admin.pem ${TARGET_DIR}${CONFIG_DIR}/certs/admin.pem
 cp -pr /wazuh-certificates/admin-key.pem ${TARGET_DIR}${CONFIG_DIR}/certs/admin-key.pem
 
-# Set path to indexer home directory
-sed -i 's/-Djava.security.policy=file:\/\/\/etc\/wazuh-indexer\/opensearch-performance-analyzer\/opensearch_security.policy/-Djava.security.policy=file:\/\/\/usr\/share\/wazuh-indexer\/opensearch-performance-analyzer\/opensearch_security.policy/g' ${TARGET_DIR}${CONFIG_DIR}/jvm.options
-
 chmod -R 500 ${TARGET_DIR}${CONFIG_DIR}/certs
 chmod -R 400 ${TARGET_DIR}${CONFIG_DIR}/certs/*
 

--- a/docker/prod/config/opensearch.yml
+++ b/docker/prod/config/opensearch.yml
@@ -23,4 +23,4 @@ plugins.security.restapi.roles_enabled:
 - "all_access"
 - "security_rest_api_access"
 plugins.security.system_indices.enabled: true
-plugins.security.system_indices.indices: [".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-reports-*", ".opendistro-notifications-*", ".opendistro-notebooks", ".replication-metadata-store", ".wazuh-internal-state"]
+plugins.security.system_indices.indices: [".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-reports-*", ".opendistro-notifications-*", ".replication-metadata-store", ".wazuh-internal-state"]

--- a/docker/prod/config/opensearch.yml
+++ b/docker/prod/config/opensearch.yml
@@ -23,4 +23,4 @@ plugins.security.restapi.roles_enabled:
 - "all_access"
 - "security_rest_api_access"
 plugins.security.system_indices.enabled: true
-plugins.security.system_indices.indices: [".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-anomaly-results*", ".opendistro-anomaly-detector*", ".opendistro-anomaly-checkpoints", ".opendistro-anomaly-detection-state", ".opendistro-reports-*", ".opendistro-notifications-*", ".opendistro-notebooks", ".opensearch-observability", ".opendistro-asynchronous-search-response*", ".replication-metadata-store", ".wazuh-internal-state"]
+plugins.security.system_indices.indices: [".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-reports-*", ".opendistro-notifications-*", ".opendistro-notebooks", ".replication-metadata-store", ".wazuh-internal-state"]


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This PR identifies and removes bundled OpenSearch plugins not required by Wazuh, freeing up RAM and disk space.

### Related Issues
Resolves https://github.com/wazuh/wazuh-indexer-plugins/issues/1272
