### PR TITLE
Grant wazuh_admin/wazuh_demo access to content-manager resource-lock index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix `/etc/default/wazuh-indexer` ownership and permissions in deb [(#1533)](https://github.com/wazuh/wazuh-indexer/pull/1533)
 - Fix Java warnings by updating JVM options for native access [(#1574)](https://github.com/wazuh/wazuh-indexer/pull/1574)
 - Fix SLF4J startup warning in reindex module by adding Log4j2 provider [(#1650)](https://github.com/wazuh/wazuh-indexer/pull/1650)
+- Fix missing index permissions for the Content Manager resource-lock index [(#1747)](https://github.com/wazuh/wazuh-indexer/pull/1747)
 
 ### Dependencies
 -

--- a/distribution/src/config/security/roles.wazuh.yml
+++ b/distribution/src/config/security/roles.wazuh.yml
@@ -119,6 +119,7 @@ wazuh_admin:
     - index_patterns:
         - 'wazuh-threatintel-*'
         - '.opensearch-sap-*'
+        - '.wazuh-content-manager-resource-locks'
       allowed_actions:
         - 'index'
         - 'delete'
@@ -224,6 +225,7 @@ wazuh_demo:
     - index_patterns:
         - 'wazuh-threatintel-*'
         - '.opensearch-sap-*'
+        - '.wazuh-content-manager-resource-locks'
       allowed_actions:
         - 'index'
         - 'delete'


### PR DESCRIPTION
### Description
Adds `.wazuh-content-manager-resource-locks` to the `index_permissions` of the `wazuh_admin` and `wazuh_demo` roles.

This index was introduced by `ResourceLockService` (wazuh/wazuh-indexer-plugins#1291) to serialize the per-type resource-creation-limit check, but was never added to any role's index permissions. As a result, no non-superadmin user could create any Content Manager resource (integration/kvdb/decoder/rule/filter).

### Issues Resolved
Found while validating wazuh/wazuh-indexer-plugins#1353
