### PR TITLE
Fix full component name on upgrade error

### DIFF
--- a/.github/workflows/5_builderpackage_indexer.yml
+++ b/.github/workflows/5_builderpackage_indexer.yml
@@ -585,7 +585,7 @@ jobs:
             if [ "$rc" -eq 0 ]; then
               echo "ERROR: upgrade unexpectedly succeeded"; exit 1
             fi
-            if ! echo "$out" | grep -qF "Upgrade from indexer versions prior to 5.x is not supported"; then
+            if ! echo "$out" | grep -qF "Upgrade from Wazuh indexer versions prior to 5.x is not supported"; then
               echo "ERROR: expected block banner not found in output"; exit 1
             fi
             if ! echo "$out" | grep -qF "Detected installed version:"; then
@@ -649,7 +649,7 @@ jobs:
             if [ "$rc" -eq 0 ]; then
               echo "ERROR: upgrade unexpectedly succeeded"; exit 1
             fi
-            if ! echo "$out" | grep -qF "Upgrade from indexer versions prior to 5.x is not supported"; then
+            if ! echo "$out" | grep -qF "Upgrade from Wazuh indexer versions prior to 5.x is not supported"; then
               echo "ERROR: expected block banner not found in output"; exit 1
             fi
             if ! echo "$out" | grep -qF "Detected installed version:"; then

--- a/distribution/packages/src/deb/debian/preinst
+++ b/distribution/packages/src/deb/debian/preinst
@@ -24,7 +24,7 @@ case "$1" in
         if [ -n "${detected_version}" ]; then
             cat >&2 <<EOF
 ==============================================================
-ERROR: Upgrade from indexer versions prior to 5.x is not supported.
+ERROR: Upgrade from Wazuh indexer versions prior to 5.x is not supported.
 
 Detected installed version: ${detected_version}
 

--- a/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
+++ b/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
@@ -155,7 +155,7 @@ if [ $1 = 2 ]; then
     if [ -n "${detected_version}" ]; then
         cat >&2 <<EOF
 ==============================================================
-ERROR: Upgrade from indexer versions prior to 5.x is not supported.
+ERROR: Upgrade from Wazuh indexer versions prior to 5.x is not supported.
 
 Detected installed version: ${detected_version}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This PR fixes the component name detailed on the upgrade error to be consistent with the rest of the Wazuh components

### Related Issues
Closes #1661
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
