### PR TITLE
Delete extra DLS config

### DIFF
--- a/distribution/src/config/security/roles.wazuh.yml
+++ b/distribution/src/config/security/roles.wazuh.yml
@@ -418,7 +418,6 @@ wazuh_ai_assistant:
     - index_patterns:
         - 'wazuh-ai-assistant-sessions*'
         - '.ds-wazuh-ai-assistant-sessions-*'
-      dls: ''
       fls: []
       masked_fields: []
       allowed_actions:


### PR DESCRIPTION
## Description

This PR deletes the extra `dls: ''` block since it was creating some noise in the logs, and it was not doing anything

## Proposed Changes

Delete extra config block

### Results and Evidence

Log is not appearing after the changes:
```console 
root@idxr-node1:/home/vagrant# grep CompiledRoles /var/log/wazuh-indexer/wazuh-cluster.log 
root@idxr-node1:/home/vagrant# 

```

### Artifacts Affected

Roles

### Configuration Changes

NA

### Documentation Updates

NA

### Tests Introduced

NA

## Review Checklist

<!--
List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
- [ ] ...
