### PR TITLE
Restrict wazuh_demo to read-only access on threat detectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@
 - Update the Content Manager OpenAPI (`openapi.yml`) to match the current API [(#1353)](https://github.com/wazuh/wazuh-indexer-plugins/issues/1353)
 - [BUG] wazuh-readonly missing promotion and mapping permissions [(#1752)](https://github.com/wazuh/wazuh-indexer/issues/1752)
 - [BUG] The `own_index` demo role is mapped to every user [(#6030)](https://github.com/wazuh/internal-devel-requests/issues/6030)
+- [BUG] Restrict the `wazuh_demo` role to read-only access on threat detectors [(#1531)](https://github.com/wazuh/wazuh-indexer-plugins/issues/1531)
 
 ## Prior versions
 - []()

--- a/distribution/src/config/security/roles.wazuh.yml
+++ b/distribution/src/config/security/roles.wazuh.yml
@@ -135,7 +135,9 @@ wazuh_admin:
 
 # ---------------------------------------------------------------------#
 # wazuh-demo: default user with regular access. Can visualize data and
-# index/update/delete threatintel resources.
+# index/update/delete threatintel resources. Threat detectors are read-only:
+# creating, updating (including enabling/disabling) and deleting them is
+# reserved to wazuh_admin.
 # ---------------------------------------------------------------------#
 wazuh_demo:
   reserved: true
@@ -164,13 +166,16 @@ wazuh_demo:
     - 'cluster:admin/wazuh/securityanalytics/logtype/*'
     - 'cluster:admin/wazuh/securityanalytics/rules/evaluate'
     - 'cluster:admin/wazuh/securityanalytics/space/delete'
-    # Security Analytics (OpenSearch plugin, full)
+    # Security Analytics (OpenSearch plugin)
     - 'cluster:admin/opensearch/securityanalytics/alerts/*'
     - 'cluster:admin/opensearch/securityanalytics/connections/*'
     - 'cluster:admin/opensearch/securityanalytics/correlationAlerts/*'
     - 'cluster:admin/opensearch/securityanalytics/correlations/*'
     - 'cluster:admin/opensearch/securityanalytics/correlation/*'
-    - 'cluster:admin/opensearch/securityanalytics/detector/*'
+    # Detectors are read-only: standard detectors are provisioned from the CTI
+    # catalog, and disabling one silently stops detection for its integration.
+    - 'cluster:admin/opensearch/securityanalytics/detector/get'
+    - 'cluster:admin/opensearch/securityanalytics/detector/search'
     - 'cluster:admin/opensearch/securityanalytics/findings/*'
     - 'cluster:admin/opensearch/securityanalytics/logtype/*'
     - 'cluster:admin/opensearch/securityanalytics/mapping/*'


### PR DESCRIPTION
## Description

`wazuh_demo` held `cluster:admin/opensearch/securityanalytics/detector/*` — the full detector action set, including `detector/write` and `detector/delete`. It is the role of an account whose password is published in the image.

Deleting a shipped detector is refused by an explicit guard above the permission system, because losing one would disable detection for its integration. Switching the same detector off has the same practical effect and is deliberately not guarded, since standard detectors are meant to be enabled and disabled as a whole. That makes it an administrative operation, and it should not be reachable by a role shipped for demonstration.

Part of wazuh/wazuh-indexer-plugins#1531, which needs all three of:

| | |
|---|---|
| this PR | restricts `wazuh_demo` to read-only access on detectors |
| wazuh/wazuh-indexer-security-analytics#332 | logs each transition with the account that requested it |
| wazuh/wazuh-indexer-plugins#1565 | documents the detection gap and the permissions |

## Proposed Changes

In `distribution/src/config/security/roles.wazuh.yml`:

```diff
-    - 'cluster:admin/opensearch/securityanalytics/detector/*'
+    - 'cluster:admin/opensearch/securityanalytics/detector/get'
+    - 'cluster:admin/opensearch/securityanalytics/detector/search'
```

The same detector subset `wazuh_readonly` already has. `wazuh_admin` is unchanged and keeps `detector/*`.

**Deliberately unchanged:** everything else in the role. Threat intelligence indices, Content Manager content operations, custom Sigma rules, log types and the remaining Security Analytics actions stay writable — the role's purpose is to visualize data and manage threat intelligence content, and that still works. Only the detection configuration is taken away.

`cluster:admin/wazuh/securityanalytics/detector/set_enabled`, which the Content Manager uses to mirror an integration's `enabled` onto its detector, was never granted to `wazuh_demo`, so there is no second route to the same effect.

### Results and Evidence

Verified on a `vagrant/5.0` VM (OpenSearch 3.6.0, security plugin enabled) against `apache-http`, a real **standard** (CTI-provisioned) detector, with this role block applied through `securityadmin.sh -t roles`.

<details><summary>Before and after, plus the back door</summary>

**Before** — the reported bug:

```
PUT /_plugins/_security_analytics/detectors/{id}  {"enabled": false}   as wazuh-demo
  -> 200, detector ends enabled = False
```

**After:**

```
  -> 403 "no permissions for [cluster:admin/opensearch/securityanalytics/detector/write]
          and User [name=wazuh-demo, backend_roles=[], requestedTenant=null]"
  -> detector stays enabled = True
```

**The permitted path is untouched** — the same request as `wazuh-admin` returns 200.

**The back door is closed too.** The detector shares its integration's document id and the Content Manager mirrors the integration's `enabled` onto it:

```
PUT /_plugins/_content_manager/integrations/{id}  {"resource": {… "enabled": false}}   as wazuh-demo
  -> 403 "no permissions for [cluster:admin/wazuh/securityanalytics/detector/set_enabled]"
  -> detector enabled = True (unchanged), integration enabled = True (unchanged)
```

No partial state: the integration document is not left updated with its detector out of sync.

</details>

<details><summary>Regression probes — the rest of the role still works</summary>

| Probe | Expected | Result |
|---|---|---|
| `wazuh-demo` GET detector | 200 | 200, returns `apache-http` |
| `wazuh-demo` search detectors | 200 | 200 |
| `wazuh-demo` read findings | 200 | 200 |
| `wazuh-demo` write to `wazuh-threatintel-*` | 201 | 201 (probe document removed afterwards) |
| `wazuh-demo` DELETE a standard detector | 403, RBAC first | `no permissions for [… /detector/delete]` |
| `wazuh-admin` DELETE a standard detector | 400, the guard | `Standard detectors cannot be deleted by users.` |
| `roles.wazuh.yml` parses; `wazuh_admin` unchanged | yes | 67 permissions on `wazuh_demo`; `wazuh_admin` keeps `detector/*` |

</details>

> **Note for whoever applies this to a running cluster:** the installed `/etc/wazuh-indexer/opensearch-security/roles.yml` is the stock OpenSearch roles **plus** the six Wazuh ones (53 keys). Do not overwrite it with `roles.wazuh.yml` (6 keys) — replace the `wazuh_demo` block, then run `securityadmin.sh -t roles`.

### Artifacts Affected

`distribution/src/config/security/roles.wazuh.yml` — shipped default security configuration. Packaged, not executable; it reaches a cluster through `securityadmin.sh` at install time.

### Configuration Changes

A default role loses two permissions: `wazuh_demo` can no longer create, update, enable, disable or delete a threat detector.

**Backwards compatibility.** Existing deployments are unaffected until the new `roles.yml` is applied — the security configuration lives in the `.opendistro_security` index and is not rewritten by an upgrade on its own. Operators who want a demo account to toggle detectors should duplicate the role and grant `detector/write` on the copy; `wazuh_*` roles are `reserved` and cannot be edited in place.

### Documentation Updates

In wazuh/wazuh-indexer-plugins#1565: `docs/ref/security/access-control.md`, `docs/ref/security/permissions.md` (which also gains `detector/set_enabled`, previously missing) and `docs/ref/modules/ruleset-management/index.md`.

### Tests Introduced

None. A configuration file with no test harness in this repository; verification is the cluster evidence above.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality — not applicable, security configuration
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues — merges with wazuh/wazuh-indexer-security-analytics#332 and wazuh/wazuh-indexer-plugins#1565
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`) — CHANGELOG entry added
