### PR TITLE
Restrict roles permissions

### DIFF
--- a/distribution/src/config/security/roles.wazuh.yml
+++ b/distribution/src/config/security/roles.wazuh.yml
@@ -199,7 +199,6 @@ wazuh_demo:
     - 'cluster:admin/opendistro/ad/tasks/search'
     # Notifications (read)
     - 'cluster:admin/opensearch/notifications/channels/get'
-    - 'cluster:admin/opensearch/notifications/configs/get'
     - 'cluster:admin/opensearch/notifications/features'
     # Reporting (read + download)
     - 'cluster:admin/opendistro/reports/definition/get'
@@ -302,7 +301,6 @@ wazuh_readonly:
     - 'cluster:admin/opendistro/ad/tasks/search'
     # Notifications (read)
     - 'cluster:admin/opensearch/notifications/channels/get'
-    - 'cluster:admin/opensearch/notifications/configs/get'
     - 'cluster:admin/opensearch/notifications/features'
     # Reporting (read + download)
     - 'cluster:admin/opendistro/reports/definition/get'


### PR DESCRIPTION
## Description

This PR fixes a permission error related to `wazuh-readonly` and `wazuh-demo` users since they were allowed to check the complete notifications' config, now the administrators will need to assign the permissions to the users if their environment necessities align with it

## Proposed Changes

Delete roles from `wazuh-readonly` and `wazuh-demo`

### Results and Evidence

``` console
root@default:/home/vagrant# curl -sk -u wazuh-readonly:wazuh-readonly 'https://localhost:9200/_plugins/_notifications/configs/jira'
{"error":{"root_cause":[{"type":"security_exception","reason":"no permissions for [cluster:admin/opensearch/notifications/configs/get] and User [name=wazuh-readonly, backend_roles=[], requestedTenant=null]"}],"type":"security_exception","reason":"no permissions for [cluster:admin/opensearch/notifications/configs/get] and User [name=wazuh-readonly, backend_roles=[], requestedTenant=null]"},"status":403}
```

### Artifacts Affected

Roles

### Configuration Changes

Now `wazuh-readonly` and `wazuh-demo` can't access the configurations of the notifications channels

### Documentation Updates

NA

### Tests Introduced

NA

## Review Checklist


- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
- [ ] ...
