### PR TITLE
Add request-size limit management

### DIFF
--- a/server/src/main/java/org/opensearch/rest/RestController.java
+++ b/server/src/main/java/org/opensearch/rest/RestController.java
@@ -70,9 +70,12 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
@@ -87,6 +90,7 @@ import static org.opensearch.core.rest.RestStatus.INTERNAL_SERVER_ERROR;
 import static org.opensearch.core.rest.RestStatus.METHOD_NOT_ALLOWED;
 import static org.opensearch.core.rest.RestStatus.NOT_ACCEPTABLE;
 import static org.opensearch.core.rest.RestStatus.OK;
+import static org.opensearch.core.rest.RestStatus.REQUEST_ENTITY_TOO_LARGE;
 import static org.opensearch.rest.BytesRestResponse.TEXT_CONTENT_TYPE;
 
 /**
@@ -115,6 +119,16 @@ public class RestController implements HttpServerTransport.Dispatcher {
     }
 
     private final PathTrie<RestMethodHandlers> handlers = new PathTrie<>(RestUtils.REST_DECODER);
+
+    /**
+     * Maps a registered (possibly wrapped) handler instance to the original, unwrapped handler that
+     * declares a {@link RestHandler#maxContentLength()} limit. Populated at registration time, when
+     * the unwrapped handler is still visible; consulted at dispatch time — where only the wrapped
+     * handler is available — so a per-handler request-size limit survives handler wrapping (e.g. the
+     * security plugin's REST filter) instead of being masked by it. Only handlers that declare a limit
+     * are recorded, so the common no-limit path adds no lookup cost.
+     */
+    private final Map<RestHandler, RestHandler> contentLengthLimitedHandlers = new ConcurrentHashMap<>();
 
     private final UnaryOperator<RestHandler> handlerWrapper;
 
@@ -234,7 +248,13 @@ public class RestController implements HttpServerTransport.Dispatcher {
         if (handler instanceof BaseRestHandler baseRestHandler) {
             usageService.addRestHandler(baseRestHandler);
         }
-        registerHandlerNoWrap(method, path, handlerWrapper.apply(handler));
+        final RestHandler wrappedHandler = handlerWrapper.apply(handler);
+        // Record the unwrapped handler while it is still visible, keyed by the wrapped instance that
+        // dispatch will see, so a per-handler max content length survives handler wrapping.
+        if (handler.maxContentLength().isPresent()) {
+            contentLengthLimitedHandlers.put(wrappedHandler, handler);
+        }
+        registerHandlerNoWrap(method, path, wrappedHandler);
     }
 
     private void registerHandlerNoWrap(RestRequest.Method method, String path, RestHandler maybeWrappedHandler) {
@@ -328,6 +348,37 @@ public class RestController implements HttpServerTransport.Dispatcher {
 
     private void dispatchRequest(RestRequest request, RestChannel channel, RestHandler handler) throws Exception {
         final int contentLength = request.content().length();
+
+        // Enforce any per-handler request-size limit before the request is charged to the
+        // in-flight-requests circuit breaker (below) and before the handler runs, so an oversized body
+        // on this route cannot be turned into heap pressure or trip the shared breaker. The limit is
+        // read from the original (unwrapped) handler recorded at registration time.
+        final RestHandler limitSource = contentLengthLimitedHandlers.get(handler);
+        if (limitSource != null) {
+            final OptionalLong maxContentLength = limitSource.maxContentLength();
+            if (maxContentLength.isPresent() && contentLength > maxContentLength.getAsLong()) {
+                logger.warn(
+                    "Rejected oversized request for [{}]: {} bytes exceeds the per-handler limit of {} bytes.",
+                    request.path(),
+                    contentLength,
+                    maxContentLength.getAsLong()
+                );
+                channel.sendResponse(
+                    BytesRestResponse.createSimpleErrorResponse(
+                        channel,
+                        REQUEST_ENTITY_TOO_LARGE,
+                        String.format(
+                            Locale.ROOT,
+                            "Request body for [%s] exceeds the maximum allowed size of %d bytes.",
+                            request.path(),
+                            maxContentLength.getAsLong()
+                        )
+                    )
+                );
+                return;
+            }
+        }
+
         final MediaType mediaType = request.getMediaType();
         if (contentLength > 0) {
             if (mediaType == null) {

--- a/server/src/main/java/org/opensearch/rest/RestHandler.java
+++ b/server/src/main/java/org/opensearch/rest/RestHandler.java
@@ -40,6 +40,7 @@ import org.opensearch.transport.client.node.NodeClient;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.OptionalLong;
 import java.util.stream.Collectors;
 
 /**
@@ -61,6 +62,23 @@ public interface RestHandler {
 
     default boolean canTripCircuitBreaker() {
         return true;
+    }
+
+    /**
+     * The maximum allowed size, in bytes, of the request body this handler will accept. When present,
+     * {@link RestController} rejects a request whose content length exceeds this value with {@code 413
+     * REQUEST_ENTITY_TOO_LARGE} <em>before</em> the request is charged to the in-flight-requests
+     * circuit breaker and before {@link #handleRequest} runs, so an oversized body on this route
+     * cannot be turned into heap pressure. Return {@link OptionalLong#empty()} (the default) to apply
+     * no per-handler limit beyond the global {@code http.max_content_length}.
+     *
+     * <p>The value is read on every request, so a handler backed by a dynamic setting reflects setting
+     * changes without re-registration.
+     *
+     * @return the maximum request body size in bytes, or empty for no per-handler limit.
+     */
+    default OptionalLong maxContentLength() {
+        return OptionalLong.empty();
     }
 
     /**

--- a/server/src/test/java/org/opensearch/rest/RestControllerTests.java
+++ b/server/src/test/java/org/opensearch/rest/RestControllerTests.java
@@ -370,6 +370,59 @@ public class RestControllerTests extends OpenSearchTestCase {
         assertEquals(0, inFlightRequestsBreaker.getUsed());
     }
 
+    public void testDispatchRejectsOversizedRequestBeforeChargingBreaker() {
+        // A handler that caps its request body at 8 bytes.
+        restController.registerHandler(RestRequest.Method.GET, "/limited", new RestHandler() {
+            @Override
+            public void handleRequest(RestRequest request, RestChannel channel, NodeClient client) {
+                channel.sendResponse(new BytesRestResponse(RestStatus.OK, BytesRestResponse.TEXT_CONTENT_TYPE, BytesArray.EMPTY));
+            }
+
+            @Override
+            public java.util.OptionalLong maxContentLength() {
+                return java.util.OptionalLong.of(8L);
+            }
+        });
+
+        // Body larger than the handler limit (8) but well under the breaker limit, so any rejection is
+        // attributable to the size cap and not to the breaker.
+        String content = randomAlphaOfLength(64);
+        RestRequest request = testRestRequest("/limited", content, MediaTypeRegistry.JSON);
+        AssertingChannel channel = new AssertingChannel(request, true, RestStatus.REQUEST_ENTITY_TOO_LARGE);
+
+        restController.dispatchRequest(request, channel, client.threadPool().getThreadContext());
+
+        assertTrue(channel.getSendResponseCalled());
+        // The oversized request was rejected before the in-flight-requests breaker was ever charged.
+        assertEquals(0, inFlightRequestsBreaker.getTrippedCount());
+        assertEquals(0, inFlightRequestsBreaker.getUsed());
+    }
+
+    public void testDispatchAllowsRequestWithinHandlerContentLimit() {
+        restController.registerHandler(RestRequest.Method.GET, "/limited-ok", new RestHandler() {
+            @Override
+            public void handleRequest(RestRequest request, RestChannel channel, NodeClient client) {
+                channel.sendResponse(new BytesRestResponse(RestStatus.OK, BytesRestResponse.TEXT_CONTENT_TYPE, BytesArray.EMPTY));
+            }
+
+            @Override
+            public java.util.OptionalLong maxContentLength() {
+                return java.util.OptionalLong.of(1024L);
+            }
+        });
+
+        // Sized to the breaker limit so a within-cap request is not rejected by the breaker either.
+        String content = randomAlphaOfLength((int) Math.round(BREAKER_LIMIT.bytesAsInt() / inFlightRequestsBreaker.getOverhead()));
+        RestRequest request = testRestRequest("/limited-ok", content, MediaTypeRegistry.JSON);
+        AssertingChannel channel = new AssertingChannel(request, true, RestStatus.OK);
+
+        restController.dispatchRequest(request, channel, client.threadPool().getThreadContext());
+
+        assertTrue(channel.getSendResponseCalled());
+        assertEquals(0, inFlightRequestsBreaker.getTrippedCount());
+        assertEquals(0, inFlightRequestsBreaker.getUsed());
+    }
+
     public void testDispatchRequiresContentTypeForRequestsWithContent() {
         String content = randomAlphaOfLength((int) Math.round(BREAKER_LIMIT.getBytes() / inFlightRequestsBreaker.getOverhead()));
         RestRequest request = testRestRequest("/", content, null);


### PR DESCRIPTION
## Description

The `logtest` content-manager endpoints let a user POST large bodies that trip the parent circuit breaker, so users start receiving `429 circuit_breaking_exception`. The content-manager plugin can cap the body size, but a plugin/REST
handler runs too late to stop this: in `RestController.dispatchRequest` the request bytes are reserved against the `in_flight_requests` breaker before `handler.handleRequest` is ever called. So the size check has to live in the wazuh-indexer, ahead of that reservation

This PR adds a generic, opt-in `RestHandler.maxContentLength()` hook and enforces it in `RestController` before the in-flight-requests breaker charge

## Proposed Changes

- `RestHandler.maxContentLength()`: new `default` method returning `OptionalLong.empty()`. Handlers opt in by overriding it.
- `RestController`: Records each handler that declares a limit in a small map at registration
  time

This is additive and opt-in, it does not change behaviour for any other endpoint

## Results and Evidence

- Unit test worked as expected
- Live validation in the issue comment

## Artifacts Affected

- wazuh-indexer 

## Configuration Changes

- NA

## Documentation Updates

- NA

## Tests Introduced

- `RestControllerTests.testDispatchRejectsOversizedRequestBeforeChargingBreaker`
- `RestControllerTests.testDispatchAllowsRequestWithinHandlerContentLimit`

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
- [ ] ...
