### PR TITLE
Add bootstrap.memory_lock to default opensearch.yml configuration

### DIFF
--- a/distribution/packages/src/common/init.d/wazuh-indexer
+++ b/distribution/packages/src/common/init.d/wazuh-indexer
@@ -48,6 +48,7 @@ fi
 # Sets the default values for wazuh-indexer variables used in this script
 OPENSEARCH_HOME="/usr/share/$NAME"
 MAX_OPEN_FILES=65535
+MAX_LOCKED_MEMORY=unlimited
 MAX_MAP_COUNT=262144
 OPENSEARCH_PATH_CONF="/etc/$NAME"
 

--- a/distribution/packages/src/common/systemd/wazuh-indexer.service
+++ b/distribution/packages/src/common/systemd/wazuh-indexer.service
@@ -53,6 +53,9 @@ LimitAS=infinity
 # Specifies the maximum file size
 LimitFSIZE=infinity
 
+# Specifies the maximum locked-in-memory address space
+LimitMEMLOCK=infinity
+
 # Disable timeout logic and wait until process is stopped
 TimeoutStopSec=0
 

--- a/distribution/src/config/opensearch.prod.yml
+++ b/distribution/src/config/opensearch.prod.yml
@@ -38,3 +38,4 @@ plugins.security.restapi.roles_enabled:
 plugins.security.system_indices.enabled: true
 plugins.security.system_indices.indices: [".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-reports-*", ".opensearch-notifications-*", ".replication-metadata-store", ".wazuh-internal-state"]
 cluster.default_number_of_replicas: 0
+bootstrap.memory_lock: true

--- a/distribution/src/config/opensearch.yml
+++ b/distribution/src/config/opensearch.yml
@@ -40,7 +40,7 @@ ${path.logs}
 #
 # Lock the memory on startup:
 #
-#bootstrap.memory_lock: true
+bootstrap.memory_lock: true
 #
 # Make sure that the heap size is set to about half the memory available
 # on the system and that the owner of the process is allowed to use this

--- a/distribution/src/config/opensearch.yml
+++ b/distribution/src/config/opensearch.yml
@@ -40,7 +40,7 @@ ${path.logs}
 #
 # Lock the memory on startup:
 #
-bootstrap.memory_lock: true
+#bootstrap.memory_lock: true
 #
 # Make sure that the heap size is set to about half the memory available
 # on the system and that the owner of the process is allowed to use this


### PR DESCRIPTION
### Description
Enable memory locking by default in the Wazuh Indexer configuration.

### Issues Resolved
Resolves https://github.com/wazuh/wazuh-indexer/issues/1670