### PR TITLE
Unmap the own_index demo role to every user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@
 - Default zstd index codec [(#1271)](https://github.com/wazuh/wazuh-indexer-plugins/issues/1271)
 - Update the Content Manager OpenAPI (`openapi.yml`) to match the current API [(#1353)](https://github.com/wazuh/wazuh-indexer-plugins/issues/1353)
 - [BUG] wazuh-readonly missing promotion and mapping permissions [(#1752)](https://github.com/wazuh/wazuh-indexer/issues/1752)
+- [BUG] The `own_index` demo role is mapped to every user [(#6030)](https://github.com/wazuh/internal-devel-requests/issues/6030)
 
 ## Prior versions
 - []()

--- a/build-scripts/assemble.sh
+++ b/build-scripts/assemble.sh
@@ -175,6 +175,28 @@ function parse_args() {
 }
 
 # ====
+# Remove a top-level entry from a security configuration file
+#
+# The entry spans from its key down to (but not including) the next line that
+# starts at column zero, which is either the next key or a comment.
+# ====
+function remove_security_entry() {
+    local key="$1"
+    local file="$2"
+
+    awk -v key="^${key}:" '
+        $0 ~ key { skip = 1; next }
+        /^[^[:space:]]/ { skip = 0 }
+        !skip
+    ' "$file" >"${file}.tmp" && mv "${file}.tmp" "$file"
+
+    if grep -q "^${key}:" "$file"; then
+        echo "ERROR: failed to remove the '${key}' entry from ${file}"
+        exit 1
+    fi
+}
+
+# ====
 # Set up configuration files
 # ====
 function add_configuration_files() {
@@ -183,7 +205,15 @@ function add_configuration_files() {
     cat "$PATH_CONF/security/roles_mapping.wazuh.yml" >>"$PATH_CONF/opensearch-security/roles_mapping.yml"
     cat "$PATH_CONF/security/internal_users.wazuh.yml" >>"$PATH_CONF/opensearch-security/internal_users.yml"
     cat "$PATH_CONF/security/action_groups.wazuh.yml" >>"$PATH_CONF/opensearch-security/action_groups.yml"
-    
+
+    # The demo configuration shipped by the security plugin maps the built-in
+    # "own_index" role to every user ("*"). That role grants indices_all over an
+    # index named after the user, so any account -- read-only ones included --
+    # can create and fill an index, change its settings and attach aliases that
+    # fall inside the product's own index patterns. A security cluster has no
+    # use for per-user scratch indices, so drop the mapping.
+    remove_security_entry "own_index" "$PATH_CONF/opensearch-security/roles_mapping.yml"
+
     # Disable multi-tenancy
     sed -i 's/#kibana:/kibana:/' "$PATH_CONF/opensearch-security/config.yml"
     sed -i 's/#multitenancy_enabled: true/  multitenancy_enabled: false/' "$PATH_CONF/opensearch-security/config.yml"


### PR DESCRIPTION
## Description

The demo configuration shipped by the security plugin maps the built-in `own_index`
role to `users: ["*"]`. Wazuh appends its own mappings onto that file during
packaging and never removes it, so every account in the image — `wazuh-readonly`
included — ends up with `indices_all` over an index named after itself.

That grant is enough to create and fill an index with no quota, change its settings
until the replicas cannot be allocated and the cluster goes yellow, attach an alias
that falls inside the dashboard's own index patterns so the product's views return
attacker-controlled documents, and take `number_of_shards` up to
`cluster.max_shards_per_node` so no index can be created at all.

## Proposed Changes

A security cluster has no use case for per-user scratch indices, so the mapping is
dropped during packaging.

- `build-scripts/assemble.sh`: new `remove_security_entry()` helper that deletes a
  top-level entry from a security YAML, called on `own_index` right after the Wazuh
  configuration is appended. The removal is guarded — if the entry survives, the
  build fails rather than shipping the grant again.
- `CHANGELOG.md`: entry under `### Fixed`.

Two files, no source changes.

### Results and Evidence

Reproduced and verified on a clean `docker-env` cluster (wiped volume both times).
Before: the packaged image as built today. After: the same image with the patched
packaging step applied.

`wazuh-readonly` effective roles:

```
before   "roles" : [ "own_index", "wazuh_readonly" ]
after    "roles" : [ "wazuh_readonly" ]
```

| # | Vector | Before | After |
|---|---|---|---|
| 1 | `PUT /wazuh-readonly` | `200 acknowledged` | `403 indices:admin/create` |
| 1 | `POST /wazuh-readonly/_doc` | `201 created` | `403 indices:data/write/index` |
| 2 | `number_of_replicas: 5` | `200` — cluster **yellow**, 5 unassigned | `403 indices:admin/settings/update` |
| 3 | alias `wazuh-states-inventory-processes-forged` | `200` — doc visible under the product pattern | `403 indices:admin/aliases` |
| 4 | index with `number_of_shards: 940` | `200` — budget full, admin gets `validation_exception` | `403 indices:admin/create` |
| 5 | `readall` / `kibanaro` / `anomalyadmin` / `logstash` | `200` | `403` |

Point 3 before the fix, queried as `admin` against the product's own pattern:

```
GET /wazuh-states-inventory-processes*/_search
  "hits" : { "total" : { "value" : 1 } ,
             "hits" : [ { "_index" : "wazuh-readonly", "_source" : { "x" : "hello" } } ] }
```

Point 4 before the fix:

```
PUT /product-index   (as admin)
  "type" : "validation_exception",
  "reason" : "Validation Failed: 1: this action would add [1] total LOCAL_ONLY shards,
              but this cluster currently has [1002]/[1000] maximum LOCAL_ONLY shards open;"
```

After the fix the cluster stays **green** at 60 shards, and `admin` creates
`product-index` normally.

Regression check — nothing else moved:

```
wazuh-readonly  GET /_cat/indices        200
wazuh-readonly  GET /wazuh-*/_search     200
wazuh-readonly  GET /_cluster/health     200
wazuh-admin / wazuh-demo / wazuh-manager authinfo   200
```

The resulting `roles_mapping.yml` still parses and keeps every other mapping —
only the `own_index` block is removed:

```
_meta, all_access, logstash, kibana_user, readall, manage_snapshots,
kibana_server, dashboard_server, wazuh_admin, wazuh_demo, wazuh_readonly,
wazuh_manager
```

Full logs: `~/wazuh/scripts/evidence-6030/` (`01`–`03` before, `04`–`06` after).

### Artifacts Affected

All `wazuh-indexer` packages (tar/deb/rpm). The change is in the packaging step, so
it only takes effect on newly built packages.

### Configuration Changes

`config/opensearch-security/roles_mapping.yml` no longer contains the `own_index`
entry. Nothing else in the file changes.

Existing installations are **not** fixed by upgrading alone: the mapping already
lives in the `.opendistro_security` index and has to be reloaded with
`securityadmin.sh` (or `indexer-security-init.sh`) against the new config.

### Documentation Updates

None. `own_index` is not documented as a Wazuh role.

### Tests Introduced

None automated. `remove_security_entry()` fails the build if the entry it was asked
to remove is still present, which covers the regression this PR is about. Manual
verification is in the evidence above.

## Notes for the reviewer

`snapshotrestore` can still create indices after this change. That grant is the
upstream **static** `manage_snapshots` role (`indices:admin/create` +
`indices:data/write/index` on `*`) reached through the `snapshotrestore` backend
role — not `own_index`. It belongs with the demo user database (BUG_057).

Two expectations from the issue are intentionally not coded here:

- alias creation inside the product patterns is no longer reachable by unprivileged
  accounts, since nothing grants them `indices:admin/aliases` — it falls out of this
  change rather than needing its own guard;
- logging when `cluster.max_shards_per_node` is reached is the same gap as BUG_061
  and is an OpenSearch-core concern, not a role-mapping one.

## Review Checklist

- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [ ] Correct labels applied
