### PR TITLE
Merge 4.14.8 into 4.14.9

### DIFF
--- a/VERSION.json
+++ b/VERSION.json
@@ -1,4 +1,4 @@
 {
   "version": "4.14.8",
-  "stage": "alpha0"
+  "stage": "rc1"
 }

--- a/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
+++ b/distribution/packages/src/rpm/wazuh-indexer.rpm.spec
@@ -295,7 +295,7 @@ exit 0
 %ghost %attr(440, %{name}, %{name}) %{config_dir}/.was_active
 
 %changelog
-* Wed Sep 02 2026 support <info@wazuh.com> - 4.14.8
+* Wed Sep 16 2026 support <info@wazuh.com> - 4.14.8
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-14-8.html
 * Thu Jul 09 2026 support <info@wazuh.com> - 4.14.7
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-14-7.html


### PR DESCRIPTION
## Description

This PR merges changes from branch `4.14.8` into branch `4.14.9`

Related to #1925

## Proposed Changes

Merge-only PR, no extra commits.

The content it brings across is #1920, removing the systemd and SysV links left behind on uninstall: the new `debian/postrm`, the `debian/prerm` additions and the matching `%preun` block in `wazuh-indexer.rpm.spec`.

Two files conflicted.

`VERSION.json` is a version conflict and keeps the `4.14.9` side (`4.14.9` / `alpha0`).

The `%changelog` in `wazuh-indexer.rpm.spec` conflicted because each branch had bumped its own entry. It keeps the `4.14.9` entry from this branch and takes the updated date for the `4.14.8` entry from the incoming branch, since `4.14.8` owns its own release date. This is the same resolution used in the previous merge of this kind, #1781.

### Results and Evidence

### Artifacts Affected

- `wazuh-indexer` DEB package
- `wazuh-indexer` RPM package

### Configuration Changes

### Documentation Updates

### Tests Introduced

## Review Checklist

- [x] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
