### PR TITLE
Add missing permissions to read the settings index to the wazuh_manager role

### DIFF
--- a/distribution/src/config/security/roles.wazuh.yml
+++ b/distribution/src/config/security/roles.wazuh.yml
@@ -340,6 +340,10 @@ wazuh_manager:
     - 'cluster_monitor'
   index_permissions:
     - index_patterns:
+        - '.wazuh-settings'
+      allowed_actions:
+        - 'read'
+    - index_patterns:
         - '.wazuh-cti-consumers'
         - 'wazuh-active-responses*'
         - 'wazuh-threatintel-*'


### PR DESCRIPTION
### Description
Add missing permissions to read the settings index to the wazuh_manager role

### Related Issues
Resolves #1541 
