### PR TITLE
Upload artifacts to internal CI S3 bucket

### DIFF
--- a/.github/workflows/4_builderpackage_indexer.yml
+++ b/.github/workflows/4_builderpackage_indexer.yml
@@ -2,6 +2,7 @@ run-name: Build ${{ inputs.distribution }} Wazuh Indexer on ${{ inputs.architect
 name: Build packages (on demand)
 
 permissions:
+  id-token: write
   contents: read
 
 # This workflow runs when any of the following occur:

--- a/.github/workflows/4_builderpackage_indexer.yml
+++ b/.github/workflows/4_builderpackage_indexer.yml
@@ -68,6 +68,12 @@ on:
         type: string
         required: false
     secrets:
+      AWS_INDEXER_ACTIONS_ROLE:
+        required: true
+        description: "AWS IAM OIDC role for S3 and infrastructure access"
+      CI_INTERNAL_S3_BUCKET:
+        required: true
+        description: "Internal S3 bucket URI used to stage build artifacts"
       CI_AWS_REGION:
         required: true
         description: "AWS region for the final package upload"
@@ -77,6 +83,10 @@ on:
       CI_INTERNAL_DEVELOPMENT_BUCKET_USER_SECRET_KEY:
         required: true
         description: "AWS user secret key for the final package upload"
+
+env:
+  CI_ARTIFACTS_REPO: wazuh-indexer
+  CI_ARTIFACTS_WORKFLOW: 4_builderpackage_indexer
 
 # ==========================
 # Bibliography
@@ -218,3 +228,25 @@ jobs:
           aws s3 cp "$src" "$dest"
           s3uri="${dest}${{ steps.package.outputs.name }}.sha512"
           echo "::notice::S3 sha512 URI: ${s3uri}"
+
+      - name: Set up AWS CLI
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_INDEXER_ACTIONS_ROLE }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+
+      - name: Upload package to CI internal bucket
+        if: ${{ inputs.upload }}
+        run: |
+          dest="${{ secrets.CI_INTERNAL_S3_BUCKET }}/${{ env.CI_ARTIFACTS_REPO }}/${{ env.CI_ARTIFACTS_WORKFLOW }}/${{ github.run_id }}/"
+
+          aws s3 cp "artifacts/dist/${{ steps.package.outputs.name }}" "$dest"
+          echo "::notice::CI internal S3 URI: ${dest}${{ steps.package.outputs.name }}"
+
+      - name: Upload checksum to CI internal bucket
+        if: ${{ inputs.upload && inputs.checksum }}
+        run: |
+          dest="${{ secrets.CI_INTERNAL_S3_BUCKET }}/${{ env.CI_ARTIFACTS_REPO }}/${{ env.CI_ARTIFACTS_WORKFLOW }}/${{ github.run_id }}/"
+
+          aws s3 cp "artifacts/dist/${{ steps.package.outputs.name }}.sha512" "$dest"
+          echo "::notice::CI internal S3 sha512 URI: ${dest}${{ steps.package.outputs.name }}.sha512"

--- a/.github/workflows/4_builderpackage_indexer_on_push.yml
+++ b/.github/workflows/4_builderpackage_indexer_on_push.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   call-build-workflow:
     permissions:
+      id-token: write
       actions: read
     uses: ./.github/workflows/4_builderpackage_indexer.yml
     secrets: inherit


### PR DESCRIPTION
## Description

This pull requests add 3 missing job steps to upload generated artifacts to the internal S3 bucket, used for CI.

- Step 1: set up AWS credentials.
- Step 2: upload wazuh-indexer package.
- Step 3: upload package's checksum.

Missing environment variables and secrets were also declared.

## Proposed Changes

- Add missing Upload
- Upgrade versions

### Results and Evidence

Workflow run: https://github.com/wazuh/wazuh-indexer/actions/runs/32344398236

### Artifacts Affected

Builder Workflow

### Configuration Changes

NA

### Documentation Updates

NA

### Tests Introduced

NA

## Review Checklist

<!--
List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
- [ ] ...
