### PR TITLE
Implemented upgrade block message

### DIFF
--- a/.github/workflows/5_builderpackage_indexer.yml
+++ b/.github/workflows/5_builderpackage_indexer.yml
@@ -585,7 +585,10 @@ jobs:
             if [ "$rc" -eq 0 ]; then
               echo "ERROR: upgrade unexpectedly succeeded"; exit 1
             fi
-            if ! echo "$out" | grep -qF "Direct upgrade from Wazuh Indexer 4.X to 5.X is not supported"; then
+            if ! echo "$out" | grep -qF "Upgrade from indexer versions prior to 5.x is not supported"; then
+              echo "ERROR: expected block banner not found in output"; exit 1
+            fi
+            if ! echo "$out" | grep -qF "Detected installed version:"; then
               echo "ERROR: expected block banner not found in output"; exit 1
             fi
 
@@ -646,7 +649,10 @@ jobs:
             if [ "$rc" -eq 0 ]; then
               echo "ERROR: upgrade unexpectedly succeeded"; exit 1
             fi
-            if ! echo "$out" | grep -qF "Direct upgrade from Wazuh Indexer 4.X to 5.X is not supported"; then
+            if ! echo "$out" | grep -qF "Upgrade from indexer versions prior to 5.x is not supported"; then
+              echo "ERROR: expected block banner not found in output"; exit 1
+            fi
+            if ! echo "$out" | grep -qF "Detected installed version:"; then
               echo "ERROR: expected block banner not found in output"; exit 1
             fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Update ruleset feed for 5.0.0 beta2 [(#1463)](https://github.com/wazuh/wazuh-indexer/pull/1463)
 - Block 5.x updates from 4.x [(#1545)](https://github.com/wazuh/wazuh-indexer/pull/1545)
 - Bundle missing workload-management dependency in the distribution package [(#1597)](https://github.com/wazuh/wazuh-indexer/pull/1597)
+- Unify indexer upgrade block message [(#1655)](https://github.com/wazuh/wazuh-indexer/pull/1655)
 
 ### Deprecated
 -

--- a/distribution/packages/src/deb/debian/postinst
+++ b/distribution/packages/src/deb/debian/postinst
@@ -11,12 +11,13 @@
 
 set -e
 
-# If a pre-5.x version is still installed on disk, the preinst blocked a 4.x -> 5.x
-# upgrade and the new package files were never unpacked. dpkg is not atomic and may still
-# invoke this postinst, so do nothing in that case (rpm aborts the transaction instead).
-if grep -Pq '4\.\d+\.\d+' /usr/share/wazuh-indexer/VERSION* 2>/dev/null; then
-    exit 0
-fi
+# dpkg is not atomic: when an earlier step (e.g. the preinst version block) aborts an
+# upgrade, dpkg still invokes this postinst with an abort-* action.
+case "$1" in
+    abort-upgrade|abort-remove|abort-deconfigure)
+        exit 0
+        ;;
+esac
 
 echo "Running Wazuh Indexer Post-Installation Script"
 

--- a/distribution/packages/src/deb/debian/postinst
+++ b/distribution/packages/src/deb/debian/postinst
@@ -11,6 +11,13 @@
 
 set -e
 
+# If a pre-5.x version is still installed on disk, the preinst blocked a 4.x -> 5.x
+# upgrade and the new package files were never unpacked. dpkg is not atomic and may still
+# invoke this postinst, so do nothing in that case (rpm aborts the transaction instead).
+if grep -Pq '4\.\d+\.\d+' /usr/share/wazuh-indexer/VERSION* 2>/dev/null; then
+    exit 0
+fi
+
 echo "Running Wazuh Indexer Post-Installation Script"
 
 name="wazuh-indexer"

--- a/distribution/packages/src/deb/debian/preinst
+++ b/distribution/packages/src/deb/debian/preinst
@@ -20,12 +20,16 @@ echo "Running Wazuh Indexer Pre-Installation Script"
 case "$1" in
     upgrade)
         # Hard block: refuse 4.X -> 5.X upgrades
-        if grep -Pq '4\.\d+\.\d+' /usr/share/wazuh-indexer/VERSION*; then
-            cat >&2 <<'EOF'
+        detected_version=$(grep -Pho '4\.\d+\.\d+' /usr/share/wazuh-indexer/VERSION* 2>/dev/null | head -n1)
+        if [ -n "${detected_version}" ]; then
+            cat >&2 <<EOF
 ==============================================================
-ERROR: Direct upgrade from Wazuh Indexer 4.X to 5.X is not supported.
+ERROR: Upgrade from indexer versions prior to 5.x is not supported.
 
-A clean installation of Wazuh Indexer 5.x is required.
+Detected installed version: ${detected_version}
+
+A clean installation of indexer 5.x is required.
+Refer to the 5.x migration guide for more information.
 ==============================================================
 EOF
             exit 1

--- a/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
+++ b/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
@@ -158,12 +158,16 @@ if [ $1 = 2 ]; then
     echo "Running upgrade pre-script"
 
     # Hard block: refuse 4.X -> 5.X upgrades
-    if grep -Pq '4\.\d+\.\d+' /usr/share/wazuh-indexer/VERSION*; then
-        cat >&2 <<'EOF'
+    detected_version=$(grep -Pho '4\.\d+\.\d+' /usr/share/wazuh-indexer/VERSION* 2>/dev/null | head -n1)
+    if [ -n "${detected_version}" ]; then
+        cat >&2 <<EOF
 ==============================================================
-ERROR: Direct upgrade from Wazuh Indexer 4.X to 5.X is not supported.
+ERROR: Upgrade from indexer versions prior to 5.x is not supported.
 
-A clean installation of Wazuh Indexer 5.x is required.
+Detected installed version: ${detected_version}
+
+A clean installation of indexer 5.x is required.
+Refer to the 5.x migration guide for more information.
 ==============================================================
 EOF
         exit 1


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This PR implements a consistent and clear error message across all components when upgrading from Wazuh Indexer versions prior to 5.x. The message now explicitly shows the detected installed version and provides clear guidance on the required clean installation.

It also fixes the unexpected execution of the _post-inst_ steps on the `DEB` package after the _pre-inst_ failure


### Related Issues
Resolves #1653 


