### PR TITLE
Add index permissions for `wazuh-events-raw-v5*`

### DIFF
--- a/distribution/src/config/security/roles.wazuh.yml
+++ b/distribution/src/config/security/roles.wazuh.yml
@@ -362,6 +362,7 @@ wazuh_manager:
         - 'read'
     - index_patterns:
         - 'wazuh-events-v5-*'
+        - 'wazuh-events-raw-v5*'
         - 'wazuh-metrics-*'
       allowed_actions:
         - 'read'


### PR DESCRIPTION
## Description

This PR fixes an issue where the `wazuh-manager` user cannot write to the `wazuh-events-raw-v5` index.

## Proposed Changes

```
diff --git a/distribution/src/config/security/roles.wazuh.yml b/distribution/src/config/security/roles.wazuh.yml
index e25a4768b96..25872fc2e36 100644
--- a/distribution/src/config/security/roles.wazuh.yml
+++ b/distribution/src/config/security/roles.wazuh.yml
@@ -362,6 +362,7 @@ wazuh_manager:
         - 'read'
     - index_patterns:
         - 'wazuh-events-v5-*'
+        - 'wazuh-events-raw-v5*'
         - 'wazuh-metrics-*'
       allowed_actions:
         - 'read'
```

### Results and Evidence

With the changes above, we can now index to `wazuh-events-v5-raw` using `wazuh-manager`
<img width="1620" height="710" alt="2026-07-21_07-04" src="https://github.com/user-attachments/assets/8c871609-ddff-49cf-81ff-f1ae5d18ed25" />

### Artifacts Affected

- `roles.wazuh.yml`