### PR TITLE
Github artifacts migration s3 5.0.0

### DIFF
--- a/.github/workflows/5_builderpackage_docker.yml
+++ b/.github/workflows/5_builderpackage_docker.yml
@@ -1,6 +1,11 @@
 run-name: Build Wazuh Indexer Docker image | ${{ inputs.id }}
 name: (5.x) Build Docker image
 
+env:
+  CI_DEV_INTERNAL_BUCKET: s3://xdrsiem-ci-dev-internal
+  CI_ARTIFACTS_REPO: wazuh-indexer
+  CI_ARTIFACTS_WORKFLOW: 5_builderpackage_indexer
+
 # This workflow runs when any of the following occur:
 # - Run manually
 # - Invoked from another workflow
@@ -61,6 +66,9 @@ on:
       QUAY_TOKEN:
         required: true
         description: "Quay.io token"
+      AWS_INDEXER_ACTIONS_ROLE:
+        required: true
+        description: "AWS IAM OIDC role for S3 access"
 
 # ==========================
 # Bibliography
@@ -95,6 +103,7 @@ jobs:
   build-and-push-docker-image:
     permissions:
       contents: read
+      id-token: write
     needs: [call-build-workflow]
     runs-on:
       - codebuild-github-actions-codebuild-runner-indexer-amd-${{ github.run_id }}-${{ github.run_attempt }}
@@ -114,12 +123,25 @@ jobs:
           platforms=$(echo '${{ inputs.architecture }}' | jq -r '[.[] | if . == "x64" then "linux/amd64" elif . == "arm64" then "linux/arm64" else empty end] | join(",")')
           echo "platforms=${platforms}" >> "$GITHUB_OUTPUT"
 
-      - name: Download tarballs
-        uses: actions/download-artifact@v8
+      - name: Set up AWS CLI
+        uses: aws-actions/configure-aws-credentials@v6
         with:
-          path: ${{ env.docker_path }}
-          pattern: "wazuh-indexer_*linux*"
-          merge-multiple: true
+          role-to-assume: ${{ secrets.AWS_INDEXER_ACTIONS_ROLE }}
+          aws-region: "us-east-1"
+
+      - name: Download tarballs
+        run: |
+          mkdir -p "${{ env.docker_path }}"
+          s3_base="${{ env.CI_DEV_INTERNAL_BUCKET }}/${{ env.CI_ARTIFACTS_REPO }}/${{ env.CI_ARTIFACTS_WORKFLOW }}"
+          zip_name="artifacts_${{ github.run_id }}.zip"
+          aws s3 cp "${s3_base}/${zip_name}" "${{ env.docker_path }}/${zip_name}"
+
+          if [ ! -f "${{ env.docker_path }}/${zip_name}" ]; then
+            echo "::error::No indexer artifact ZIP found in S3 at ${s3_base}/${zip_name}"
+            exit 1
+          fi
+
+          unzip -j -o "${{ env.docker_path }}/${zip_name}" '*/wazuh-indexer_*linux*.tar.gz' -d "${{ env.docker_path }}"
 
       - name: Display structure of downloaded files
         run: ls -lR ${{ env.docker_path }}

--- a/.github/workflows/5_builderpackage_indexer.yml
+++ b/.github/workflows/5_builderpackage_indexer.yml
@@ -1,9 +1,17 @@
 run-name: Build ${{ inputs.distribution }} Wazuh Indexer on ${{ inputs.architecture }} | ${{ inputs.id }}
 name: (5.x) Build packages
 
+env:
+  CI_DEV_INTERNAL_BUCKET: s3://xdrsiem-ci-dev-internal
+  CI_ARTIFACTS_REPO: wazuh-indexer
+  CI_ARTIFACTS_WORKFLOW: 5_builderpackage_indexer
+  CI_ENGINE_ARTIFACTS_REPO: wazuh
+  CI_ENGINE_ARTIFACTS_WORKFLOW: 5_builderpackage_engine-standalone
+
 permissions:
   contents: read
   packages: read
+  id-token: write
 
 # This workflow runs when any of the following occur:
 # - Run manually
@@ -91,12 +99,9 @@ on:
         default: "main"
         required: false
     secrets:
-      CI_INTERNAL_DEVELOPMENT_BUCKET_USER_ACCESS_KEY:
+      AWS_INDEXER_ACTIONS_ROLE:
         required: true
-        description: "AWS user access key"
-      CI_INTERNAL_DEVELOPMENT_BUCKET_USER_SECRET_KEY:
-        required: true
-        description: "AWS user secret key"
+        description: "AWS IAM OIDC role for S3 and infrastructure access"
 
     outputs:
       name:
@@ -671,12 +676,10 @@ jobs:
           if-no-files-found: error
 
       - name: Set up AWS CLI
-        if: ${{ inputs.upload }}
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          aws-access-key-id: ${{ secrets.CI_INTERNAL_DEVELOPMENT_BUCKET_USER_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.CI_INTERNAL_DEVELOPMENT_BUCKET_USER_SECRET_KEY }}
-          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-to-assume: ${{ secrets.AWS_INDEXER_ACTIONS_ROLE }}
+          aws-region: "us-east-1"
 
       - name: Upload package to S3
         if: ${{ inputs.upload }}
@@ -695,3 +698,47 @@ jobs:
           aws s3 cp "$src" "$dest"
           s3uri="${dest}${{ steps.package.outputs.name }}.sha512"
           echo "::notice::S3 sha512 URI: ${s3uri}"
+
+      - name: Upload package artifact to S3
+        run: |
+          pkg_name="${{ steps.package.outputs.name }}"
+          pkg_path="artifacts/dist/${pkg_name}"
+          s3_stage_base="${{ env.CI_DEV_INTERNAL_BUCKET }}/${{ env.CI_ARTIFACTS_REPO }}/${{ env.CI_ARTIFACTS_WORKFLOW }}/staging_${{ github.run_id }}/${{ matrix.distribution }}_${{ matrix.architecture }}"
+
+          if [ ! -f "$pkg_path" ]; then
+            echo "::error::Package not found at ${pkg_path}"
+            exit 1
+          fi
+
+          aws s3 cp "$pkg_path" "${s3_stage_base}/${pkg_name}"
+          echo "::notice::Staged artifact in S3: ${s3_stage_base}/${pkg_name}"
+
+  bundle-artifacts:
+    name: Bundle workflow artifacts
+    needs: [build]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Set up AWS CLI
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_INDEXER_ACTIONS_ROLE }}
+          aws-region: "us-east-1"
+
+      - name: Create and upload consolidated artifact ZIP
+        run: |
+          s3_base="${{ env.CI_DEV_INTERNAL_BUCKET }}/${{ env.CI_ARTIFACTS_REPO }}/${{ env.CI_ARTIFACTS_WORKFLOW }}"
+          s3_stage_base="${s3_base}/staging_${{ github.run_id }}"
+          zip_name="artifacts_${{ github.run_id }}.zip"
+
+          rm -rf artifacts_staging
+          mkdir -p artifacts_staging
+          aws s3 cp "${s3_stage_base}/" artifacts_staging/ --recursive
+
+          if [ -z "$(find artifacts_staging -type f -print -quit)" ]; then
+            echo "::error::No staged artifacts found at ${s3_stage_base}"
+            exit 1
+          fi
+
+          (cd artifacts_staging && zip -r "../${zip_name}" .)
+          aws s3 cp "${zip_name}" "${s3_base}/${zip_name}"
+          echo "::notice::Artifact uploaded to S3: ${s3_base}/${zip_name}"

--- a/.github/workflows/5_builderpackage_indexer.yml
+++ b/.github/workflows/5_builderpackage_indexer.yml
@@ -593,12 +593,6 @@ jobs:
             bash /build-scripts/ci/test_upgrade_block.sh
           "
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: ${{ steps.package.outputs.name }}
-          path: artifacts/dist/${{ steps.package.outputs.name }}
-          if-no-files-found: error
 
       - name: Set up AWS CLI
         uses: aws-actions/configure-aws-credentials@v6

--- a/.github/workflows/5_builderpackage_indexer.yml
+++ b/.github/workflows/5_builderpackage_indexer.yml
@@ -622,7 +622,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.CI_INTERNAL_DEVELOPMENT_BUCKET_USER_SECRET_KEY }}
           aws-region: ${{ secrets.CI_AWS_REGION }}
 
-      - name: Upload package to S3
+      - name: Upload final package to S3
         if: ${{ inputs.upload }}
         run: |
           src="artifacts/dist/${{ steps.package.outputs.name }}"

--- a/.github/workflows/5_builderpackage_indexer.yml
+++ b/.github/workflows/5_builderpackage_indexer.yml
@@ -431,7 +431,7 @@ jobs:
           bucket="${{ secrets.CI_INTERNAL_S3_BUCKET }}"
           s3_base="s3://${bucket#s3://}/${{ env.CI_ENGINE_ARTIFACTS_REPO }}/${{ env.CI_ENGINE_ARTIFACTS_WORKFLOW }}"
           aws s3 cp "$s3_base/" "${{ github.workspace }}/artifacts/engine/" --recursive \
-            --exclude "*" --include "*/wazuh-engine-*-linux-${arch_suffix}.zip"
+            --exclude "*" --include "${{ github.run_id }}/wazuh-engine-*-linux-${arch_suffix}.zip"
 
           shopt -s nullglob
           archives=("${{ github.workspace }}/artifacts/engine"/${{ github.run_id }}/wazuh-engine-*-linux-${arch_suffix}.zip)

--- a/.github/workflows/5_builderpackage_indexer.yml
+++ b/.github/workflows/5_builderpackage_indexer.yml
@@ -390,6 +390,7 @@ jobs:
       wazuh-branch: ${{ needs.branches.outputs.wazuh_ref }}
       build-type: "release"
       arch: ${{ inputs.architecture }}
+    secrets: inherit
 
   build:
     needs: [setup, branches, build-wazuh-engine]

--- a/.github/workflows/5_builderpackage_indexer.yml
+++ b/.github/workflows/5_builderpackage_indexer.yml
@@ -425,12 +425,39 @@ jobs:
       - uses: actions/checkout@v7
 
       # Built by the build-wazuh-engine job
-      - name: Download Wazuh Engine
-        uses: actions/download-artifact@v8
+      - name: Set up AWS CLI
+        uses: aws-actions/configure-aws-credentials@v6
         with:
-          pattern: wazuh-engine-*-linux-${{ matrix.architecture == 'x64' && 'amd64' || 'arm64' }}
-          merge-multiple: true
-          path: ${{ github.workspace }}/artifacts/engine
+          role-to-assume: ${{ secrets.AWS_INDEXER_ACTIONS_ROLE }}
+          aws-region: "us-east-1"
+
+      # Built by the build-wazuh-engine job
+      - name: Download Wazuh Engine
+        run: |
+          mkdir -p "${{ github.workspace }}/artifacts/engine"
+          arch_suffix="${{ matrix.architecture == 'x64' && 'amd64' || 'arm64' }}"
+          s3_base="${{ env.CI_DEV_INTERNAL_BUCKET }}/${{ env.CI_ENGINE_ARTIFACTS_REPO }}/${{ env.CI_ENGINE_ARTIFACTS_WORKFLOW }}"
+          aws s3 cp "$s3_base/" "${{ github.workspace }}/artifacts/engine/" --recursive \
+            --exclude "*" --include "*linux-${arch_suffix}*/artifacts_${{ github.run_id }}.zip"
+
+          shopt -s nullglob
+          archives=("${{ github.workspace }}/artifacts/engine"/*/artifacts_${{ github.run_id }}.zip)
+          if [ ${#archives[@]} -eq 0 ]; then
+            echo "::error::No Wazuh Engine artifacts found in S3 for run ${{ github.run_id }} (arch ${arch_suffix})"
+            aws s3 ls "$s3_base/" || true
+            exit 1
+          fi
+
+          for z in "${archives[@]}"; do
+            unzip -j -o "$z" -d "${{ github.workspace }}/artifacts/engine"
+          done
+
+          engine_pattern="wazuh-engine-*-linux-${arch_suffix}.tar.gz"
+          if ! find "${{ github.workspace }}/artifacts/engine" -maxdepth 1 -type f -name "$engine_pattern" | grep -q .; then
+            echo "::error::No Wazuh Engine tarball found for pattern $engine_pattern"
+            ls -l "${{ github.workspace }}/artifacts/engine" || true
+            exit 1
+          fi
 
       - name: Prepare workspace for container user
         run: |

--- a/.github/workflows/5_builderpackage_indexer.yml
+++ b/.github/workflows/5_builderpackage_indexer.yml
@@ -429,7 +429,7 @@ jobs:
           mkdir -p "${{ github.workspace }}/artifacts/engine"
           arch_suffix="${{ matrix.architecture == 'x64' && 'amd64' || 'arm64' }}"
           bucket="${{ secrets.CI_INTERNAL_S3_BUCKET }}"
-          s3_base="s3://${bucket#s3://}/${{ env.CI_ENGINE_ARTIFACTS_REPO }}/${{ env.CI_ENGINE_ARTIFACTS_WORKFLOW }}"
+          s3_base="s3://${bucket#s3://}/${{ env.CI_ARTIFACTS_REPO }}/${{ env.CI_ARTIFACTS_WORKFLOW }}"
           aws s3 cp "$s3_base/" "${{ github.workspace }}/artifacts/engine/" --recursive \
             --exclude "*" --include "${{ github.run_id }}/wazuh-engine-*-linux-${arch_suffix}.zip"
 

--- a/.github/workflows/5_builderpackage_indexer.yml
+++ b/.github/workflows/5_builderpackage_indexer.yml
@@ -2,7 +2,6 @@ run-name: Build ${{ inputs.distribution }} Wazuh Indexer on ${{ inputs.architect
 name: (5.x) Build packages
 
 env:
-  CI_DEV_INTERNAL_BUCKET: s3://xdrsiem-ci-dev-internal
   CI_ARTIFACTS_REPO: wazuh-indexer
   CI_ARTIFACTS_WORKFLOW: 5_builderpackage_indexer
   CI_ENGINE_ARTIFACTS_REPO: wazuh
@@ -102,6 +101,18 @@ on:
       AWS_INDEXER_ACTIONS_ROLE:
         required: true
         description: "AWS IAM OIDC role for S3 and infrastructure access"
+      CI_INTERNAL_S3_BUCKET:
+        required: true
+        description: "Internal S3 bucket URI used to stage build artifacts"
+      CI_AWS_REGION:
+        required: true
+        description: "AWS region for the internal S3 bucket and final package upload"
+      CI_INTERNAL_DEVELOPMENT_BUCKET_USER_ACCESS_KEY:
+        required: true
+        description: "AWS user access key for the final package upload"
+      CI_INTERNAL_DEVELOPMENT_BUCKET_USER_SECRET_KEY:
+        required: true
+        description: "AWS user secret key for the final package upload"
 
     outputs:
       name:
@@ -410,14 +421,14 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_INDEXER_ACTIONS_ROLE }}
-          aws-region: "us-east-1"
+          aws-region: ${{ secrets.CI_AWS_REGION }}
 
       # Built by the build-wazuh-engine job
       - name: Download Wazuh Engine
         run: |
           mkdir -p "${{ github.workspace }}/artifacts/engine"
           arch_suffix="${{ matrix.architecture == 'x64' && 'amd64' || 'arm64' }}"
-          s3_base="${{ env.CI_DEV_INTERNAL_BUCKET }}/${{ env.CI_ENGINE_ARTIFACTS_REPO }}/${{ env.CI_ENGINE_ARTIFACTS_WORKFLOW }}"
+          s3_base="${{ secrets.CI_INTERNAL_S3_BUCKET }}/${{ env.CI_ENGINE_ARTIFACTS_REPO }}/${{ env.CI_ENGINE_ARTIFACTS_WORKFLOW }}"
           aws s3 cp "$s3_base/" "${{ github.workspace }}/artifacts/engine/" --recursive \
             --exclude "*" --include "*linux-${arch_suffix}*/artifacts_${{ github.run_id }}.zip"
 
@@ -588,7 +599,29 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_INDEXER_ACTIONS_ROLE }}
-          aws-region: "us-east-1"
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+
+      - name: Upload package artifact to S3
+        run: |
+          pkg_name="${{ steps.package.outputs.name }}"
+          pkg_path="artifacts/dist/${pkg_name}"
+          s3_stage_base="${{ secrets.CI_INTERNAL_S3_BUCKET }}/${{ env.CI_ARTIFACTS_REPO }}/${{ env.CI_ARTIFACTS_WORKFLOW }}/staging_${{ github.run_id }}/${{ matrix.distribution }}_${{ matrix.architecture }}"
+
+          if [ ! -f "$pkg_path" ]; then
+            echo "::error::Package not found at ${pkg_path}"
+            exit 1
+          fi
+
+          aws s3 cp "$pkg_path" "${s3_stage_base}/${pkg_name}"
+          echo "::notice::Staged artifact in S3: ${s3_stage_base}/${pkg_name}"
+
+      - name: Set up AWS CLI for final package upload
+        if: ${{ inputs.upload }}
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-access-key-id: ${{ secrets.CI_INTERNAL_DEVELOPMENT_BUCKET_USER_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.CI_INTERNAL_DEVELOPMENT_BUCKET_USER_SECRET_KEY }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
 
       - name: Upload package to S3
         if: ${{ inputs.upload }}
@@ -608,20 +641,6 @@ jobs:
           s3uri="${dest}${{ steps.package.outputs.name }}.sha512"
           echo "::notice::S3 sha512 URI: ${s3uri}"
 
-      - name: Upload package artifact to S3
-        run: |
-          pkg_name="${{ steps.package.outputs.name }}"
-          pkg_path="artifacts/dist/${pkg_name}"
-          s3_stage_base="${{ env.CI_DEV_INTERNAL_BUCKET }}/${{ env.CI_ARTIFACTS_REPO }}/${{ env.CI_ARTIFACTS_WORKFLOW }}/staging_${{ github.run_id }}/${{ matrix.distribution }}_${{ matrix.architecture }}"
-
-          if [ ! -f "$pkg_path" ]; then
-            echo "::error::Package not found at ${pkg_path}"
-            exit 1
-          fi
-
-          aws s3 cp "$pkg_path" "${s3_stage_base}/${pkg_name}"
-          echo "::notice::Staged artifact in S3: ${s3_stage_base}/${pkg_name}"
-
   bundle-artifacts:
     name: Bundle workflow artifacts
     needs: [build]
@@ -631,11 +650,11 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_INDEXER_ACTIONS_ROLE }}
-          aws-region: "us-east-1"
+          aws-region: ${{ secrets.CI_AWS_REGION }}
 
       - name: Create and upload consolidated artifact ZIP
         run: |
-          s3_base="${{ env.CI_DEV_INTERNAL_BUCKET }}/${{ env.CI_ARTIFACTS_REPO }}/${{ env.CI_ARTIFACTS_WORKFLOW }}"
+          s3_base="${{ secrets.CI_INTERNAL_S3_BUCKET }}/${{ env.CI_ARTIFACTS_REPO }}/${{ env.CI_ARTIFACTS_WORKFLOW }}"
           s3_stage_base="${s3_base}/staging_${{ github.run_id }}"
           zip_name="artifacts_${{ github.run_id }}.zip"
 

--- a/.github/workflows/5_builderpackage_indexer.yml
+++ b/.github/workflows/5_builderpackage_indexer.yml
@@ -385,7 +385,7 @@ jobs:
 
   build-wazuh-engine:
     needs: [compatibility-check, branches]
-    uses: wazuh/wazuh/.github/workflows/5_builderpackage_engine-standalone.yml@main
+    uses: wazuh/wazuh/.github/workflows/5_builderpackage_engine-standalone.yml@5.0.0
     with:
       wazuh-branch: ${{ needs.branches.outputs.wazuh_ref }}
       build-type: "release"

--- a/.github/workflows/5_builderpackage_indexer.yml
+++ b/.github/workflows/5_builderpackage_indexer.yml
@@ -428,12 +428,13 @@ jobs:
         run: |
           mkdir -p "${{ github.workspace }}/artifacts/engine"
           arch_suffix="${{ matrix.architecture == 'x64' && 'amd64' || 'arm64' }}"
-          s3_base="${{ secrets.CI_INTERNAL_S3_BUCKET }}/${{ env.CI_ENGINE_ARTIFACTS_REPO }}/${{ env.CI_ENGINE_ARTIFACTS_WORKFLOW }}"
+          bucket="${{ secrets.CI_INTERNAL_S3_BUCKET }}"
+          s3_base="s3://${bucket#s3://}/${{ env.CI_ENGINE_ARTIFACTS_REPO }}/${{ env.CI_ENGINE_ARTIFACTS_WORKFLOW }}"
           aws s3 cp "$s3_base/" "${{ github.workspace }}/artifacts/engine/" --recursive \
-            --exclude "*" --include "*linux-${arch_suffix}*/artifacts_${{ github.run_id }}.zip"
+            --exclude "*" --include "*/wazuh-engine-*-linux-${arch_suffix}.zip"
 
           shopt -s nullglob
-          archives=("${{ github.workspace }}/artifacts/engine"/*/artifacts_${{ github.run_id }}.zip)
+          archives=("${{ github.workspace }}/artifacts/engine"/${{ github.run_id }}/wazuh-engine-*-linux-${arch_suffix}.zip)
           if [ ${#archives[@]} -eq 0 ]; then
             echo "::error::No Wazuh Engine artifacts found in S3 for run ${{ github.run_id }} (arch ${arch_suffix})"
             aws s3 ls "$s3_base/" || true

--- a/.github/workflows/5_builderpackage_indexer.yml
+++ b/.github/workflows/5_builderpackage_indexer.yml
@@ -606,15 +606,15 @@ jobs:
         run: |
           pkg_name="${{ steps.package.outputs.name }}"
           pkg_path="artifacts/dist/${pkg_name}"
-          s3_stage_base="${{ secrets.CI_INTERNAL_S3_BUCKET }}/${{ env.CI_ARTIFACTS_REPO }}/${{ env.CI_ARTIFACTS_WORKFLOW }}/staging_${{ github.run_id }}/${{ matrix.distribution }}_${{ matrix.architecture }}"
+          s3_base="${{ secrets.CI_INTERNAL_S3_BUCKET }}/${{ env.CI_ARTIFACTS_REPO }}/${{ env.CI_ARTIFACTS_WORKFLOW }}/${{ github.run_id }}"
 
           if [ ! -f "$pkg_path" ]; then
             echo "::error::Package not found at ${pkg_path}"
             exit 1
           fi
 
-          aws s3 cp "$pkg_path" "${s3_stage_base}/${pkg_name}"
-          echo "::notice::Staged artifact in S3: ${s3_stage_base}/${pkg_name}"
+          aws s3 cp "$pkg_path" "${s3_base}/${pkg_name}"
+          echo "::notice::Uploaded artifact to S3: ${s3_base}/${pkg_name}"
 
       - name: Set up AWS CLI for final package upload
         if: ${{ inputs.upload }}
@@ -641,33 +641,3 @@ jobs:
           aws s3 cp "$src" "$dest"
           s3uri="${dest}${{ steps.package.outputs.name }}.sha512"
           echo "::notice::S3 sha512 URI: ${s3uri}"
-
-  bundle-artifacts:
-    name: Bundle workflow artifacts
-    needs: [build]
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Set up AWS CLI
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          role-to-assume: ${{ secrets.AWS_INDEXER_ACTIONS_ROLE }}
-          aws-region: ${{ secrets.CI_AWS_REGION }}
-
-      - name: Create and upload consolidated artifact ZIP
-        run: |
-          s3_base="${{ secrets.CI_INTERNAL_S3_BUCKET }}/${{ env.CI_ARTIFACTS_REPO }}/${{ env.CI_ARTIFACTS_WORKFLOW }}"
-          s3_stage_base="${s3_base}/staging_${{ github.run_id }}"
-          zip_name="artifacts_${{ github.run_id }}.zip"
-
-          rm -rf artifacts_staging
-          mkdir -p artifacts_staging
-          aws s3 cp "${s3_stage_base}/" artifacts_staging/ --recursive
-
-          if [ -z "$(find artifacts_staging -type f -print -quit)" ]; then
-            echo "::error::No staged artifacts found at ${s3_stage_base}"
-            exit 1
-          fi
-
-          (cd artifacts_staging && zip -r "../${zip_name}" .)
-          aws s3 cp "${zip_name}" "${s3_base}/${zip_name}"
-          echo "::notice::Artifact uploaded to S3: ${s3_base}/${zip_name}"


### PR DESCRIPTION
### Description
Migrates all GitHub Actions artifacts in the wazuh-indexer repository to the `xdrsiem-ci-dev-internal S3 bucket`, as part of the [GitHub artifacts migration to S3](vscode-file://vscode-app/snap/code/247/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).

All actions/upload-artifact and actions/download-artifact usages have been replaced with aws s3 cp operations targeting the following path convention:
https://github.com/wazuh/internal-devel-requests/issues/5304#:~:text=The%20path%20of%20the%20artifacts%20will%20be%3A
### Related Issues
Resolves https://github.com/wazuh/internal-devel-requests/issues/5304

