### PR TITLE
Report skipped bumps in the repository bumper workflow

### DIFF
--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -188,10 +188,14 @@ jobs:
           PR_NUMBER=$(gh pr list --head "$BUMP_BRANCH" --base "${{ github.ref_name }}" --state merged --json number --jq '.[0].number')
 
           if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" == "null" ]; then
-            echo "Error: The original PR for the bump was not found"
+            echo "The original PR for the bump was not found"
             echo "Searching merged PR from: $BUMP_BRANCH to ${{ github.ref_name }}"
-            exit 1
+            echo "pr_found=false" >> $GITHUB_OUTPUT
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            exit 0
           fi
+
+          echo "pr_found=true" >> $GITHUB_OUTPUT
 
           echo "Original PR found: #$PR_NUMBER"
 
@@ -236,6 +240,17 @@ jobs:
         run: |
           # Any checks for the PR are bypassed since the branch is expected to be functional
           gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --squash --admin
+
+      - name: "Result: original bump pull request not found"
+        if: inputs.revert == true && steps.revert_step.outputs.pr_found == 'false'
+        run: echo "There is no original bump pull request to revert, nothing to do."
+
+      - name: "Result: no changes to commit"
+        if: >-
+          (inputs.revert != true && steps.check_changes.outputs.has_changes == 'false') ||
+          (inputs.revert == true && steps.revert_step.outputs.pr_found == 'true' &&
+          steps.revert_step.outputs.has_changes == 'false')
+        run: echo "The bump produced no changes, no pull request was created."
 
       - name: Show logs
         if: inputs.revert != true


### PR DESCRIPTION
## Description

The repository bumper workflow fails with a `failure` conclusion in two harmless no-op situations, preventing the release orchestrator in `wazuh-qa-automation` from distinguishing between actual failures and runs that simply had nothing to do.

Closes #1808

## Proposed Changes

- Replace `exit 1` with `exit 0` and output variables (`pr_found`, `has_changes`) in the `Revert references (Revert)` step when the original bump PR is not found.
- Add two `Result:` reporting steps with names matched by the orchestrator:
  - `"Result: original bump pull request not found"` — executed on revert when no original bump PR exists.
  - `"Result: no changes to commit"` — executed when a bump or revert produces no changes.

### Results and Evidence

Four workflow runs on a test branch validating the scenarios described in the issue:

1. [**Revert with no original bump PR**](https://github.com/wazuh/wazuh-indexer/actions/runs/31490491168) — run ends as `success`, `Result: original bump pull request not found` is executed, Push/Create PR/Merge are skipped.
2. [**Bump with no changes**](https://github.com/wazuh/wazuh-indexer/actions/runs/31490633636) — run ends as `success`, `Result: no changes to commit` is executed, no PR created.
3. [**Normal bump**](https://github.com/wazuh/wazuh-indexer/actions/runs/31490504333) — PR created and merged, neither Result step executed.
4. [**Normal revert**](https://github.com/wazuh/wazuh-indexer/actions/runs/31490647526) — revert PR created and merged, neither Result step executed.

### Artifacts Affected

- `.github/workflows/5_bumper_repository.yml`

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

No automated tests. Validation is done via manual workflow runs as described above.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
