### PR TITLE
Grant wazuh_manager read access to wazuh-findings-v5-*

### DIFF
--- a/distribution/src/config/security/roles.wazuh.yml
+++ b/distribution/src/config/security/roles.wazuh.yml
@@ -358,6 +358,7 @@ wazuh_manager:
         - '.wazuh-cti-consumers'
         - 'wazuh-active-responses*'
         - 'wazuh-threatintel-*'
+        - 'wazuh-findings-v5-*'
       allowed_actions:
         - 'read'
     - index_patterns:


### PR DESCRIPTION
## Description

Active Response never executes on the agent: the manager needs to read the finding that triggered the order (`event.index`) to process and dispatch it, but `wazuh_manager` had no `read` permission on `wazuh-findings-v5-*`, so the read was silently denied and the order stayed queued forever.

Closes #1769

## Proposed Changes

Added `wazuh-findings-v5-*` to the existing `read`-only index pattern group for `wazuh_manager` in `roles.wazuh.yml`.

### Results and Evidence

Verified live: as `wazuh-manager`, `POST /.ds-wazuh-findings-v5-system-activity-000001/_mget` returned `403` (`no permissions for [indices:data/read/mget[shard]]`) before the fix, and `200` after applying it.

### Artifacts Affected

- `distribution/src/config/security/roles.wazuh.yml`

### Configuration Changes

None , only extends an existing role's index permissions.

### Documentation Updates

None.

### Tests Introduced

None.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [x] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
