### PR TITLE
GitHub artifacts migration s3 4.14.7

### DIFF
--- a/.github/workflows/4_builderpackage_indexer.yml
+++ b/.github/workflows/4_builderpackage_indexer.yml
@@ -1,6 +1,11 @@
 run-name: Build ${{ inputs.distribution }} Wazuh Indexer on ${{ inputs.architecture }} | ${{ inputs.id }}
 name: (4.x) Build packages
 
+env:
+  CI_DEV_INTERNAL_BUCKET: s3://xdrsiem-ci-dev-internal
+  CI_ARTIFACTS_REPO: wazuh-indexer
+  CI_ARTIFACTS_WORKFLOW: 4_builderpackage_indexer
+
 # This workflow runs when any of the following occur:
 # - Run manually
 # - Invoked from another workflow
@@ -65,15 +70,9 @@ on:
         type: string
         required: false
     secrets:
-      CI_INTERNAL_DEVELOPMENT_BUCKET_USER_ACCESS_KEY:
+      AWS_INDEXER_ACTIONS_ROLE:
         required: true
-        description: "AWS user access key"
-      CI_INTERNAL_DEVELOPMENT_BUCKET_USER_SECRET_KEY:
-        required: true
-        description: "AWS user secret key"
-      AWS_IAM_OVA_ROLE:
-        required: true
-        description: "AWS IAM role"
+        description: "AWS IAM OIDC role for S3 and infrastructure access"
 
 permissions:
   id-token: write
@@ -210,7 +209,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v5
         with:
           aws-region: "us-east-1"
-          role-to-assume: ${{ secrets.AWS_IAM_OVA_ROLE }}
+          role-to-assume: ${{ secrets.AWS_INDEXER_ACTIONS_ROLE }}
           role-session-name: "4_package_builder_indexer"
 
       - name: Setup RPM environment
@@ -329,20 +328,11 @@ jobs:
           sudo bash packaging_scripts/indexer_node_install.sh ${{ needs.setup.outputs.previous_version }}
           sudo dpkg -i "artifacts/dist/${{ steps.package.outputs.name }}"
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ steps.package.outputs.name }}
-          path: artifacts/dist/${{ steps.package.outputs.name }}
-          if-no-files-found: error
-
       - name: Set up AWS CLI
-        if: ${{ inputs.upload }}
         uses: aws-actions/configure-aws-credentials@v5
         with:
-          aws-access-key-id: ${{ secrets.CI_INTERNAL_DEVELOPMENT_BUCKET_USER_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.CI_INTERNAL_DEVELOPMENT_BUCKET_USER_SECRET_KEY }}
-          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-to-assume: ${{ secrets.AWS_INDEXER_ACTIONS_ROLE }}
+          aws-region: "us-east-1"
 
       - name: Upload package to S3
         if: ${{ inputs.upload }}
@@ -362,8 +352,53 @@ jobs:
           s3uri="${dest}${{ steps.package.outputs.name }}.sha512"
           echo "::notice::S3 sha512 URI: ${s3uri}"
 
+      - name: Upload package artifact to S3
+        run: |
+          pkg_name="${{ steps.package.outputs.name }}"
+          pkg_path="artifacts/dist/${pkg_name}"
+          s3_stage_base="${{ env.CI_DEV_INTERNAL_BUCKET }}/${{ env.CI_ARTIFACTS_REPO }}/${{ env.CI_ARTIFACTS_WORKFLOW }}/staging_${{ github.run_id }}/${{ matrix.distribution }}_${{ matrix.architecture }}"
+
+          if [ ! -f "$pkg_path" ]; then
+            echo "::error::Package not found at ${pkg_path}"
+            exit 1
+          fi
+
+          aws s3 cp "$pkg_path" "${s3_stage_base}/${pkg_name}"
+          echo "::notice::Staged artifact in S3: ${s3_stage_base}/${pkg_name}"
+
       - name: On failure delete Allocator Machine
         if: ${{ matrix.distribution == 'rpm' && (failure() || cancelled()) }}
         run: |
           cd wazuh-automation/deployability
           python3 modules/allocation/main.py --action delete --track-output /tmp/track.yaml
+
+  bundle-artifacts:
+    name: Bundle workflow artifacts
+    needs: [build]
+    runs-on:
+      - codebuild-github-actions-codebuild-runner-indexer-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    steps:
+      - name: Set up AWS CLI
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          role-to-assume: ${{ secrets.AWS_INDEXER_ACTIONS_ROLE }}
+          aws-region: "us-east-1"
+
+      - name: Create and upload consolidated artifact ZIP
+        run: |
+          s3_base="${{ env.CI_DEV_INTERNAL_BUCKET }}/${{ env.CI_ARTIFACTS_REPO }}/${{ env.CI_ARTIFACTS_WORKFLOW }}"
+          s3_stage_base="${s3_base}/staging_${{ github.run_id }}"
+          zip_name="artifacts_${{ github.run_id }}.zip"
+
+          rm -rf artifacts_staging
+          mkdir -p artifacts_staging
+          aws s3 cp "${s3_stage_base}/" artifacts_staging/ --recursive
+
+          if [ -z "$(find artifacts_staging -type f -print -quit)" ]; then
+            echo "::error::No staged artifacts found at ${s3_stage_base}"
+            exit 1
+          fi
+
+          (cd artifacts_staging && zip -r "../${zip_name}" .)
+          aws s3 cp "${zip_name}" "${s3_base}/${zip_name}"
+          echo "::notice::Artifact uploaded to S3: ${s3_base}/${zip_name}"

--- a/.github/workflows/4_builderpackage_indexer.yml
+++ b/.github/workflows/4_builderpackage_indexer.yml
@@ -1,11 +1,6 @@
 run-name: Build ${{ inputs.distribution }} Wazuh Indexer on ${{ inputs.architecture }} | ${{ inputs.id }}
 name: (4.x) Build packages
 
-env:
-  CI_DEV_INTERNAL_BUCKET: s3://xdrsiem-ci-dev-internal
-  CI_ARTIFACTS_REPO: wazuh-indexer
-  CI_ARTIFACTS_WORKFLOW: 4_builderpackage_indexer
-
 # This workflow runs when any of the following occur:
 # - Run manually
 # - Invoked from another workflow
@@ -73,6 +68,15 @@ on:
       AWS_INDEXER_ACTIONS_ROLE:
         required: true
         description: "AWS IAM OIDC role for S3 and infrastructure access"
+      CI_AWS_REGION:
+        required: true
+        description: "AWS region for the internal S3 bucket and final package upload"
+      CI_INTERNAL_DEVELOPMENT_BUCKET_USER_ACCESS_KEY:
+        required: true
+        description: "AWS user access key for the final package upload"
+      CI_INTERNAL_DEVELOPMENT_BUCKET_USER_SECRET_KEY:
+        required: true
+        description: "AWS user secret key for the final package upload"
 
 permissions:
   id-token: write
@@ -208,7 +212,7 @@ jobs:
         if: ${{ matrix.distribution == 'rpm' }}
         uses: aws-actions/configure-aws-credentials@v5
         with:
-          aws-region: "us-east-1"
+          aws-region: ${{ secrets.CI_AWS_REGION }}
           role-to-assume: ${{ secrets.AWS_INDEXER_ACTIONS_ROLE }}
           role-session-name: "4_package_builder_indexer"
 
@@ -328,11 +332,13 @@ jobs:
           sudo bash packaging_scripts/indexer_node_install.sh ${{ needs.setup.outputs.previous_version }}
           sudo dpkg -i "artifacts/dist/${{ steps.package.outputs.name }}"
 
-      - name: Set up AWS CLI
+      - name: Set up AWS CLI for final package upload
+        if: ${{ inputs.upload }}
         uses: aws-actions/configure-aws-credentials@v5
         with:
-          role-to-assume: ${{ secrets.AWS_INDEXER_ACTIONS_ROLE }}
-          aws-region: "us-east-1"
+          aws-access-key-id: ${{ secrets.CI_INTERNAL_DEVELOPMENT_BUCKET_USER_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.CI_INTERNAL_DEVELOPMENT_BUCKET_USER_SECRET_KEY }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
 
       - name: Upload package to S3
         if: ${{ inputs.upload }}
@@ -352,53 +358,8 @@ jobs:
           s3uri="${dest}${{ steps.package.outputs.name }}.sha512"
           echo "::notice::S3 sha512 URI: ${s3uri}"
 
-      - name: Upload package artifact to S3
-        run: |
-          pkg_name="${{ steps.package.outputs.name }}"
-          pkg_path="artifacts/dist/${pkg_name}"
-          s3_stage_base="${{ env.CI_DEV_INTERNAL_BUCKET }}/${{ env.CI_ARTIFACTS_REPO }}/${{ env.CI_ARTIFACTS_WORKFLOW }}/staging_${{ github.run_id }}/${{ matrix.distribution }}_${{ matrix.architecture }}"
-
-          if [ ! -f "$pkg_path" ]; then
-            echo "::error::Package not found at ${pkg_path}"
-            exit 1
-          fi
-
-          aws s3 cp "$pkg_path" "${s3_stage_base}/${pkg_name}"
-          echo "::notice::Staged artifact in S3: ${s3_stage_base}/${pkg_name}"
-
       - name: On failure delete Allocator Machine
         if: ${{ matrix.distribution == 'rpm' && (failure() || cancelled()) }}
         run: |
           cd wazuh-automation/deployability
           python3 modules/allocation/main.py --action delete --track-output /tmp/track.yaml
-
-  bundle-artifacts:
-    name: Bundle workflow artifacts
-    needs: [build]
-    runs-on:
-      - codebuild-github-actions-codebuild-runner-indexer-amd-${{ github.run_id }}-${{ github.run_attempt }}
-    steps:
-      - name: Set up AWS CLI
-        uses: aws-actions/configure-aws-credentials@v5
-        with:
-          role-to-assume: ${{ secrets.AWS_INDEXER_ACTIONS_ROLE }}
-          aws-region: "us-east-1"
-
-      - name: Create and upload consolidated artifact ZIP
-        run: |
-          s3_base="${{ env.CI_DEV_INTERNAL_BUCKET }}/${{ env.CI_ARTIFACTS_REPO }}/${{ env.CI_ARTIFACTS_WORKFLOW }}"
-          s3_stage_base="${s3_base}/staging_${{ github.run_id }}"
-          zip_name="artifacts_${{ github.run_id }}.zip"
-
-          rm -rf artifacts_staging
-          mkdir -p artifacts_staging
-          aws s3 cp "${s3_stage_base}/" artifacts_staging/ --recursive
-
-          if [ -z "$(find artifacts_staging -type f -print -quit)" ]; then
-            echo "::error::No staged artifacts found at ${s3_stage_base}"
-            exit 1
-          fi
-
-          (cd artifacts_staging && zip -r "../${zip_name}" .)
-          aws s3 cp "${zip_name}" "${s3_base}/${zip_name}"
-          echo "::notice::Artifact uploaded to S3: ${s3_base}/${zip_name}"


### PR DESCRIPTION
### Description
Migrates all GitHub Actions artifacts in the wazuh-indexer repository to the `xdrsiem-ci-dev-internal S3 bucket`, as part of the [GitHub artifacts migration to S3](vscode-file://vscode-app/snap/code/247/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).

All actions/upload-artifact and actions/download-artifact usages have been replaced with aws s3 cp operations targeting the following path convention:
https://github.com/wazuh/internal-devel-requests/issues/5304#:~:text=The%20path%20of%20the%20artifacts%20will%20be%3A
### Related Issues
Resolves https://github.com/wazuh/internal-devel-requests/issues/5304



