### PR TITLE
Create AI assistant roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Initialize `wazuh-indexer-alerting` repository [(#1)](https://github.com/wazuh/wazuh-indexer-alerting/issues/1)
 - Wazuh Indexer nightly Docker images [(#1433)](https://github.com/wazuh/wazuh-indexer/issues/1433)
 - Performance improvements & default configurations [(#1636)](https://github.com/wazuh/wazuh-indexer/issues/1636)
+- AI assistant support [(#1422)](https://github.com/wazuh/wazuh-indexer-plugins/issues/1422)
 
 ### Changed
 - Migrate issue templates from `6.0.0` [(#853)](https://github.com/wazuh/wazuh-indexer/issues/853)

--- a/distribution/src/config/security/action_groups.wazuh.yml
+++ b/distribution/src/config/security/action_groups.wazuh.yml
@@ -294,3 +294,35 @@ plugin:content_manager/version/check:
     - 'cluster:monitor/content_manager/version/check'
   type: "cluster"
   description: "Check the CTI catalog version"
+
+plugin:wazuh/ai_assistant/sessions/read:
+  reserved: true
+  hidden: false
+  allowed_actions:
+    - 'cluster:admin/ai_assistant/sessions/read'
+  type: "cluster"
+  description: "Read any user's AI assistant conversations"
+
+plugin:wazuh/ai_assistant/sessions/write:
+  reserved: true
+  hidden: false
+  allowed_actions:
+    - 'cluster:admin/ai_assistant/sessions/write'
+  type: "cluster"
+  description: "Create, update or delete any user's AI assistant conversations"
+
+plugin:wazuh/ai_assistant/settings/read:
+  reserved: true
+  hidden: false
+  allowed_actions:
+    - 'cluster:admin/ai_assistant/settings/read'
+  type: "cluster"
+  description: "Read the AI assistant's providers, settings and field policy"
+
+plugin:wazuh/ai_assistant/settings/write:
+  reserved: true
+  hidden: false
+  allowed_actions:
+    - 'cluster:admin/ai_assistant/settings/write'
+  type: "cluster"
+  description: "Write the AI assistant's providers, settings and field policy"

--- a/distribution/src/config/security/action_groups.wazuh.yml
+++ b/distribution/src/config/security/action_groups.wazuh.yml
@@ -295,22 +295,6 @@ plugin:content_manager/version/check:
   type: "cluster"
   description: "Check the CTI catalog version"
 
-plugin:wazuh/ai_assistant/sessions/read:
-  reserved: true
-  hidden: false
-  allowed_actions:
-    - 'cluster:admin/ai_assistant/sessions/read'
-  type: "cluster"
-  description: "Read any user's AI assistant conversations"
-
-plugin:wazuh/ai_assistant/sessions/write:
-  reserved: true
-  hidden: false
-  allowed_actions:
-    - 'cluster:admin/ai_assistant/sessions/write'
-  type: "cluster"
-  description: "Create, update or delete any user's AI assistant conversations"
-
 plugin:wazuh/ai_assistant/settings/read:
   reserved: true
   hidden: false

--- a/distribution/src/config/security/internal_users.wazuh.yml
+++ b/distribution/src/config/security/internal_users.wazuh.yml
@@ -15,7 +15,8 @@ wazuh-admin:
   # The hash is the hash of the password "wazuh-admin"
   hash: "$2y$12$of2izMMGqP3x4WWtijoq2.MtM1VgpoDc4RgP8AAQD/8tEbo1ftxru"
   reserved: true
-  backend_roles: []
+  backend_roles:
+    - "wazuh-admin"
   description: "Wazuh Administrator user with read access to Wazuh indexes, write access to Wazuh settings, Content Manager management endpoints, and full access to Security Analytics plugin endpoints."
 
 wazuh-demo:

--- a/distribution/src/config/security/internal_users.wazuh.yml
+++ b/distribution/src/config/security/internal_users.wazuh.yml
@@ -15,8 +15,7 @@ wazuh-admin:
   # The hash is the hash of the password "wazuh-admin"
   hash: "$2y$12$of2izMMGqP3x4WWtijoq2.MtM1VgpoDc4RgP8AAQD/8tEbo1ftxru"
   reserved: true
-  backend_roles:
-    - "wazuh-admin"
+  backend_roles: []
   description: "Wazuh Administrator user with read access to Wazuh indexes, write access to Wazuh settings, Content Manager management endpoints, and full access to Security Analytics plugin endpoints."
 
 wazuh-demo:

--- a/distribution/src/config/security/roles.wazuh.yml
+++ b/distribution/src/config/security/roles.wazuh.yml
@@ -42,9 +42,6 @@ wazuh_admin:
     - 'cluster_monitor'
     # Wazuh settings (setup plugin)
     - 'plugin:wazuh/settings/write'
-    # AI assistant sessions (setup plugin)
-    - 'plugin:wazuh/ai_assistant/sessions/read'
-    - 'plugin:wazuh/ai_assistant/sessions/write'
     # AI assistant settings (setup plugin)
     - 'plugin:wazuh/ai_assistant/settings/read'
     - 'plugin:wazuh/ai_assistant/settings/write'
@@ -144,8 +141,6 @@ wazuh_demo:
   cluster_permissions:
     - 'cluster_composite_ops'
     - 'cluster_monitor'
-    # AI assistant sessions (setup plugin)
-    - 'plugin:wazuh/ai_assistant/sessions/read'
     # AI assistant settings (setup plugin)
     - 'plugin:wazuh/ai_assistant/settings/read'
     # Content Manager
@@ -253,8 +248,6 @@ wazuh_readonly:
   cluster_permissions:
     - 'cluster_composite_ops'
     - 'cluster_monitor'
-    # AI assistant sessions (setup plugin)
-    - 'plugin:wazuh/ai_assistant/sessions/read'
     # AI assistant settings (setup plugin)
     - 'plugin:wazuh/ai_assistant/settings/read'
     - 'plugin:content_manager/subscription/get'

--- a/distribution/src/config/security/roles.wazuh.yml
+++ b/distribution/src/config/security/roles.wazuh.yml
@@ -428,11 +428,10 @@ wazuh_ai_assistant:
 #
 # OpenSearch Security has no deny rules, so the exclusion is expressed as a
 # Document Level Security query instead: every document is written with a
-# 'visible_to' field listing the backend roles allowed to read it (see the
-# 'wazuh-ai-assistant-settings-visibility' ingest pipeline installed by the
-# setup plugin, which is the index's default_pipeline), and ${user.roles} is
-# substituted with the reader's own backend roles. A user holding none of the
-# listed backend roles matches no document.
+# 'visible_to' field listing the backend roles allowed to read it (set by the
+# setup plugin's action filter, which intercepts every write to the index),
+# and ${user.roles} is substituted with the reader's own backend roles. A user
+# holding none of the listed backend roles matches no document.
 #
 # ${user.roles} expands to the BACKEND roles of the reader, not to its mapped
 # security roles, so the documents list 'admin' (the backend role behind

--- a/distribution/src/config/security/roles.wazuh.yml
+++ b/distribution/src/config/security/roles.wazuh.yml
@@ -426,25 +426,11 @@ wazuh_ai_assistant:
 # grant 'read' over the '*' index pattern (wazuh_demo, wazuh_readonly, any
 # custom role doing the same).
 #
-# OpenSearch Security has no deny rules, so the exclusion is expressed as a
-# Document Level Security query instead: every document is written with a
-# 'visible_to' field listing the backend roles allowed to read it (set by the
-# setup plugin's action filter, which intercepts every write to the index),
-# and ${user.roles} is substituted with the reader's own backend roles. A user
-# holding none of the listed backend roles matches no document.
-#
 # ${user.roles} expands to the BACKEND roles of the reader, not to its mapped
 # security roles, so the documents list 'admin' (the backend role behind
 # all_access and wazuh_admin) and 'wazuh-admin' (carried by the wazuh-admin
 # internal user, which is mapped by username). Any additional administrator
 # must hold one of those two backend roles to read the index.
-#
-# This role is mapped to every authenticated user on purpose: with
-# plugins.security.dfm_empty_overrides_all left at its default of false, a
-# DLS query defined for an index wins over any other role granting
-# unrestricted read on it, so mapping it everywhere is what makes the
-# restriction inescapable. The 'read' action granted here is harmless on its
-# own — it returns an empty result set unless the DLS query matches.
 # ---------------------------------------------------------------------#
 wazuh_ai_assistant_settings:
   reserved: true

--- a/distribution/src/config/security/roles.wazuh.yml
+++ b/distribution/src/config/security/roles.wazuh.yml
@@ -42,6 +42,12 @@ wazuh_admin:
     - 'cluster_monitor'
     # Wazuh settings (setup plugin)
     - 'plugin:wazuh/settings/write'
+    # AI assistant sessions (setup plugin)
+    - 'plugin:wazuh/ai_assistant/sessions/read'
+    - 'plugin:wazuh/ai_assistant/sessions/write'
+    # AI assistant settings (setup plugin)
+    - 'plugin:wazuh/ai_assistant/settings/read'
+    - 'plugin:wazuh/ai_assistant/settings/write'
     # Content Manager
     - 'plugin:content_manager/integration/*'
     - 'plugin:content_manager/decoder/*'
@@ -125,12 +131,6 @@ wazuh_admin:
         - 'delete'
         - 'indices:admin/exists'
         - 'indices:admin/refresh'
-    - index_patterns:
-        - '.wazuh-ai-assistant-settings'
-      allowed_actions:
-        - 'read'
-        - 'index'
-        - 'delete'
   tenant_permissions: []
   static: false
 
@@ -144,6 +144,10 @@ wazuh_demo:
   cluster_permissions:
     - 'cluster_composite_ops'
     - 'cluster_monitor'
+    # AI assistant sessions (setup plugin)
+    - 'plugin:wazuh/ai_assistant/sessions/read'
+    # AI assistant settings (setup plugin)
+    - 'plugin:wazuh/ai_assistant/settings/read'
     # Content Manager
     - 'plugin:content_manager/integration/*'
     - 'plugin:content_manager/decoder/*'
@@ -249,6 +253,10 @@ wazuh_readonly:
   cluster_permissions:
     - 'cluster_composite_ops'
     - 'cluster_monitor'
+    # AI assistant sessions (setup plugin)
+    - 'plugin:wazuh/ai_assistant/sessions/read'
+    # AI assistant settings (setup plugin)
+    - 'plugin:wazuh/ai_assistant/settings/read'
     - 'plugin:content_manager/subscription/get'
     - 'plugin:content_manager/logtest'
     - 'plugin:content_manager/logtest/*'
@@ -416,33 +424,5 @@ wazuh_ai_assistant:
       masked_fields: []
       allowed_actions:
         - 'write'
-  tenant_permissions: []
-  static: false
-
-# ---------------------------------------------------------------------#
-# wazuh-ai-assistant-settings: hides the AI provider credentials and the
-# assistant-wide settings from everyone but the administrators. The index
-# holds sensitive information, so it must stay unreadable for the roles that
-# grant 'read' over the '*' index pattern (wazuh_demo, wazuh_readonly, any
-# custom role doing the same).
-#
-# ${user.roles} expands to the BACKEND roles of the reader, not to its mapped
-# security roles, so the documents list 'admin' (the backend role behind
-# all_access and wazuh_admin) and 'wazuh-admin' (carried by the wazuh-admin
-# internal user, which is mapped by username). Any additional administrator
-# must hold one of those two backend roles to read the index.
-# ---------------------------------------------------------------------#
-wazuh_ai_assistant_settings:
-  reserved: true
-  hidden: false
-  cluster_permissions: []
-  index_permissions:
-    - index_patterns:
-        - '.wazuh-ai-assistant-settings'
-      dls: '{"terms": {"visible_to": [${user.roles}]}}'
-      fls: []
-      masked_fields: []
-      allowed_actions:
-        - 'read'
   tenant_permissions: []
   static: false

--- a/distribution/src/config/security/roles.wazuh.yml
+++ b/distribution/src/config/security/roles.wazuh.yml
@@ -125,6 +125,12 @@ wazuh_admin:
         - 'delete'
         - 'indices:admin/exists'
         - 'indices:admin/refresh'
+    - index_patterns:
+        - '.wazuh-ai-assistant-settings'
+      allowed_actions:
+        - 'read'
+        - 'index'
+        - 'delete'
   tenant_permissions: []
   static: false
 
@@ -379,5 +385,79 @@ wazuh_manager:
         - 'wazuh-threatintel-*'
       allowed_actions:
         - 'manage_point_in_time'
+  tenant_permissions: []
+  static: false
+
+# ---------------------------------------------------------------------#
+# wazuh-ai-assistant: grants every authenticated user access to their own
+# AI assistant conversations, and only to those. Reads are restricted with
+# Document Level Security parameter substitution: ${user.name} is replaced
+# with the name of the authenticated user, so only the documents whose
+# 'user' field matches it are visible.
+# ---------------------------------------------------------------------#
+wazuh_ai_assistant:
+  reserved: true
+  hidden: false
+  cluster_permissions: []
+  index_permissions:
+    - index_patterns:
+        - 'wazuh-ai-assistant-sessions*'
+        - '.ds-wazuh-ai-assistant-sessions-*'
+      dls: '{"term": {"user": "${user.name}"}}'
+      fls: []
+      masked_fields: []
+      allowed_actions:
+        - 'read'
+    - index_patterns:
+        - 'wazuh-ai-assistant-sessions*'
+        - '.ds-wazuh-ai-assistant-sessions-*'
+      dls: ''
+      fls: []
+      masked_fields: []
+      allowed_actions:
+        - 'write'
+  tenant_permissions: []
+  static: false
+
+# ---------------------------------------------------------------------#
+# wazuh-ai-assistant-settings: hides the AI provider credentials and the
+# assistant-wide settings from everyone but the administrators. The index
+# holds sensitive information, so it must stay unreadable for the roles that
+# grant 'read' over the '*' index pattern (wazuh_demo, wazuh_readonly, any
+# custom role doing the same).
+#
+# OpenSearch Security has no deny rules, so the exclusion is expressed as a
+# Document Level Security query instead: every document is written with a
+# 'visible_to' field listing the backend roles allowed to read it (see the
+# 'wazuh-ai-assistant-settings-visibility' ingest pipeline installed by the
+# setup plugin, which is the index's default_pipeline), and ${user.roles} is
+# substituted with the reader's own backend roles. A user holding none of the
+# listed backend roles matches no document.
+#
+# ${user.roles} expands to the BACKEND roles of the reader, not to its mapped
+# security roles, so the documents list 'admin' (the backend role behind
+# all_access and wazuh_admin) and 'wazuh-admin' (carried by the wazuh-admin
+# internal user, which is mapped by username). Any additional administrator
+# must hold one of those two backend roles to read the index.
+#
+# This role is mapped to every authenticated user on purpose: with
+# plugins.security.dfm_empty_overrides_all left at its default of false, a
+# DLS query defined for an index wins over any other role granting
+# unrestricted read on it, so mapping it everywhere is what makes the
+# restriction inescapable. The 'read' action granted here is harmless on its
+# own — it returns an empty result set unless the DLS query matches.
+# ---------------------------------------------------------------------#
+wazuh_ai_assistant_settings:
+  reserved: true
+  hidden: false
+  cluster_permissions: []
+  index_permissions:
+    - index_patterns:
+        - '.wazuh-ai-assistant-settings'
+      dls: '{"terms": {"visible_to": [${user.roles}]}}'
+      fls: []
+      masked_fields: []
+      allowed_actions:
+        - 'read'
   tenant_permissions: []
   static: false

--- a/distribution/src/config/security/roles_mapping.wazuh.yml
+++ b/distribution/src/config/security/roles_mapping.wazuh.yml
@@ -36,3 +36,21 @@ wazuh_manager:
   hidden: false
   users:
     - "wazuh-manager"
+
+# Mapped to every authenticated user: the DLS query in the role scopes each
+# user down to their own AI assistant conversations.
+wazuh_ai_assistant:
+  reserved: true
+  hidden: false
+  users:
+    - "*"
+
+# Mapped to every authenticated user so that its DLS query is attached to
+# '.wazuh-ai-assistant-settings' for all of them, including the holders of
+# roles that grant 'read' over '*'. Only the holders of the backend roles
+# listed in each document's 'visible_to' field get to see it.
+wazuh_ai_assistant_settings:
+  reserved: true
+  hidden: false
+  users:
+    - "*"

--- a/distribution/src/config/security/roles_mapping.wazuh.yml
+++ b/distribution/src/config/security/roles_mapping.wazuh.yml
@@ -44,13 +44,3 @@ wazuh_ai_assistant:
   hidden: false
   users:
     - "*"
-
-# Mapped to every authenticated user so that its DLS query is attached to
-# '.wazuh-ai-assistant-settings' for all of them, including the holders of
-# roles that grant 'read' over '*'. Only the holders of the backend roles
-# listed in each document's 'visible_to' field get to see it.
-wazuh_ai_assistant_settings:
-  reserved: true
-  hidden: false
-  users:
-    - "*"


### PR DESCRIPTION
## Description

Companion PR to the setup-plugin changes for AI assistant support. The indices/documents themselves are managed by the setup and content-manager plugins; this PR ships the security configuration that gates them, which lives in this repository:

- **`wazuh_ai_assistant`**: default role, mapped to every authenticated user, granting access to the `wazuh-ai-assistant-sessions` data stream restricted with DLS parameter substitution: each user reads only the conversations whose `user` field matches `${user.name}`.
- New cluster permissions `plugin:wazuh/ai_assistant/sessions/{read,write}` and `plugin:wazuh/ai_assistant/settings/{read,write}`, gating a privileged admin API instead of a DLS query.

Related to https://github.com/wazuh/wazuh-indexer-plugins/issues/1422

## Proposed Changes

**New cluster permissions**

**New roles**

- New `wazuh_ai_assistant` role, used for the DLS
- `wazuh_admin` gets `plugin:wazuh/ai_assistant/*` cluster permissions (read + write, sessions + settings).
- `wazuh_demo` and `wazuh_readonly`have read cluster permissions: (`.../sessions/read`, `.../settings/read`).

### Results and Evidence

Validation in https://github.com/wazuh/wazuh-indexer-plugins/issues/1422#issuecomment-5267114411

Permission matrix:

| User | `GET settings`/`GET providers` | `PUT`/`POST`/`DELETE` |
| --- | --- | --- |
| `admin` (superuser) | 200 | 200 |
| `wazuh-demo` | 200 | 403 |
| `wazuh-readonly` | 200 | 403 |
| `wazuh-manager` | 403 | 403 |

### Artifacts Affected

- Security configuration shipped in the packages (`action_groups.yml`, `roles.yml`, `roles_mapping.yml` fragments)

### Configuration Changes

| Role | Change |
| --- | --- |
| `wazuh_ai_assistant` | **new**, mapped to all users, DLS-restricted read on `wazuh-ai-assistant-sessions*` |
| `wazuh_admin` | `plugin:wazuh/ai_assistant/{sessions,settings}/{read,write}` |
| `wazuh_demo`, `wazuh_readonly` | `plugin:wazuh/ai_assistant/{sessions,settings}/read` |

### Documentation Updates

In https://github.com/wazuh/wazuh-indexer-plugins/pull/1424

### Tests Introduced

NA

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality — live validation here, automated tests in the companion PR
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes (companion PR)
- [x] Meets requirements and/or definition of done
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied