### PR TITLE
Fix builderpackage workflow

### DIFF
--- a/.github/workflows/5_builderpackage_indexer.yml
+++ b/.github/workflows/5_builderpackage_indexer.yml
@@ -4,6 +4,7 @@ name: (5.x) Build packages
 permissions:
   contents: read
   packages: read
+  id-token: write
 
 # This workflow runs when any of the following occur:
 # - Run manually
@@ -380,7 +381,11 @@ jobs:
 
   build-wazuh-engine:
     needs: [compatibility-check, branches]
-    uses: wazuh/wazuh/.github/workflows/5_builderpackage_engine-standalone.yml@main
+    uses: wazuh/wazuh/.github/workflows/5_builderpackage_engine-standalone.yml@5.0.0
+    permissions:
+      id-token: write
+      contents: read
+      packages: read
     with:
       wazuh-branch: ${{ needs.branches.outputs.wazuh_ref }}
       build-type: "release"


### PR DESCRIPTION
### Description

Adds missing permissions to the reusable workflow and link to the 5.0.0 branch version.

**Validation**

Workflow run: https://github.com/wazuh/wazuh-indexer/actions/runs/28781477625

### Related Issues
Resolves #1721 