### PR TITLE
Remove the OpenSearch demo users and their role mappings

### DIFF
--- a/build-scripts/assemble.sh
+++ b/build-scripts/assemble.sh
@@ -179,10 +179,22 @@ function parse_args() {
 #
 # The entry spans from its key down to (but not including) the next line that
 # starts at column zero, which is either the next key or a comment.
+#
+# The entry is required to be there. Every call removes a grant we have decided
+# the product must not ship, so an entry that has already vanished is not a
+# no-op to shrug at: upstream renamed or restructured it, and the grant may now
+# live under a key this function no longer looks for. Fail the build instead of
+# silently producing a package that still carries it.
 # ====
 function remove_security_entry() {
     local key="$1"
     local file="$2"
+
+    if ! grep -q "^${key}:" "$file"; then
+        echo "ERROR: no '${key}' entry found in ${file}."
+        echo "       Upstream changed this file. Re-check where the grant went before releasing."
+        exit 1
+    fi
 
     awk -v key="^${key}:" '
         $0 ~ key { skip = 1; next }
@@ -213,6 +225,59 @@ function add_configuration_files() {
     # fall inside the product's own index patterns. A security cluster has no
     # use for per-user scratch indices, so drop the mapping.
     remove_security_entry "own_index" "$PATH_CONF/opensearch-security/roles_mapping.yml"
+
+    # That same demo configuration ships seven internal users, every one of them
+    # enabled with its password equal to its username. Only two have a job here:
+    # "admin", which the installer and the passwords tool expect, and
+    # "kibanaserver", the service account the dashboard authenticates with. The
+    # rest are upstream's demonstration accounts and are removed:
+    #
+    #   anomalyadmin    - anomaly_full_access, assigned directly on the account
+    #   kibanaro        - kibanauser + readall, i.e. write access to the saved
+    #                     objects (see the roles_mapping block below)
+    #   logstash        - create indices and write to logstash-* and *beat*
+    #   readall         - read every index in the cluster
+    #   snapshotrestore - manage_snapshots
+    #
+    for user in anomalyadmin kibanaro logstash readall snapshotrestore; do
+        remove_security_entry "$user" "$PATH_CONF/opensearch-security/internal_users.yml"
+    done
+
+    # Deleting the accounts is only half of it. Four of them held no privilege
+    # directly: they carried a backend role, and the mappings below are what
+    # turn that name into a role. A backend role comes from whatever
+    # authenticates the user -- an LDAP or AD group, a JWT claim -- so while
+    # these mappings stand, a directory group that merely happens to be named
+    # "readall" or "kibanauser" is granted the privilege with no account of
+    # ours involved and nobody assigning anything. Those names are the ones
+    # upstream's own documentation uses, so the coincidence is likely.
+    #
+    #   kibana_user      <- "kibanauser": delete, index and manage over
+    #                       .kibana*, that is, write access to the index
+    #                       patterns, visualizations and dashboards the product
+    #                       ships. Multi-tenancy is disabled a few lines down,
+    #                       so there is no per-user tenant for such a write to
+    #                       land in: it reaches what every analyst sees. None of
+    #                       the Wazuh personas needs this role -- they are all
+    #                       read-only over .kibana* (see roles.wazuh.yml) and
+    #                       saved objects are managed by admin.
+    #   readall          <- "readall": read every index in the cluster
+    #   logstash         <- "logstash": create indices, write logstash-*/*beat*
+    #   manage_snapshots <- "snapshotrestore": snapshot and restore
+    #
+    # "all_access" and "kibana_server" are deliberately left in place: they are
+    # how admin and kibanaserver get their privileges.
+    #
+    # Note that this removes the paths to those roles, not the roles. They are
+    # static -- bundled in the plugin jar under static_config/static_roles.yml
+    # -- so they cannot be deleted from a configuration file, and they cannot be
+    # weakened by redefining them either: on an overlap the plugin discards the
+    # dynamic definition and keeps the static one. An operator who maps a user
+    # to one of these roles by hand still gets it; what is removed here is every
+    # path the product ships.
+    for mapping in kibana_user readall logstash manage_snapshots; do
+        remove_security_entry "$mapping" "$PATH_CONF/opensearch-security/roles_mapping.yml"
+    done
 
     # Disable multi-tenancy
     sed -i 's/#kibana:/kibana:/' "$PATH_CONF/opensearch-security/config.yml"


### PR DESCRIPTION
## Description

The security configuration shipped in the Wazuh Indexer packages is assembled by appending Wazuh's own entries to the files the `opensearch-security` plugin installs. Those upstream files are the plugin's **demo configuration**, and nothing removed them, so every package shipped OpenSearch's demonstration accounts: seven internal users, all enabled, all with the password equal to the username.

One of them is the subject of wazuh/internal-devel-requests#6113. `kibanaro` carries the backend roles `kibanauser` and `readall` — both names read as read-only — but `kibanauser` maps to the static `kibana_user` role, which holds `delete`, `index` and `manage` over `.kibana*`. Since the shipped configuration disables multi-tenancy there is no per-user tenant for such a write to land in, so the account can delete or silently repoint any of the 46 index patterns, visualizations and dashboards the product ships. QA demonstrated it with a single `DELETE` request.

The finding is not limited to that one account: the same demo configuration also maps `readall` (read on every index), `logstash` (create indices, write `logstash-*`) and `manage_snapshots`, and those mappings key off *backend role names*, so they apply to any LDAP/AD group or JWT claim that happens to use those names.

This PR stops shipping the demo accounts and the mappings that lead to those roles.

Closes wazuh/internal-devel-requests#6113

## Proposed Changes

All changes are in `build-scripts/assemble.sh`, inside `add_configuration_files()`, which runs on the `tar`, `rpm` and `deb` paths alike.

**Removed five upstream internal users** from `internal_users.yml`. Only `admin` (expected by the installer and the passwords tool) and `kibanaserver` (the service account the dashboard authenticates as) are kept:

| User | What it granted |
| --- | --- |
| `anomalyadmin` | `anomaly_full_access`, assigned directly on the account |
| `kibanaro` | `kibanauser` + `readall` → write access to the shipped saved objects |
| `logstash` | create indices, write to `logstash-*` and `*beat*` |
| `readall` | read every index in the cluster |
| `snapshotrestore` | `manage_snapshots` |

**Removed four role mappings** from `roles_mapping.yml`: `kibana_user`, `readall`, `logstash` and `manage_snapshots`. Deleting the accounts alone is not enough — these entries map *backend role names*, which come from the authentication backend, so while they stand a directory group merely named `readall` or `kibanauser` is granted the privilege with no account of ours involved. `all_access` and `kibana_server` are deliberately kept: they are how `admin` and `kibanaserver` get their privileges.

**Hardened `remove_security_entry()`** so a missing entry fails the build. The function previously verified only that the key was gone *after* the `awk` pass; if upstream renamed or dropped the key the removal was a silent no-op and the package shipped as if the grant had been stripped. It now also requires the entry to be present beforehand.

### A note on what this does not do

`kibana_user` and the other roles are **static**: they live in `static_config/static_roles.yml` inside the plugin jar. They cannot be deleted from a configuration file, and they cannot be weakened by redefining them either — on an overlap the plugin discards the dynamic definition and keeps the static one (`DynamicConfigFactory`: *"Dynamic definitions have been removed in favor of static configuration."*). An operator who maps a user to `kibana_user` by hand still gets write access to the shared saved objects. What this PR removes is every path the product ships, not the role.

### Results and Evidence

Verified on a real package. A `deb`/`x64` package was built with `build-scripts/assemble.sh` and the two shipped files were read back out of it:

`internal_users.yml` in the package — only `admin` and `kibanaserver` remain from upstream, alongside the four Wazuh accounts. `anomalyadmin`, `kibanaro`, `logstash`, `readall` and `snapshotrestore` are gone:

`roles_mapping.yml` in the package — `own_index`, `kibana_user`, `readall`, `logstash` and `manage_snapshots` are gone; `all_access` and `kibana_server` are kept, as intended:

<img width="952" height="311" alt="imagen" src="https://github.com/user-attachments/assets/7497225b-b6e8-4b93-8dc9-d6a1f43a50d2" />

These two files are architecture- and format-independent — they come from a noarch plugin zip and `add_configuration_files()` has no branch on architecture or package format — so this package is representative of the `deb`, `rpm` and `tar` outputs on both `x64` and `arm64`.

Checks made against the inputs before building, using the shipped `remove_security_entry()` and the removal block extracted from `assemble.sh` (not copied) over the `config/*.yml` files from `opensearch-security-3.6.0.0.zip` plus the four `*.wazuh.yml` overlays:

- Both files still parse as YAML (`yaml.safe_load`, 7 and 9 top-level keys).
- Whole blocks are cut cleanly, including `kibanaro`'s nested `attributes:` sub-map and the trailing blank lines. `admin` and `kibanaserver` are byte-for-byte unchanged.
- None of the five removed accounts' bcrypt hashes survives anywhere in the file.
- The existence check fires: a second pass over already-cleaned files exits `1` with `ERROR: no 'own_index' entry found in ...`.

### Artifacts Affected

- **Packages:** `deb`, `rpm` and `tar`, on `x64` and `arm64`. `add_configuration_files()` is called from `assemble_tar()`, `assemble_rpm()` and `assemble_deb()`, and none of the removals depends on the target.
- **Default configuration files**, as installed:
  - `/etc/wazuh-indexer/opensearch-security/internal_users.yml`
  - `/etc/wazuh-indexer/opensearch-security/roles_mapping.yml`
  - (in the tarball, the same two files under `config/opensearch-security/`)

### Configuration Changes

No new parameters. The change is to what the packages ship by default.

**Removed defaults:** the five internal users and four role mappings listed above.

**Backward compatibility:**

- **Authentication backends.** A deployment whose LDAP/AD groups or JWT claims are named `kibanauser`, `readall`, `logstash` or `snapshotrestore` currently receives the corresponding role through the upstream mappings. After this change it does not. Affected users lose that access and the cause is an entry that no longer exists, which is not self-evident — this needs to reach the migration documentation and the release notes.
- **Existing clusters are not cleaned retroactively.** The live security configuration is stored in the security index, not read from disk at each start; the on-disk files are the seed applied by `indexer-security-init.sh`. A cluster already initialized keeps the demo users until that script is run again or the accounts are deleted through the Security API. New installations get the cleaned configuration.
- **The static roles remain assignable.** As described above, an operator can still map a user to `kibana_user` manually.

### Documentation Updates

The documentation lives in `wazuh-indexer-plugins/docs`, so this will be explained on a companion PR.

### Tests Introduced
N/A

## Review Checklist

<!--
List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
