### PR TITLE
Add missing permission to dashboard_server role

### DIFF
--- a/distribution/src/config/security/roles.wazuh.yml
+++ b/distribution/src/config/security/roles.wazuh.yml
@@ -27,6 +27,7 @@ dashboard_server:
         - 'wazuh-*'
       allowed_actions:
         - 'read'
+        - 'indices:admin/mappings/get'
   tenant_permissions: []
   static: false
 


### PR DESCRIPTION
## Description

Indexer security plugin denied to `kibanaserver` (role `dashboard_server`) the action `indices:admin/mappings/get` on the Wazuh 5.x data indices. The Wazuh Dashboard fetches `_mapping` on its index patterns at startup to build them, so every Dashboard start/restart raised a `security_exception`.

This PR fix the problem by granting `indices:admin/mappings/get` to `dashboard_server` on `wazuh-*`.

Closes #1844 

## Proposed Changes

- Add `indices:admin/mappings/get` to the `dashboard_server` role

### Results and Evidence

Validated on a nightly AIO

| Pattern | Before | After |
| --- | --- | --- |
| `wazuh-states-inventory-packages*` | 403 | 200 |
| `wazuh-states-vulnerabilities*` | 403 | 200 |
| `wazuh-events-v5*` | 403 | 200 |


### Artifacts Affected

- Roles

### Configuration Changes

| Role | Index pattern | Before | After |
| --- | --- | --- | --- |
| `dashboard_server` | `wazuh-*` | `read` | `read`, `indices:admin/mappings/get` |


### Documentation Updates

NA

### Tests Introduced

NA

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)