### PR TITLE
Add postrm and %postun scripts to remove runtime files on uninstall

### DIFF
--- a/distribution/packages/src/deb/debian/postrm
+++ b/distribution/packages/src/deb/debian/postrm
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Copyright Wazuh Indexer Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The Wazuh Indexer Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# deb wazuh-indexer postrm script
+
+set -e
+
+name="wazuh-indexer"
+product_dir=/usr/share/${name}
+
+case "$1" in
+    remove|purge)
+        rm -rf "${product_dir}/engine"
+        rm -rf "${product_dir}/plugins"
+        ;;
+    upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
+        ;;
+    *)
+        echo "postrm called with unknown argument '$1'" >&2
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
+++ b/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
@@ -282,6 +282,16 @@ fi
 
 exit 0
 
+%postun
+set -e
+
+if [ $1 -eq 0 ]; then
+    rm -rf %{product_dir}/engine
+    rm -rf %{product_dir}/plugins
+fi
+
+exit 0
+
 %files -f %{_topdir}/filelist.txt
 %defattr(640, %{name}, %{name}, 750)
 


### PR DESCRIPTION
### Description 
Add post-removal scripts for both DEB and RPM packages to clean up runtime-generated files that the package manager cannot track. 

When `wazuh-engine` runs as a subprocess of `wazuh-indexer`, it writes files into `engine/data/` (RocksDB IOC databases, logtest session namespaces, engine state) that do not exist at install time and are therefore never registered by dpkg or rpm. The bundled plugins also generate runtime data inside their directories. Without a post-removal script, these files are left on disk after uninstall.

### Issues Resolved 
Resolves https://github.com/wazuh/wazuh-indexer/issues/1687