### PR TITLE
Add the AI assistant session write action group

### DIFF
--- a/distribution/src/config/security/action_groups.wazuh.yml
+++ b/distribution/src/config/security/action_groups.wazuh.yml
@@ -312,3 +312,11 @@ plugin:wazuh/ai_assistant/settings/write:
     - 'cluster:admin/ai_assistant/settings/write'
   type: "cluster"
   description: "Write the AI assistant's providers, settings and field policy"
+
+plugin:wazuh/ai_assistant/session/write:
+  reserved: true
+  hidden: false
+  allowed_actions:
+    - 'cluster:admin/ai_assistant/session/write'
+  type: "cluster"
+  description: "Create, update and delete the caller's own AI assistant sessions"

--- a/distribution/src/config/security/roles.wazuh.yml
+++ b/distribution/src/config/security/roles.wazuh.yml
@@ -405,15 +405,33 @@ wazuh_manager:
 
 # ---------------------------------------------------------------------#
 # wazuh-ai-assistant: grants every authenticated user access to their own
-# AI assistant conversations, and only to those. Reads are restricted with
-# Document Level Security parameter substitution: ${user.name} is replaced
-# with the name of the authenticated user, so only the documents whose
-# 'user' field matches it are visible.
+# AI assistant conversations, and only to those.
+#
+# Reads and writes are scoped by two different mechanisms, and the
+# asymmetry is deliberate. Reads are restricted with Document Level
+# Security parameter substitution: ${user.name} is replaced with the name
+# of the authenticated user, so only the documents whose 'user' field
+# matches it are visible.
+#
+# DLS cannot do the same for writes -- it is a read-path filter -- and no
+# role syntax can express "this document's 'user' must equal your name".
+# So writes are mediated by the setup plugin instead, through the cluster
+# permission below: it derives 'user' from the authenticated principal and
+# discards whatever the request body sent. See
+# /_plugins/_setup/ai_assistant/sessions in the setup plugin's API
+# reference.
+#
+# The index-level 'write' block is still granted for now, so that clients
+# writing directly to the data stream keep working until they migrate to
+# the endpoints. Removing it is what closes
+# wazuh/internal-devel-requests#6111, and it must be gated on the Wazuh
+# Dashboard having migrated, or sessions stop persisting silently.
 # ---------------------------------------------------------------------#
 wazuh_ai_assistant:
   reserved: true
   hidden: false
-  cluster_permissions: []
+  cluster_permissions:
+    - 'plugin:wazuh/ai_assistant/session/write'
   index_permissions:
     - index_patterns:
         - 'wazuh-ai-assistant-sessions*'

--- a/distribution/src/config/security/roles_mapping.wazuh.yml
+++ b/distribution/src/config/security/roles_mapping.wazuh.yml
@@ -37,8 +37,11 @@ wazuh_manager:
   users:
     - "wazuh-manager"
 
-# Mapped to every authenticated user: the DLS query in the role scopes each
-# user down to their own AI assistant conversations.
+# Mapped to every authenticated user. The role's DLS query scopes each user's
+# READS down to their own AI assistant conversations; their writes are scoped
+# instead by the setup plugin, which stamps the owner server-side. Granting
+# this role to everyone is therefore safe: it confers access to the caller's
+# own conversations and nothing else. See the comment above the role itself.
 wazuh_ai_assistant:
   reserved: true
   hidden: false


### PR DESCRIPTION
## Description

The `wazuh_ai_assistant` role is mapped to `users: ["*"]`, so every authenticated user holds it, and
it grants index-level `write` on `wazuh-ai-assistant-sessions*` with no scoping. Document Level
Security is a read-path filter and cannot scope a write, so the `dls` key on the sibling `read`
block protects nothing on the write path: any account reaching the index can store a session whose
`user` field names somebody else. The document then surfaces in the victim's history and is
invisible to its author. The shipped **read-only** profile is enough to do it.

No role syntax can express "this document's `user` must equal your name", so `user` has to stop
being client input. The setup plugin now mediates session writes and derives the owner from the
authenticated principal — wazuh/wazuh-indexer-plugins#1554.

This PR is the security-configuration half, and it is the change that actually closes the issue: it
grants the cluster permission the endpoints are gated on, and removes the unscoped index-level
`write` grant that made `user` forgeable.

Closes wazuh/internal-devel-requests#6111.

## Proposed Changes

| File | Change |
| --- | --- |
| `action_groups.wazuh.yml` | new `plugin:wazuh/ai_assistant/session/write`, wrapping `cluster:admin/ai_assistant/session/write` |
| `roles.wazuh.yml` | `wazuh_ai_assistant` gains that cluster permission and **loses the unscoped `write` block**; the `read` block and its DLS query are untouched |
| `roles_mapping.wazuh.yml` | comment fix only — no change to `users: ["*"]` |

```yaml
wazuh_ai_assistant:
  cluster_permissions:
    - 'plugin:wazuh/ai_assistant/session/write'   # <- added
  index_permissions:
    - index_patterns: ['wazuh-ai-assistant-sessions*', '.ds-wazuh-ai-assistant-sessions-*']
      dls: '{"term": {"user": "${user.name}"}}'
      allowed_actions: ['read']                   # unchanged
#   - index_patterns: [...]                       # <- removed
#     allowed_actions: ['write']
```

**The asymmetry is the fix.** Reads stay scoped by DLS, which works — it is a read-path mechanism —
so a `_search` needs index-level `read` and no cluster permission, and listing or reading a
transcript behaves exactly as before. Writes have no index-level grant at all and go through the
endpoints, which derive `user` from the authenticated principal. That is also what makes the read
filter sound for the first time: it now filters on an authenticated fact rather than on client
input.

> [!IMPORTANT]
> **The Wazuh Dashboard still writes directly and will fail every create, update and delete until it
> moves onto the endpoints** — 3 `asCurrentUser` calls, 0 to the endpoint, on both `main` and
> `5.0.0`. That migration is tracked on their side and this change is what it depends on. Merge
> order: wazuh/wazuh-indexer-plugins#1554, then the Dashboard migration, then this.

`users: ["*"]` can stay, and stays. Once writes are mediated, the grant means "call an endpoint that
only ever acts on your own sessions" — every user needs that and there is nothing left to abuse.

Two comments are also corrected, because both asserted the property the write grant broke: they
claimed DLS scopes the role, without qualifying that it only ever scoped the reads. That reading is
how the gap survived review the first time.

### Results and Evidence

Applied to a live 5.0.0 cluster with `securityadmin.sh`, then exercised with two **stock** users —
`wazuh-readonly` and `admin`, both of which hold `wazuh_ai_assistant` only because it is mapped
to `*`.

**The original proof-of-concept from the issue is now refused:**

```
POST /wazuh-ai-assistant-sessions/_doc                 as wazuh-readonly
{"user":"admin","title":"INJECTED BY wazuh-readonly", ...}
  -> 403  no permissions for [indices:data/write/index]
```

Before this change it returned `201 created`, landing in `.ds-wazuh-ai-assistant-sessions-000003`
under `"user": "admin"` — a session in the administrator's history, written by the shipped
read-only profile and invisible to its author.

**And the endpoint works, with the server deciding the owner:**

```
POST /_plugins/_setup/ai_assistant/sessions            as wazuh-readonly
{"title":"forged ownership attempt","messages":[],"user":"admin"}
  -> 200

GET /wazuh-ai-assistant-sessions/_search {ids:[<new id>]}   as wazuh-readonly
  -> "user": "wazuh-readonly"        <- not "admin"

GET /wazuh-ai-assistant-sessions/_search {"term":{"user":"admin"}}   as admin
  -> total 0                          <- not in the victim's history
```

Cross-user operations are refused, in both directions — there is no administrative override:

```
PUT / PATCH / DELETE  …/sessions/<admin's id>    as wazuh-readonly  -> 404 (x3), untouched
PUT / DELETE          …/sessions/<readonly's id> as admin           -> 404 (x2)
```

`404` rather than `403` is deliberate: a `403` would confirm that another user's session id exists.

<details><summary>Regression probes — reads and the un-migrated write path</summary>

| Probe | Result |
| --- | --- |
| `_search` on the stream as `wazuh-readonly` | **`200`** — a `_search` needs index-level `read`, which is untouched, and no cluster permission |
| Per-owner DLS still isolates reads | `wazuh-readonly` sees only its own; `admin` sees only its own |
| `_search` with a `term` filter, per identity | each sees only their own — DLS unchanged |
| `authinfo` for a user created with `{"backend_roles": []}` | still `['own_index', 'wazuh_ai_assistant']` — mapping unchanged |

Two consequences of removing the grant, worth knowing before they get filed as bugs:

- **An ordinary user can no longer `_delete_by_query` their own sessions** — no index-level write
  remains, so the endpoint is the only way to remove one. `admin` cannot do it on their behalf
  either, because the DLS hides those documents from it.
- **A "no leftovers" check has to be run per identity.** An `admin`-only count is DLS-scoped to
  admin's own documents and reports a clean cluster that is not one.

</details>

### Artifacts Affected

Security configuration only — three files under `distribution/src/config/security/`. No packaging,
no code, no default settings.

`wazuh_ai_assistant` is `reserved: true`, so the change takes effect only when `securityadmin.sh`
re-initialises the security index: a fresh install, or an explicit re-init. **Existing upgraded
clusters keep the old role definition**, which is worth confirming against how 5.0.0 upgrades are
expected to handle reserved-role changes.

### Configuration Changes

One new action group, `plugin:wazuh/ai_assistant/session/write`, granted to `wazuh_ai_assistant`.

**Additive.** No permission is removed, no default changed, no mapping changed. On a cluster running
a plugin build without the endpoints the new permission simply grants an action nothing serves.

### Documentation Updates

The user-facing documentation for this role and the endpoints it gates lives in the plugins
repository and is part of wazuh/wazuh-indexer-plugins#1554 — `docs/ref/security/access-control.md`,
`docs/ref/modules/setup/api-reference.md` and `docs/dev/plugins/setup.md`. Nothing in this repository
documents the role.

### Tests Introduced

None — this repository has no test harness for the security configuration. Coverage is the 109 unit
and integration tests in wazuh/wazuh-indexer-plugins#1554, plus the live-cluster evidence above,
which is the only place the two-identity behaviour can actually be exercised.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality — not applicable, see above
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues — **merge order matters.** Needs
      wazuh/wazuh-indexer-plugins#1554 (the endpoints) and the Dashboard migration to land first;
      this one breaks conversation saving until the Dashboard moves off direct writes.
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (`no-changelog`)

