### PR TITLE
Grant 'indices:admin/refresh' permissions to the 'wazuh_manager' role

### DIFF
--- a/.github/workflows/5_codequality_changelog.yml
+++ b/.github/workflows/5_codequality_changelog.yml
@@ -19,5 +19,5 @@ jobs:
       - uses: dangoslen/changelog-enforcer@v3
         id: verify-changelog
         with:
-          skipLabels: "autocut, skip-changelog"
+          skipLabels: "no-changelog"
           changeLogPath: "CHANGELOG.md"

--- a/distribution/src/config/security/roles.wazuh.yml
+++ b/distribution/src/config/security/roles.wazuh.yml
@@ -347,7 +347,7 @@ wazuh_readonly:
 # ---------------------------------------------------------------------#
 # wazuh-manager: service account. Reads CTI consumer state, active
 # responses and threat intelligence content; ingests events, metrics
-# and states; manages state documents (index + delete).
+# and states; manages state documents (index + delete + refresh).
 # ---------------------------------------------------------------------#
 wazuh_manager:
   reserved: true
@@ -374,18 +374,26 @@ wazuh_manager:
       allowed_actions:
         - 'read'
         - 'index'
+    # Agent removal opens a point in time over the target indices and then
+    # runs a _delete_by_query against it. A PIT pins the searcher as it is at
+    # creation time and never picks up later refreshes, so documents written
+    # inside the refresh interval would stay invisible to the deletion and
+    # survive it. 'indices:admin/refresh' lets the manager refresh each target
+    # index first; it is not implied by 'read', 'index' or 'delete'.
     - index_patterns:
         - 'wazuh-states-*'
       allowed_actions:
         - 'read'
         - 'index'
         - 'delete'
+        - 'indices:admin/refresh'
     - index_patterns:
         - 'wazuh-agent-*'
       allowed_actions:
         - 'read'
         - 'index'
         - 'delete'
+        - 'indices:admin/refresh'
     - index_patterns:
         - '.wazuh-threatintel-vulnerabilities*'
         - 'wazuh-threatintel-*'


### PR DESCRIPTION
## Description

Grant 'indices:admin/refresh' permissions to the 'wazuh_manager' role.

Closes https://github.com/wazuh/wazuh-indexer-plugins/issues/1513

## Proposed Changes

`roles.wazuh.yml`: grant 'indices:admin/refresh' permissions to the 'wazuh_manager' role

### Results and Evidence

None.

### Artifacts Affected

Packages

### Configuration Changes

`roles.yml`

### Documentation Updates

Applied in https://github.com/wazuh/wazuh-indexer-plugins/pull/1516.

### Tests Introduced

None

## Review Checklist

<!--
List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
- [ ] ...
