### PR TITLE
Set tag input default to false and revert bogus v5.0.0-rc1 references

### DIFF
--- a/.github/workflows/5_builderpackage_indexer.yml
+++ b/.github/workflows/5_builderpackage_indexer.yml
@@ -396,7 +396,7 @@ jobs:
 
   build-wazuh-engine:
     needs: [compatibility-check, branches]
-    uses: wazuh/wazuh/.github/workflows/5_builderpackage_engine-standalone.yml@v5.0.0-rc1
+    uses: wazuh/wazuh/.github/workflows/5_builderpackage_engine-standalone.yml@5.0.0
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -21,7 +21,7 @@ on:
         type: string
       tag:
         description: 'Set to true when this bump is preparing a tag release'
-        default: true
+        default: false
         required: false
         type: boolean
       issue-link:


### PR DESCRIPTION
## Description

The `tag` input in the bumper workflow defaulted to `true`, causing stage-only bumps to wrongly pin workflow references to a tag (`v5.0.0-rc1`) that doesn't exist yet. This PR sets the default to `false` and reverts those references back to `5.0.0`.

## Related Issues
Resolves https://github.com/wazuh/wazuh-indexer/issues/1765
