### PR TITLE
Grant the action names the logtest sub-endpoints actually register

### DIFF
--- a/distribution/src/config/security/action_groups.wazuh.yml
+++ b/distribution/src/config/security/action_groups.wazuh.yml
@@ -210,6 +210,7 @@ plugin:content_manager/logtest:
   hidden: false
   allowed_actions:
     - 'cluster:monitor/content_manager/logtest'
+    - 'cluster:admin/wazuh/securityanalytics/rules/evaluate'
   type: "cluster"
   description: "Run a log test"
 
@@ -218,6 +219,7 @@ plugin:content_manager/logtest/detection:
   hidden: false
   allowed_actions:
     - 'cluster:monitor/content_manager/logtest/detection'
+    - 'cluster:admin/wazuh/securityanalytics/rules/evaluate'
   type: "cluster"
   description: "Run a logtest detection"
 

--- a/distribution/src/config/security/action_groups.wazuh.yml
+++ b/distribution/src/config/security/action_groups.wazuh.yml
@@ -217,7 +217,7 @@ plugin:content_manager/logtest/detection:
   reserved: true
   hidden: false
   allowed_actions:
-    - 'cluster:monitor/content_manager/logtest_detection'
+    - 'cluster:monitor/content_manager/logtest/detection'
   type: "cluster"
   description: "Run a logtest detection"
 
@@ -225,7 +225,7 @@ plugin:content_manager/logtest/normalization:
   reserved: true
   hidden: false
   allowed_actions:
-    - 'cluster:monitor/content_manager/logtest_normalization'
+    - 'cluster:monitor/content_manager/logtest/normalization'
   type: "cluster"
   description: "Run a logtest normalization"
 


### PR DESCRIPTION
## Description

Two defects in the logtest action groups, both of which make them unusable for building a role.

The `detection` and `normalization` action groups granted an action name the plugin never registers:
an underscore where the plugin uses a slash. Any role built from them was refused with 403.

And once that is fixed, `/logtest/detection` still fails, because evaluating the rules goes through
`cluster:admin/wazuh/securityanalytics/rules/evaluate` and no action group grants it. That action is
written directly into three roles in `roles.wazuh.yml`, so the shipped roles work while a custom one
cannot.

Closes #1845

## Proposed Changes

In `distribution/src/config/security/action_groups.wazuh.yml`:

```diff
 plugin:content_manager/logtest:
   allowed_actions:
     - 'cluster:monitor/content_manager/logtest'
+    - 'cluster:admin/wazuh/securityanalytics/rules/evaluate'

 plugin:content_manager/logtest/detection:
   allowed_actions:
-    - 'cluster:monitor/content_manager/logtest_detection'
+    - 'cluster:monitor/content_manager/logtest/detection'
+    - 'cluster:admin/wazuh/securityanalytics/rules/evaluate'

 plugin:content_manager/logtest/normalization:
   allowed_actions:
-    - 'cluster:monitor/content_manager/logtest_normalization'
+    - 'cluster:monitor/content_manager/logtest/normalization'
```

`/logtest` gets the evaluate action too because it also runs detection when an `integration` is given.
`normalization` does not, since it never evaluates rules.

### Results and Evidence

Validated on an AIO with a least-privilege role holding only the three logtest action groups, and a
user mapped to it. Before the fix, `POST /logtest` worked and both sub-endpoints were refused. After
it, the three return a real result.

<details>
<summary>The role used</summary>

```json
{
  "cluster_permissions": [
    "plugin:content_manager/logtest",
    "plugin:content_manager/logtest/detection",
    "plugin:content_manager/logtest/normalization"
  ],
  "index_permissions": [
    {
      "index_patterns": ["wazuh-threatintel-*"],
      "allowed_actions": ["read"]
    }
  ]
}
```

No action name is written by hand: every cluster permission comes from an action group.

</details>

<details>
<summary>Before: 403 on both sub-endpoints</summary>

Each 403 names the action the security plugin looked for, with a slash, which is not the one the
action group granted:

| Request | Result |
| --- | --- |
| `POST /logtest` | `200` |
| `POST /logtest/normalization` | `403` `no permissions for [cluster:monitor/content_manager/logtest/normalization]` |
| `POST /logtest/detection` | `403` `no permissions for [cluster:monitor/content_manager/logtest/detection]` |

</details>

<details>
<summary>After: the action group grants the registered name</summary>

```
GET _plugins/_security/api/actiongroups/plugin%3Acontent_manager%2Flogtest%2Fdetection
```

```json
{
  "plugin:content_manager/logtest/detection": {
    "reserved": true,
    "hidden": false,
    "allowed_actions": [
      "cluster:monitor/content_manager/logtest/detection",
      "cluster:admin/wazuh/securityanalytics/rules/evaluate"
    ],
    "type": "cluster",
    "description": "Run a logtest detection"
  }
}
```

</details>

<details>
<summary>After: normalization parses the event</summary>

```
POST _plugins/_content_manager/logtest/normalization
```

```json
{
  "space": "standard",
  "queue": 1,
  "location": "/var/log/syslog",
  "trace_level": "NONE",
  "event": "Aug 25 10:15:22 host sshd[1234]: Accepted password for admin from 10.0.2.15 port 55211 ssh2"
}
```

The raw event, parsed by the `linux` integration's decoders:

```json
{
  "message": {
    "output": {
      "event": {
        "action": "logged-in",
        "outcome": "success",
        "dataset": "system-auth",
        "category": ["authentication", "session"]
      },
      "user": { "name": "admin" },
      "source": { "ip": "10.0.2.15", "port": 55211 },
      "process": { "name": "sshd", "pid": 1234 },
      "wazuh": {
        "integration": {
          "name": "linux",
          "decoders": [
            "decoder/core-wazuh-message/0",
            "decoder/syslog/0",
            "decoder/system-auth/0"
          ]
        }
      }
    },
    "validation": { "valid": true, "errors": [] }
  },
  "status": 200
}
```

</details>

<details>
<summary>After: detection evaluates the rules</summary>

```
POST _plugins/_content_manager/logtest/detection
```

```json
{
  "space": "standard",
  "integration": "3709ad37-5c45-48aa-8abe-2d7645fb71ac",
  "input": {
    "event": {
      "action": "logged-in",
      "outcome": "success",
      "dataset": "system-auth",
      "category": ["authentication", "session"]
    },
    "user": { "name": "admin" },
    "source": { "ip": "10.0.2.15", "port": 55211 },
    "process": { "name": "sshd", "pid": 1234 }
  }
}
```

```json
{
  "message": {
    "status": "success",
    "rules_evaluated": 6,
    "rules_matched": 0,
    "matches": []
  },
  "status": 200
}
```

</details>

#### One requirement stays with the role author

`/logtest` and `/logtest/detection` look up the integration and the rule bodies in the content indices
using the caller's identity, so the role also needs `read` on `wazuh-threatintel-*`, as in the role
above. An action group cannot carry that, since index permissions are bound to the patterns a role
declares.

### Artifacts Affected

`distribution/src/config/security/action_groups.wazuh.yml`

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

None.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
