### PR TITLE
Bundle the `opensearch-custom-codecs` plugin to provide the zstd index codec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,13 +25,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add `--set-as-main` flag support to repository bumper [(#1396)](https://github.com/wazuh/wazuh-indexer/pull/1396)
 - Add Alerting fork to Wazuh Indexer packages [(#1402)](https://github.com/wazuh/wazuh-indexer/pull/1402)
 - Add nightly Docker image build workflow [(#1442)](https://github.com/wazuh/wazuh-indexer/pull/1442)
+- Bundle the `opensearch-custom-codecs` plugin to provide the zstd index codec [(#1636)](https://github.com/wazuh/wazuh-indexer/issues/1636)
 
 ### Fixed
 - Set secure permissions (750) for engine sockets directory [(#1330)](https://github.com/wazuh/wazuh-indexer/pull/1330)
 - Resolve dependency mismatch between Alerting and Notifications plugins [(#1379)](https://github.com/wazuh/wazuh-indexer/pull/1379)
 - Fix `/etc/default/wazuh-indexer` ownership and permissions in deb [(#1533)](https://github.com/wazuh/wazuh-indexer/pull/1533)
 - Fix Java warnings by updating JVM options for native access [(#1574)](https://github.com/wazuh/wazuh-indexer/pull/1574)
-- Fix SLF4J startup warning in reindex module by adding Log4j2 provider [(#1617)](https://github.com/wazuh/wazuh-indexer/pull/1617)
+- Fix SLF4J startup warning in reindex module by adding Log4j2 provider [(#1650)](https://github.com/wazuh/wazuh-indexer/pull/1650)
 
 ### Dependencies
 -

--- a/build-scripts/assemble.sh
+++ b/build-scripts/assemble.sh
@@ -23,7 +23,8 @@ else
         "opensearch-anomaly-detection" # Requires "opensearch-job-scheduler"
         "asynchronous-search"          # "opensearch-asynchronous-search"
         "opensearch-cross-cluster-replication"
-        "geospatial" # "opensearch-geospatial"
+        "opensearch-custom-codecs" # Provides the zstd/zstd_no_dict index codecs
+        "geospatial"               # "opensearch-geospatial"
         "opensearch-index-management"
         "opensearch-observability"
         "opensearch-security"


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

Bundles the `opensearch-custom-codecs` plugin into the Wazuh Indexer distribution by adding it to the plugin list in `build-scripts/assemble.sh`. This plugin registers the `zstd` / `zstd_no_dict` index codecs, which are not part of core OpenSearch.

Without it, the Wazuh plugins that set `index.codec: zstd` fail at index creation with `unknown value for [index.codec] must be one of [default, lz4, best_compression, zlib] but was: zstd`, causing the `.opendistro-ism-config` setup to fail and the node to shut down. This change is the distribution-side counterpart to the codec change in wazuh-indexer-plugins and must ship in the same release.

### Related Issues
Related: https://github.com/wazuh/wazuh-indexer-plugins/issues/1271
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
