### PR TITLE
Add new security config

### DIFF
--- a/build-scripts/assemble.sh
+++ b/build-scripts/assemble.sh
@@ -182,6 +182,8 @@ function add_configuration_files() {
     cat "$PATH_CONF/security/roles.wazuh.yml" >>"$PATH_CONF/opensearch-security/roles.yml"
     cat "$PATH_CONF/security/roles_mapping.wazuh.yml" >>"$PATH_CONF/opensearch-security/roles_mapping.yml"
     cat "$PATH_CONF/security/internal_users.wazuh.yml" >>"$PATH_CONF/opensearch-security/internal_users.yml"
+    cat "$PATH_CONF/security/action_groups.wazuh.yml" >>"$PATH_CONF/opensearch-security/action_groups.yml"
+    
     # Disable multi-tenancy
     sed -i 's/#kibana:/kibana:/' "$PATH_CONF/opensearch-security/config.yml"
     sed -i 's/#multitenancy_enabled: true/  multitenancy_enabled: false/' "$PATH_CONF/opensearch-security/config.yml"

--- a/distribution/src/config/security/action_groups.wazuh.yml
+++ b/distribution/src/config/security/action_groups.wazuh.yml
@@ -1,0 +1,296 @@
+
+# Content Manager plugin action groups.
+# Each group maps a logical permission name (used in roles.yml) to the
+# actual transport action name(s) registered by the plugin.
+
+plugin:content_manager/integration/create:
+  reserved: true
+  hidden: false
+  allowed_actions:
+    - 'cluster:admin/content_manager/integration/create'
+  type: "cluster"
+  description: "Create a content manager integration resource"
+
+plugin:content_manager/integration/update:
+  reserved: true
+  hidden: false
+  allowed_actions:
+    - 'cluster:admin/content_manager/integration/update'
+  type: "cluster"
+  description: "Update a content manager integration resource"
+
+plugin:content_manager/integration/delete:
+  reserved: true
+  hidden: false
+  allowed_actions:
+    - 'cluster:admin/content_manager/integration/delete'
+  type: "cluster"
+  description: "Delete a content manager integration resource"
+
+plugin:content_manager/integration/*:
+  reserved: true
+  hidden: false
+  allowed_actions:
+    - 'plugin:content_manager/integration/create'
+    - 'plugin:content_manager/integration/update'
+    - 'plugin:content_manager/integration/delete'
+  type: "cluster"
+  description: "Full access to content manager integration resources"
+
+plugin:content_manager/decoder/create:
+  reserved: true
+  hidden: false
+  allowed_actions:
+    - 'cluster:admin/content_manager/decoder/create'
+  type: "cluster"
+  description: "Create a content manager decoder resource"
+
+plugin:content_manager/decoder/update:
+  reserved: true
+  hidden: false
+  allowed_actions:
+    - 'cluster:admin/content_manager/decoder/update'
+  type: "cluster"
+  description: "Update a content manager decoder resource"
+
+plugin:content_manager/decoder/delete:
+  reserved: true
+  hidden: false
+  allowed_actions:
+    - 'cluster:admin/content_manager/decoder/delete'
+  type: "cluster"
+  description: "Delete a content manager decoder resource"
+
+plugin:content_manager/decoder/*:
+  reserved: true
+  hidden: false
+  allowed_actions:
+    - 'plugin:content_manager/decoder/create'
+    - 'plugin:content_manager/decoder/update'
+    - 'plugin:content_manager/decoder/delete'
+  type: "cluster"
+  description: "Full access to content manager decoder resources"
+
+plugin:content_manager/rule/create:
+  reserved: true
+  hidden: false
+  allowed_actions:
+    - 'cluster:admin/content_manager/rule/create'
+  type: "cluster"
+  description: "Create a content manager rule resource"
+
+plugin:content_manager/rule/update:
+  reserved: true
+  hidden: false
+  allowed_actions:
+    - 'cluster:admin/content_manager/rule/update'
+  type: "cluster"
+  description: "Update a content manager rule resource"
+
+plugin:content_manager/rule/delete:
+  reserved: true
+  hidden: false
+  allowed_actions:
+    - 'cluster:admin/content_manager/rule/delete'
+  type: "cluster"
+  description: "Delete a content manager rule resource"
+
+plugin:content_manager/rule/*:
+  reserved: true
+  hidden: false
+  allowed_actions:
+    - 'plugin:content_manager/rule/create'
+    - 'plugin:content_manager/rule/update'
+    - 'plugin:content_manager/rule/delete'
+  type: "cluster"
+  description: "Full access to content manager rule resources"
+
+plugin:content_manager/kvdb/create:
+  reserved: true
+  hidden: false
+  allowed_actions:
+    - 'cluster:admin/content_manager/kvdb/create'
+  type: "cluster"
+  description: "Create a content manager KVDB resource"
+
+plugin:content_manager/kvdb/update:
+  reserved: true
+  hidden: false
+  allowed_actions:
+    - 'cluster:admin/content_manager/kvdb/update'
+  type: "cluster"
+  description: "Update a content manager KVDB resource"
+
+plugin:content_manager/kvdb/delete:
+  reserved: true
+  hidden: false
+  allowed_actions:
+    - 'cluster:admin/content_manager/kvdb/delete'
+  type: "cluster"
+  description: "Delete a content manager KVDB resource"
+
+plugin:content_manager/kvdb/*:
+  reserved: true
+  hidden: false
+  allowed_actions:
+    - 'plugin:content_manager/kvdb/create'
+    - 'plugin:content_manager/kvdb/update'
+    - 'plugin:content_manager/kvdb/delete'
+  type: "cluster"
+  description: "Full access to content manager KVDB resources"
+
+plugin:content_manager/filter/create:
+  reserved: true
+  hidden: false
+  allowed_actions:
+    - 'cluster:admin/content_manager/filter/create'
+  type: "cluster"
+  description: "Create a content manager filter resource"
+
+plugin:content_manager/filter/update:
+  reserved: true
+  hidden: false
+  allowed_actions:
+    - 'cluster:admin/content_manager/filter/update'
+  type: "cluster"
+  description: "Update a content manager filter resource"
+
+plugin:content_manager/filter/delete:
+  reserved: true
+  hidden: false
+  allowed_actions:
+    - 'cluster:admin/content_manager/filter/delete'
+  type: "cluster"
+  description: "Delete a content manager filter resource"
+
+plugin:content_manager/filter/*:
+  reserved: true
+  hidden: false
+  allowed_actions:
+    - 'plugin:content_manager/filter/create'
+    - 'plugin:content_manager/filter/update'
+    - 'plugin:content_manager/filter/delete'
+  type: "cluster"
+  description: "Full access to content manager filter resources"
+
+plugin:content_manager/subscription/get:
+  reserved: true
+  hidden: false
+  allowed_actions:
+    - 'cluster:monitor/content_manager/subscription/get'
+  type: "cluster"
+  description: "Get the CTI subscription"
+
+plugin:content_manager/subscription/post:
+  reserved: true
+  hidden: false
+  allowed_actions:
+    - 'cluster:admin/content_manager/subscription/create'
+  type: "cluster"
+  description: "Create/update the CTI subscription"
+
+plugin:content_manager/subscription/delete:
+  reserved: true
+  hidden: false
+  allowed_actions:
+    - 'cluster:admin/content_manager/subscription/delete'
+  type: "cluster"
+  description: "Delete the CTI subscription"
+
+plugin:content_manager/update:
+  reserved: true
+  hidden: false
+  allowed_actions:
+    - 'cluster:admin/content_manager/update/trigger'
+  type: "cluster"
+  description: "Trigger an on-demand CTI catalog sync"
+
+plugin:content_manager/logtest:
+  reserved: true
+  hidden: false
+  allowed_actions:
+    - 'cluster:monitor/content_manager/logtest'
+  type: "cluster"
+  description: "Run a log test"
+
+plugin:content_manager/logtest/detection:
+  reserved: true
+  hidden: false
+  allowed_actions:
+    - 'cluster:monitor/content_manager/logtest_detection'
+  type: "cluster"
+  description: "Run a logtest detection"
+
+plugin:content_manager/logtest/normalization:
+  reserved: true
+  hidden: false
+  allowed_actions:
+    - 'cluster:monitor/content_manager/logtest_normalization'
+  type: "cluster"
+  description: "Run a logtest normalization"
+
+plugin:content_manager/logtest/*:
+  reserved: true
+  hidden: false
+  allowed_actions:
+    - 'plugin:content_manager/logtest/detection'
+    - 'plugin:content_manager/logtest/normalization'
+  type: "cluster"
+  description: "Full access to logtest sub-operations"
+
+plugin:content_manager/promote/get:
+  reserved: true
+  hidden: false
+  allowed_actions:
+    - 'cluster:monitor/content_manager/promote/get'
+  type: "cluster"
+  description: "Preview a promotion diff"
+
+plugin:content_manager/promote/post:
+  reserved: true
+  hidden: false
+  allowed_actions:
+    - 'cluster:admin/content_manager/promote/create'
+  type: "cluster"
+  description: "Execute a space promotion"
+
+plugin:content_manager/promote/*:
+  reserved: true
+  hidden: false
+  allowed_actions:
+    - 'plugin:content_manager/promote/get'
+    - 'plugin:content_manager/promote/post'
+  type: "cluster"
+  description: "Full access to space promotion"
+
+plugin:content_manager/space/delete:
+  reserved: true
+  hidden: false
+  allowed_actions:
+    - 'cluster:admin/content_manager/space/delete'
+  type: "cluster"
+  description: "Delete a content space"
+
+plugin:content_manager/policy/update:
+  reserved: true
+  hidden: false
+  allowed_actions:
+    - 'cluster:admin/content_manager/policy/update'
+  type: "cluster"
+  description: "Update the draft policy"
+
+plugin:wazuh/settings/write:
+  reserved: true
+  hidden: false
+  allowed_actions:
+    - 'cluster:admin/setup/settings/update'
+  type: "cluster"
+  description: "Write Wazuh settings"
+
+plugin:content_manager/version/check:
+  reserved: true
+  hidden: false
+  allowed_actions:
+    - 'cluster:monitor/content_manager/version/check'
+  type: "cluster"
+  description: "Check the CTI catalog version"

--- a/distribution/src/config/security/internal_users.wazuh.yml
+++ b/distribution/src/config/security/internal_users.wazuh.yml
@@ -1,14 +1,33 @@
-# This file contains the internal users configuration for Wazuh.
+
+# ---------------------------------------------------------------------#
+# Wazuh Indexer Default Users
+# ---------------------------------------------------------------------#
+# WARNING: Change these default passwords immediately after installation.
+
 wazuh-server:
   # The hash is the hash of the password "wazuh-server"
   hash: "$2y$12$4pwjkynhYg09QJtJ5zxAcuqUSOV8JBziFDca6u9cV/H9oglVCGZEW"
   reserved: true
   backend_roles: []
-  description: "Wazuh Server user with read/write access to stateful and write-only access to stateless indexes."
+  description: "Wazuh Server user with write-only access to stateless (events) indexes, read/write/delete access to stateful (states) indexes, and read access to consumers, threat intelligence content, and active-responses indexes."
 
-wazuh-dashboard:
-  # The hash is the hash of the password "wazuh-dashboard"
-  hash: "$2y$12$Mn2XvokTfwo2NWL2AK83yOkio1qmJyZrAp0iEWqs3lz0L8ruhu9LK"
+wazuh-admin:
+  # The hash is the hash of the password "wazuh-admin"
+  hash: "$2y$12$of2izMMGqP3x4WWtijoq2.MtM1VgpoDc4RgP8AAQD/8tEbo1ftxru"
   reserved: true
   backend_roles: []
-  description: "Wazuh Dashboard user with read access to stateful and stateless indexes, write access to metrics indexes and management for sample data indexes."
+  description: "Wazuh Administrator user with read access to Wazuh indexes, write access to Wazuh settings, Content Manager management endpoints, and full access to Security Analytics plugin endpoints."
+
+wazuh-demo:
+  # The hash is the hash of the password "wazuh-demo"
+  hash: "$2y$12$AT8tsUCOG/aFMr2hwQS6xuUkIfFj1rO2VxHUIsRRtPV3utzLgdVbW"
+  reserved: true
+  backend_roles: []
+  description: "Wazuh user with read access to consumers and threat intelligence content, read access to Content Manager subscription details, and write access to Content Manager endpoints (updates, kvdbs, decoders, filters, rules, integrations, logtest, promotions, policies, and spaces), plus full access to Security Analytics plugin endpoints."
+
+wazuh-readonly:
+  # The hash is the hash of the password "wazuh-readonly"
+  hash: "$2y$12$jxMGvesP0pdvs0uzoWsvYOFysWZujpEcSL5PQmkVuifR8izAO2i5q"
+  reserved: true
+  backend_roles: []
+  description: "Wazuh Read-Only user with read access to settings, consumers, threat intelligence content, subscriptions, and Security Analytics plugin (SAP) detectors."

--- a/distribution/src/config/security/roles.wazuh.yml
+++ b/distribution/src/config/security/roles.wazuh.yml
@@ -1,167 +1,273 @@
-# Wazuh monitoring and statistics index permissions
-manage_wazuh_index:
-  reserved: true
-  hidden: false
-  cluster_permissions: []
-  index_permissions:
-  - index_patterns:
-    - "wazuh-*"
-    # dls: ""
-    # fls: []
-    # masked_fields: []
-    allowed_actions:
-    - "read"
-    - "delete"
-    - "manage"
-    - "index"
-  tenant_permissions: []
-  static: false
 
-# Wazuh roles for security configuration
-
-stateful-read:
-  reserved: true
-  cluster_permissions: []
-  index_permissions:
-    - index_patterns:
-        - "wazuh-states-*"
-      # dls: ""
-      # fls: []
-      # masked_fields: []
-      allowed_actions:
-        - "read"
-  tenant_permissions: []
-  static: true
-
-stateful-write:
-  reserved: true
-  cluster_permissions: []
-  index_permissions:
-    - index_patterns:
-        - "wazuh-states-*"
-      # dls: ""
-      # fls: []
-      # masked_fields: []
-      allowed_actions:
-        - "index"
-  tenant_permissions: []
-  static: true
-
-stateful-delete:
-  reserved: true
-  cluster_permissions: []
-  index_permissions:
-    - index_patterns:
-        - "wazuh-states-*"
-      # dls: ""
-      # fls: []
-      # masked_fields: []
-      allowed_actions:
-        - "delete"
-  tenant_permissions: []
-  static: true
-
-stateless-read:
-  reserved: true
-  cluster_permissions: []
-  index_permissions:
-    - index_patterns:
-        - "wazuh-alerts*"
-        - "wazuh-archives*"
-      # dls: ""
-      # fls: []
-      # masked_fields: []
-      allowed_actions:
-        - "read"
-  tenant_permissions: []
-  static: true
-
-stateless-write:
-  reserved: true
-  cluster_permissions: []
-  index_permissions:
-    - index_patterns:
-        - "wazuh-alerts*"
-        - "wazuh-archives*"
-      # dls: ""
-      # fls: []
-      # masked_fields: []
-      allowed_actions:
-        - "index"
-  tenant_permissions: []
-  static: true
-
-metrics-read:
-  reserved: true
-  cluster_permissions: []
-  index_permissions:
-    - index_patterns:
-        - "wazuh-monitoring*"
-        - "wazuh-statistics*"
-      # dls: ""
-      # fls: []
-      # masked_fields: []
-      allowed_actions:
-        - "read"
-  tenant_permissions: []
-  static: true
-
-metrics-write:
-  reserved: true
-  cluster_permissions: []
-  index_permissions:
-    - index_patterns:
-        - "wazuh-monitoring*"
-        - "wazuh-statistics*"
-      # dls: ""
-      # fls: []
-      # masked_fields: []
-      allowed_actions:
-        - "index"
-  tenant_permissions: []
-  static: true
-
-sample-data-management:
-  reserved: true
-  cluster_permissions: []
-  index_permissions:
-    - index_patterns:
-        - "*-sample-*"
-      # dls: ""
-      # fls: []
-      # masked_fields: []
-      allowed_actions:
-        - "data_access"
-        - "manage"
-  tenant_permissions: []
-  static: true
-
-
-# Roles for Content Manager plugin subscription management
-cm_subscription_read:
+# ---------------------------------------------------------------------#
+# wazuh-admin: full access to all Wazuh features, excluding super-admin
+# features such as security configuration.
+# ---------------------------------------------------------------------#
+wazuh_admin:
   reserved: true
   hidden: false
   cluster_permissions:
-    - "plugin:content_manager/subscription_get"
-  index_permissions: []
+    - 'cluster_composite_ops'
+    - 'cluster_monitor'
+    # Content Manager
+    - 'plugin:wazuh/settings/write'
+    - 'plugin:content_manager/integration/*'
+    - 'plugin:content_manager/decoder/*'
+    - 'plugin:content_manager/rule/*'
+    - 'plugin:content_manager/kvdb/*'
+    - 'plugin:content_manager/filter/*'
+    - 'plugin:content_manager/subscription/get'
+    - 'plugin:content_manager/subscription/post'
+    - 'plugin:content_manager/subscription/delete'
+    - 'plugin:content_manager/update'
+    - 'plugin:content_manager/logtest'
+    - 'plugin:content_manager/logtest/*'
+    - 'plugin:content_manager/promote/*'
+    - 'plugin:content_manager/space/delete'
+    # Security Analytics
+    - 'cluster:admin/wazuh/securityanalytics/rule/custom/*'
+    - 'cluster:admin/wazuh/securityanalytics/logtype/*'
+    - 'cluster:admin/wazuh/securityanalytics/rules/evaluate'
+    - 'cluster:admin/wazuh/securityanalytics/space/delete'
+    # Alerting (full)
+    - 'cluster:admin/opendistro/alerting/*'
+    - 'cluster:admin/opensearch/alerting/*'
+    # Anomaly detection (detector ops)
+    - 'cluster:admin/opendistro/ad/*'
+    # Notifications (full)
+    - 'cluster:admin/opensearch/notifications/*'
+    # Reporting (full)
+    - 'cluster:admin/opendistro/reports/*'
+    # Index management (full): ISM, rollups, transforms
+    - 'cluster:admin/opendistro/ism/*'
+    - 'cluster:admin/opendistro/rollup/*'
+    - 'cluster:admin/opendistro/transform/*'
+    - 'cluster:admin/opensearch/controlcenter/lron/*'
+  index_permissions:
+    - index_patterns:
+        - '*'
+        - '.kibana*'
+      allowed_actions:
+        - 'get'
+        - 'read'
+        - 'indices:admin/opensearch/ism/*'
+        - 'indices:internal/plugins/replication/index/stop'
+    - index_patterns:
+        - '.wazuh-settings'
+      allowed_actions:
+        - 'read'
+        - 'index'
+    - index_patterns:
+        - 'wazuh-events-v5*'
+      allowed_actions:
+        - 'index'
+    - index_patterns:
+        - '.wazuh-internal-state'
+      allowed_actions:
+        - 'read'
+        - 'index'
+        - 'delete'
+    - index_patterns:
+        - 'wazuh-threatintel-*'
+        - '.opensearch-sap-*'
+      allowed_actions:
+        - 'index'
+        - 'delete'
   tenant_permissions: []
   static: true
 
-cm_subscription_write:
+# ---------------------------------------------------------------------#
+# wazuh-demo: default user with regular access. Can visualize data and
+# index/update/delete threatintel resources.
+# ---------------------------------------------------------------------#
+wazuh_demo:
   reserved: true
   hidden: false
   cluster_permissions:
-    - "plugin:content_manager/subscription_post"
-    - "plugin:content_manager/subscription_delete"
-  index_permissions: []
+    - 'cluster_composite_ops'
+    - 'cluster_monitor'
+    # Content Manager
+    - 'plugin:content_manager/integration/*'
+    - 'plugin:content_manager/decoder/*'
+    - 'plugin:content_manager/rule/*'
+    - 'plugin:content_manager/kvdb/*'
+    - 'plugin:content_manager/filter/*'
+    - 'plugin:content_manager/subscription/get'
+    - 'plugin:content_manager/update'
+    - 'plugin:content_manager/logtest'
+    - 'plugin:content_manager/logtest/*'
+    - 'plugin:content_manager/promote/*'
+    - 'plugin:content_manager/space/delete'
+    # Security Analytics
+    - 'cluster:admin/wazuh/securityanalytics/rule/custom/*'
+    - 'cluster:admin/wazuh/securityanalytics/logtype/*'
+    - 'cluster:admin/wazuh/securityanalytics/rules/evaluate'
+    - 'cluster:admin/wazuh/securityanalytics/space/delete'
+    # Alerting (read + acknowledge alerts)
+    - 'cluster:admin/opendistro/alerting/alerts/get'
+    - 'cluster:admin/opendistro/alerting/destination/get'
+    - 'cluster:admin/opendistro/alerting/monitor/get'
+    - 'cluster:admin/opendistro/alerting/monitor/search'
+    - 'cluster:admin/opensearch/alerting/comments/search'
+    - 'cluster:admin/opensearch/alerting/findings/get'
+    - 'cluster:admin/opensearch/alerting/remote/indexes/get'
+    - 'cluster:admin/opensearch/alerting/v2/alerts/get'
+    - 'cluster:admin/opensearch/alerting/v2/monitor/get'
+    - 'cluster:admin/opensearch/alerting/v2/monitor/search'
+    - 'cluster:admin/opensearch/alerting/workflow/get'
+    - 'cluster:admin/opensearch/alerting/workflow_alerts/get'
+    # Anomaly detection (read)
+    - 'cluster:admin/opendistro/ad/detector/info'
+    - 'cluster:admin/opendistro/ad/detector/search'
+    - 'cluster:admin/opendistro/ad/detector/suggest'
+    - 'cluster:admin/opendistro/ad/detector/validate'
+    - 'cluster:admin/opendistro/ad/detectors/get'
+    - 'cluster:admin/opendistro/ad/result/search'
+    - 'cluster:admin/opendistro/ad/result/topAnomalies'
+    - 'cluster:admin/opendistro/ad/tasks/search'
+    # Notifications (read)
+    - 'cluster:admin/opensearch/notifications/channels/get'
+    - 'cluster:admin/opensearch/notifications/configs/get'
+    - 'cluster:admin/opensearch/notifications/features'
+    # Reporting (read + download)
+    - 'cluster:admin/opendistro/reports/definition/get'
+    - 'cluster:admin/opendistro/reports/definition/list'
+    - 'cluster:admin/opendistro/reports/instance/get'
+    - 'cluster:admin/opendistro/reports/instance/list'
+    - 'cluster:admin/opendistro/reports/menu/download'
+    # Index management (read): ISM explain/get, rollup/transform get/search
+    - 'cluster:admin/opendistro/ism/managedindex/explain'
+    - 'cluster:admin/opendistro/ism/policy/get'
+    - 'cluster:admin/opendistro/ism/policy/search'
+    - 'cluster:admin/opendistro/rollup/get'
+    - 'cluster:admin/opendistro/rollup/search'
+    - 'cluster:admin/opendistro/transform/get'
+    - 'cluster:admin/opendistro/transform/search'
+  index_permissions:
+    - index_patterns:
+        - '*'
+        - '.kibana*'
+      allowed_actions:
+        - 'get'
+        - 'read'
+    - index_patterns:
+        - '.wazuh-internal-state'
+      allowed_actions:
+        - 'read'
+    - index_patterns:
+        - 'wazuh-threatintel-*'
+        - '.opensearch-sap-*'
+      allowed_actions:
+        - 'index'
+        - 'delete'
   tenant_permissions: []
   static: true
 
-cm_update:
+# ---------------------------------------------------------------------#
+# wazuh-readonly: read-only user.
+# ---------------------------------------------------------------------#
+wazuh_readonly:
   reserved: true
   hidden: false
   cluster_permissions:
-    - "plugin:content_manager/update"
-  index_permissions: []
+    - 'cluster_composite_ops'
+    - 'cluster_monitor'
+    - 'plugin:content_manager/subscription/get'
+    - 'plugin:content_manager/logtest'
+    - 'plugin:content_manager/logtest/*'
+    - 'cluster:admin/wazuh/securityanalytics/rules/evaluate'
+    # Alerting (read + acknowledge alerts)
+    - 'cluster:admin/opendistro/alerting/alerts/get'
+    - 'cluster:admin/opendistro/alerting/destination/get'
+    - 'cluster:admin/opendistro/alerting/monitor/get'
+    - 'cluster:admin/opendistro/alerting/monitor/search'
+    - 'cluster:admin/opensearch/alerting/comments/search'
+    - 'cluster:admin/opensearch/alerting/findings/get'
+    - 'cluster:admin/opensearch/alerting/remote/indexes/get'
+    - 'cluster:admin/opensearch/alerting/v2/alerts/get'
+    - 'cluster:admin/opensearch/alerting/v2/monitor/get'
+    - 'cluster:admin/opensearch/alerting/v2/monitor/search'
+    - 'cluster:admin/opensearch/alerting/workflow/get'
+    - 'cluster:admin/opensearch/alerting/workflow_alerts/get'
+    # Anomaly detection (read)
+    - 'cluster:admin/opendistro/ad/detector/info'
+    - 'cluster:admin/opendistro/ad/detector/search'
+    - 'cluster:admin/opendistro/ad/detector/suggest'
+    - 'cluster:admin/opendistro/ad/detector/validate'
+    - 'cluster:admin/opendistro/ad/detectors/get'
+    - 'cluster:admin/opendistro/ad/result/search'
+    - 'cluster:admin/opendistro/ad/result/topAnomalies'
+    - 'cluster:admin/opendistro/ad/tasks/search'
+    # Notifications (read)
+    - 'cluster:admin/opensearch/notifications/channels/get'
+    - 'cluster:admin/opensearch/notifications/configs/get'
+    - 'cluster:admin/opensearch/notifications/features'
+    # Reporting (read + download)
+    - 'cluster:admin/opendistro/reports/definition/get'
+    - 'cluster:admin/opendistro/reports/definition/list'
+    - 'cluster:admin/opendistro/reports/instance/get'
+    - 'cluster:admin/opendistro/reports/instance/list'
+    - 'cluster:admin/opendistro/reports/menu/download'
+    # Index management (read): ISM explain/get, rollup/transform get/search
+    - 'cluster:admin/opendistro/ism/managedindex/explain'
+    - 'cluster:admin/opendistro/ism/policy/get'
+    - 'cluster:admin/opendistro/ism/policy/search'
+    - 'cluster:admin/opendistro/rollup/get'
+    - 'cluster:admin/opendistro/rollup/search'
+    - 'cluster:admin/opendistro/transform/get'
+    - 'cluster:admin/opendistro/transform/search'
+  index_permissions:
+    - index_patterns:
+        - '*'
+        - '.kibana*'
+      allowed_actions:
+        - 'get'
+        - 'read'
+    - index_patterns:
+        - '.wazuh-settings'
+      allowed_actions:
+        - 'read'
+    - index_patterns:
+        - '.wazuh-internal-state'
+      allowed_actions:
+        - 'read'
+  tenant_permissions: []
+  static: true
+
+# ---------------------------------------------------------------------#
+# wazuh-server: service account. Reads CTI consumer state, active
+# responses and threat intelligence content; ingests events, metrics
+# and states; manages state documents (index + delete).
+# ---------------------------------------------------------------------#
+wazuh_server:
+  reserved: true
+  hidden: false
+  cluster_permissions:
+    - 'cluster_composite_ops'
+    - 'cluster_monitor'
+  index_permissions:
+    - index_patterns:
+        - '.wazuh-cti-consumers'
+        - 'wazuh-active-responses-*'
+        - 'wazuh-threatintel-*'
+      allowed_actions:
+        - 'read'
+    - index_patterns:
+        - 'wazuh-events-v5-*'
+        - 'wazuh-metrics-*'
+      allowed_actions:
+        - 'read'
+        - 'index'
+    - index_patterns:
+        - 'wazuh-states-*'
+      allowed_actions:
+        - 'read'
+        - 'index'
+        - 'delete'
+    - index_patterns:
+        - '.wazuh-threatintel-vulnerabilities*'
+        - 'wazuh-threatintel-*'
+      allowed_actions:
+        - 'manage_point_in_time'
   tenant_permissions: []
   static: true

--- a/distribution/src/config/security/roles_mapping.wazuh.yml
+++ b/distribution/src/config/security/roles_mapping.wazuh.yml
@@ -1,131 +1,38 @@
-# Wazuh monitoring and statistics index permissions
-manage_wazuh_index:
+
+# ---------------------------------------------------------------------#
+# Wazuh Indexer Default Roles Mappings
+# ---------------------------------------------------------------------#
+#
+# One composite role per user.
+
+dashboard_server:
   reserved: true
   hidden: false
-  backend_roles: []
-  hosts: []
   users:
-  - "kibanaserver"
-  and_backend_roles: []
+    - "kibanaserver"
 
-# Wazuh roles mappings for security configuration
-
-stateful-read:
+wazuh_admin:
   reserved: true
   hidden: false
-  backend_roles: [ ]
-  hosts: [ ]
   users:
-    - "wazuh-server"
-    - "wazuh-dashboard"
-  and_backend_roles: [ ]
+    - "wazuh-admin"
+  backend_roles:
+    - "admin"
 
-stateful-write:
+wazuh_demo:
   reserved: true
   hidden: false
-  backend_roles: [ ]
-  hosts: [ ]
   users:
-    - "wazuh-server"
-  and_backend_roles: [ ]
+    - "wazuh-demo"
 
-stateful-delete:
+wazuh_readonly:
   reserved: true
   hidden: false
-  backend_roles: [ ]
-  hosts: [ ]
   users:
-    - "wazuh-server"
-  and_backend_roles: [ ]
+    - "wazuh-readonly"
 
-stateless-write:
+wazuh_server:
   reserved: true
   hidden: false
-  backend_roles: [ ]
-  hosts: [ ]
   users:
     - "wazuh-server"
-  and_backend_roles: [ ]
-
-stateless-read:
-  reserved: true
-  hidden: false
-  backend_roles: [ ]
-  hosts: [ ]
-  users:
-    - "wazuh-dashboard"
-  and_backend_roles: [ ]
-
-metrics-read:
-  reserved: true
-  hidden: false
-  backend_roles: [ ]
-  hosts: [ ]
-  users:
-    - "wazuh-dashboard"
-  and_backend_roles: [ ]
-
-metrics-write:
-  reserved: true
-  hidden: false
-  backend_roles: [ ]
-  hosts: [ ]
-  users:
-    - "wazuh-dashboard"
-  and_backend_roles: [ ]
-
-sample-data-management:
-  reserved: true
-  hidden: false
-  backend_roles: [ ]
-  hosts: [ ]
-  users:
-    - "wazuh-dashboard"
-  and_backend_roles: [ ]
-
-# Allow the dashboard to pre-configure integrations.
-alerting_full_access:
-  reserved: true
-  hidden: false
-  backend_roles: []
-  hosts: []
-  users:
-  - "kibanaserver"
-  and_backend_roles: []
-
-notifications_full_access:
-  reserved: true
-  hidden: false
-  backend_roles: []
-  hosts: []
-  users:
-  - "kibanaserver"
-  and_backend_roles: []
-
-# Roles for Content Manager plugin subscription management
-cm_subscription_read:
-  reserved: true
-  hidden: false
-  backend_roles: [ ]
-  hosts: [ ]
-  users:
-    - "wazuh-server"
-  and_backend_roles: [ ]
-
-cm_subscription_write:
-  reserved: true
-  hidden: false
-  backend_roles: [ ]
-  hosts: [ ]
-  users:
-    - "wazuh-dashboard"
-  and_backend_roles: [ ]
-
-cm_update:
-  reserved: true
-  hidden: false
-  backend_roles: [ ]
-  hosts: [ ]
-  users:
-    - "wazuh-dashboard"
-  and_backend_roles: [ ]


### PR DESCRIPTION
### Description

Adds new security config:

- `action_groups.yml` — to make `plugin:content_manager/*` aliases work in wazuh_admin/wazuh_demo/wazuh_readonly
- `roles.yml` — to fix the raw action names in `wazuh_full_access`
- `roles_mapping.yml` — to give admin a role that actually grants content manager permission

Packages:
- https://github.com/wazuh/wazuh-indexer/actions/runs/28451624874

### Related Issues
Resolves https://github.com/wazuh/wazuh-indexer-plugins/issues/1325